### PR TITLE
Ref errors on null

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -90,6 +90,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
 
     var getRef = (name) {
       var ref = jsThis['refs'][name] as JsObject;
+      if (ref == null) return null;
       if (ref[PROPS][INTERNAL] != null) return ref[PROPS][INTERNAL][COMPONENT];
       else return ref.callMethod('getDOMNode', []);
     };


### PR DESCRIPTION
### PROBLEM
If you try to access a ref that doesn't exist, this code will error and crash.

### SOLUTION
Add a null check for ref before trying to access properties on it.

### TESTING
1. Create a component.
2. Try to access a ref that doesn't exist on the component.
3. Verify that there is no error and you get null back.
 
