### PR TITLE
return JSObject ref if appropriate

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -118,7 +118,7 @@ abstract class Component {
 
 }
 
-/** Syntetic event */
+/** Synthetic event */
 
 class SyntheticEvent {
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -91,7 +91,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     var getRef = (name) {
       var ref = jsThis['refs'][name] as JsObject;
       if (ref[PROPS][INTERNAL] != null) return ref[PROPS][INTERNAL][COMPONENT];
-      else return ref.callMethod('getDOMNode', []);
+      else return ref;
     };
     
     var getDOMNode = () {


### PR DESCRIPTION
## Problem
- If a JS based react component is `ref`ed, the associated DOM element is returned instead of the actual JSObject.  This is useful in many cases, but prevents access to any other public methods available on the JS component.
- I realize this would be a breaking change, so if you'd prefer to expose this via some other new API call, that's a reasonable possibility as well.

## Changes
- Return the JSObject from getRef.

## Testing
- DOM node for a JS based component can still be accessed via:
```
    var whateverRef = this.ref('whateverRef');
    var domNode = whateverRef.callMethod('getDOMNode');
```
- Public API functions are also accessible on JS based components if exposed (like in some react-bootstrap components):
```
    var whateverRef = this.ref('whateverRef');
    whateverRef.callMethod('setDropdownState', [false]);
```
