### PR TITLE
Adding mouseOut and mouseOver native events

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -16,6 +16,8 @@ JsObject _TestUtils = _getNestedJsObject(
 
 JsObject _Simulate = _TestUtils['Simulate'];
 
+JsObject _SimulateNative = _TestUtils['SimulateNative'];
+
 _getNestedJsObject(
     JsObject base, List<String> keys, [String errorIfNotFound='']) {
   JsObject object = base;
@@ -147,6 +149,20 @@ class Simulate {
 
   static void wheel(JsObject element, [Map eventData = const{}]) =>
       _Simulate.callMethod('wheel', [element, new JsObject.jsify(eventData)]);
+
+}
+
+/// Native event simulation interface.
+///
+/// Provides methods that allow for simulation of mouseEnter and mouseLeave
+
+class SimulateNative {
+
+  static void mouseOut(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOut', [element, new JsObject.jsify(eventData)]);
+
+  static void mouseOver(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOver', [element, new JsObject.jsify(eventData)]);
 
 }
 

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -154,15 +154,107 @@ class Simulate {
 
 /// Native event simulation interface.
 ///
-/// Provides methods that allow for simulation of mouseEnter and mouseLeave
+/// Current implementation does not support change and keyPress native events
+///
+/// Provides methods for each type of event that can be handled by a React
+/// component.  All methods are used in the same way:
+///
+///   SimulateNative.{eventName}([JsObject] element, [Map] eventData)
 
 class SimulateNative {
+
+  static void blur(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('blur', [element, new JsObject.jsify(eventData)]);
+
+  static void click(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('click', [element, new JsObject.jsify(eventData)]);
+
+  static void contextMenu(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('contextMenu', [element, new JsObject.jsify(eventData)]);
+
+  static void copy(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('copy', [element, new JsObject.jsify(eventData)]);
+
+  static void cut(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('cut', [element, new JsObject.jsify(eventData)]);
+
+  static void doubleClick(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('doubleClick', [element, new JsObject.jsify(eventData)]);
+
+  static void drag(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('drag', [element, new JsObject.jsify(eventData)]);
+
+  static void dragEnd(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragEnd', [element, new JsObject.jsify(eventData)]);
+
+  static void dragEnter(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragEnter', [element, new JsObject.jsify(eventData)]);
+
+  static void dragExit(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragExit', [element, new JsObject.jsify(eventData)]);
+
+  static void dragLeave(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragLeave', [element, new JsObject.jsify(eventData)]);
+
+  static void dragOver(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragOver', [element, new JsObject.jsify(eventData)]);
+
+  static void dragStart(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragStart', [element, new JsObject.jsify(eventData)]);
+
+  static void drop(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('drop', [element, new JsObject.jsify(eventData)]);
+
+  static void focus(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('focus', [element, new JsObject.jsify(eventData)]);
+
+  static void input(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('input', [element, new JsObject.jsify(eventData)]);
+
+  static void keyDown(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('keyDown', [element, new JsObject.jsify(eventData)]);
+
+  static void keyUp(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('keyUp', [element, new JsObject.jsify(eventData)]);
+
+  static void mouseDown(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseDown', [element, new JsObject.jsify(eventData)]);
+
+  static void mouseMove(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseMove', [element, new JsObject.jsify(eventData)]);
 
   static void mouseOut(JsObject element, [Map eventData = const{}]) =>
       _SimulateNative.callMethod('mouseOut', [element, new JsObject.jsify(eventData)]);
 
   static void mouseOver(JsObject element, [Map eventData = const{}]) =>
       _SimulateNative.callMethod('mouseOver', [element, new JsObject.jsify(eventData)]);
+
+  static void mouseUp(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseUp', [element, new JsObject.jsify(eventData)]);
+
+  static void paste(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('paste', [element, new JsObject.jsify(eventData)]);
+
+  static void scroll(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('scroll', [element, new JsObject.jsify(eventData)]);
+
+  static void submit(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('submit', [element, new JsObject.jsify(eventData)]);
+
+  static void touchCancel(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchCancel', [element, new JsObject.jsify(eventData)]);
+
+  static void touchEnd(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchEnd', [element, new JsObject.jsify(eventData)]);
+
+  static void touchMove(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchMove', [element, new JsObject.jsify(eventData)]);
+
+  static void touchStart(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchStart', [element, new JsObject.jsify(eventData)]);
+
+  static void wheel(JsObject element, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('wheel', [element, new JsObject.jsify(eventData)]);
 
 }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -61,7 +61,9 @@ void main() {
     test('mouseDown', () => testEvent(Simulate.mouseDown, 'mouseDown'));
     test('mouseMove', () => testEvent(Simulate.mouseMove, 'mouseMove'));
     test('mouseOut', () => testEvent(Simulate.mouseOut, 'mouseOut'));
+    test('mouseOut native', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
     test('mouseOver', () => testEvent(Simulate.mouseOver, 'mouseOver'));
+    test('mouseOver native', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
     test('mouseUp', () => testEvent(Simulate.mouseUp, 'mouseUp'));
     test('paste', () => testEvent(Simulate.paste, 'paste'));
     test('scroll', () => testEvent(Simulate.scroll, 'scroll'));

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -61,9 +61,7 @@ void main() {
     test('mouseDown', () => testEvent(Simulate.mouseDown, 'mouseDown'));
     test('mouseMove', () => testEvent(Simulate.mouseMove, 'mouseMove'));
     test('mouseOut', () => testEvent(Simulate.mouseOut, 'mouseOut'));
-    test('mouseOut native', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
     test('mouseOver', () => testEvent(Simulate.mouseOver, 'mouseOver'));
-    test('mouseOver native', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
     test('mouseUp', () => testEvent(Simulate.mouseUp, 'mouseUp'));
     test('paste', () => testEvent(Simulate.paste, 'paste'));
     test('scroll', () => testEvent(Simulate.scroll, 'scroll'));
@@ -73,6 +71,44 @@ void main() {
     test('touchMove', () => testEvent(Simulate.touchMove, 'touchMove'));
     test('touchStart', () => testEvent(Simulate.touchStart, 'touchStart'));
     test('wheel', () => testEvent(Simulate.wheel, 'wheel'));
+  });
+
+  group('Simulate native event', () {
+    tearDown(() {
+      component = null;
+      domNode = null;
+    });
+
+    test('blur', () => testEvent(SimulateNative.blur, 'blur'));
+    test('click', () => testEvent(SimulateNative.click, 'click'));
+    test('copy', () => testEvent(SimulateNative.copy, 'copy'));
+    test('cut', () => testEvent(SimulateNative.cut, 'cut'));
+    test('doubleClick', () => testEvent(SimulateNative.doubleClick, 'doubleClick'));
+    test('drag', () => testEvent(SimulateNative.drag, 'drag'));
+    test('dragEnd', () => testEvent(SimulateNative.dragEnd, 'dragEnd'));
+    test('dragEnter', () => testEvent(SimulateNative.dragEnter, 'dragEnter'));
+    test('dragExit', () => testEvent(SimulateNative.dragExit, 'dragExit'));
+    test('dragLeave', () => testEvent(SimulateNative.dragLeave, 'dragLeave'));
+    test('dragOver', () => testEvent(SimulateNative.dragOver, 'dragOver'));
+    test('dragStart', () => testEvent(SimulateNative.dragStart, 'dragStart'));
+    test('drop', () => testEvent(SimulateNative.drop, 'drop'));
+    test('focus', () => testEvent(SimulateNative.focus, 'focus'));
+    test('input', () => testEvent(SimulateNative.input, 'input'));
+    test('keyDown', () => testEvent(SimulateNative.keyDown, 'keyDown'));
+    test('keyUp', () => testEvent(SimulateNative.keyUp, 'keyUp'));
+    test('mouseDown', () => testEvent(SimulateNative.mouseDown, 'mouseDown'));
+    test('mouseMove', () => testEvent(SimulateNative.mouseMove, 'mouseMove'));
+    test('mouseOut', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
+    test('mouseOver', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
+    test('mouseUp', () => testEvent(SimulateNative.mouseUp, 'mouseUp'));
+    test('paste', () => testEvent(SimulateNative.paste, 'paste'));
+    test('scroll', () => testEvent(SimulateNative.scroll, 'scroll'));
+    test('submit', () => testEvent(SimulateNative.submit, 'submit'));
+    test('touchCancel', () => testEvent(SimulateNative.touchCancel, 'touchCancel'));
+    test('touchEnd', () => testEvent(SimulateNative.touchEnd, 'touchEnd'));
+    test('touchMove', () => testEvent(SimulateNative.touchMove, 'touchMove'));
+    test('touchStart', () => testEvent(SimulateNative.touchStart, 'touchStart'));
+    test('wheel', () => testEvent(SimulateNative.wheel, 'wheel'));
   });
 
   test('findRenderedDOMComponentWithClass', () {


### PR DESCRIPTION
While working with the dart react test utils it was discovered that it was necessary to simulate some native events in order to initiate a mouseEnter or mouseLeave event during testing.

In this work, the necessary events events were added in order to create those events within the dart react test utils.

issue originally documented - http://stackoverflow.com/questions/24140773/could-not-simulate-mouseenter-event-using-react-test-utils