### PR TITLE
Add SyntheticDataTransfer for SyntheticMouseEvents

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -215,6 +215,15 @@ class SyntheticFormEvent extends SyntheticEvent {
 
 }
 
+class SyntheticDataTransfer {
+  final String dropEffect;
+  final String effectAllowed;
+  final List/*<File>*/ files;
+  final List<String> types;
+
+  SyntheticDataTransfer(this.dropEffect, this.effectAllowed, this.files, this.types);
+}
+
 class SyntheticMouseEvent extends SyntheticEvent {
 
   final bool altKey;
@@ -223,6 +232,7 @@ class SyntheticMouseEvent extends SyntheticEvent {
   final num clientX;
   final num clientY;
   final bool ctrlKey;
+  final SyntheticDataTransfer dataTransfer;
   final bool metaKey;
   final num pageX;
   final num pageY;
@@ -234,8 +244,8 @@ class SyntheticMouseEvent extends SyntheticEvent {
   SyntheticMouseEvent(bubbles, cancelable, currentTarget, _defaultPrevented,
       _preventDefault, stopPropagation, eventPhase, isTrusted, nativeEvent, target,
       timeStamp, type, this.altKey, this.button, this.buttons, this.clientX, this.clientY,
-      this.ctrlKey, this.metaKey, this.pageX, this.pageY, this.relatedTarget, this.screenX,
-      this.screenY, this.shiftKey) :
+      this.ctrlKey, this.dataTransfer, this.metaKey, this.pageX, this.pageY, this.relatedTarget,
+      this.screenX, this.screenY, this.shiftKey) :
         super( bubbles, cancelable, currentTarget, _defaultPrevented,
             _preventDefault, stopPropagation, eventPhase, isTrusted, nativeEvent, target,
             timeStamp, type){}

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -434,12 +434,26 @@ SyntheticEvent syntheticFormEventFactory(JsObject e) {
       e["target"], e["timeStamp"], e["type"]);
 }
 
+SyntheticDataTransfer syntheticDataTransferFactory(JsObject dt) {
+  if (dt == null) return null;
+  List<File> files = [];
+  for (int i = 0; i < dt["files"]["length"]; i++) {
+    files.add(dt["files"][i]);
+  }
+  List<String> types = [];
+  for (int i = 0; i < dt["types"]["length"]; i++) {
+    types.add(dt["types"][i]);
+  }
+  return new SyntheticDataTransfer(dt["dropEffect"], dt["effectAllowed"], files, types);
+}
+
 SyntheticEvent syntheticMouseEventFactory(JsObject e) {
+  SyntheticDataTransfer dt = syntheticDataTransferFactory(e["dataTransfer"]);
   return new SyntheticMouseEvent(e["bubbles"], e["cancelable"], e["currentTarget"],
       e["defaultPrevented"], () => e.callMethod("preventDefault", []),
       () => e.callMethod("stopPropagation", []), e["eventPhase"], e["isTrusted"], e["nativeEvent"],
       e["target"], e["timeStamp"], e["type"], e["altKey"], e["button"], e["buttons"], e["clientX"], e["clientY"],
-      e["ctrlKey"], e["metaKey"], e["pageX"], e["pageY"], e["relatedTarget"], e["screenX"],
+      e["ctrlKey"], dt, e["metaKey"], e["pageX"], e["pageY"], e["relatedTarget"], e["screenX"],
       e["screenY"], e["shiftKey"]);
 }
 


### PR DESCRIPTION
Addresses #39.

Adds a `SyntheticDataTransfer` class that mirrors the JS `DataTransfer` class detailed here: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer

I currently have the properties on this `dataTransfer` object set as final, but there are scenarios where the user should be able to set the value to have some effect (see above link for more details), but this will require forwarding those updates to the original JsObject.

@hleumas 