### PR TITLE
Support for nested maps

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -26,7 +26,11 @@ final emptyJsMap = newJsObjectEmpty();
 newJsMap(Map map) {
   var JsMap = newJsObjectEmpty();
   for (var key in map.keys) {
-    JsMap[key] = map[key];
+    if(map[key] is Map) {
+      JsMap[key] = newJsMap(map[key]);
+    } else {
+      JsMap[key] = map[key];
+    }
   }
   return JsMap;
 }


### PR DESCRIPTION
```<span dangerouslySetInnerHTML={{__html: someHtml}} /> ``` requires a nested object (```span({'dangerouslySetInnerHTML': {'__html': someHtml}})```) but the newJsMap function only goes trough one level. I've added support for nested Maps.