### PR TITLE
Fix ReactTestUtils and its tests

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -31,9 +31,13 @@ _getNestedJsObject(
   return object;
 }
 
-JsFunction getFactory(component) {
-  if (component is ReactComponentFactoryProxy) {
-    return (component as ReactComponentFactoryProxy).reactComponentFactory;
+/// Returns the 'type' of a component.
+///
+/// For a DOM components, this with return the String corresponding to its tagName ('div', 'a', etc.).
+/// For React.createClass()-based components, this with return the React class as a JsFunction.
+dynamic getComponentType(ReactComponentFactory componentFactory) {
+  if (componentFactory is ReactComponentFactoryProxy) {
+    return componentFactory.reactComponentFactory['type'];
   }
   return null;
 }
@@ -289,13 +293,15 @@ JsObject findRenderedDOMComponentWithTag(JsObject tree, String tag) {
 JsObject findRenderedComponentWithType(
     JsObject tree, ReactComponentFactory componentType) {
   return _TestUtils.callMethod(
-      'findRenderedComponentWithType', [tree, getFactory(componentType)]);
+      'findRenderedComponentWithType', [tree, getComponentType(componentType)]);
 }
 
 /// Returns true if element is a composite component.
 /// (created with React.createClass()).
 bool isCompositeComponent(JsObject instance) {
-  return _TestUtils.callMethod('isCompositeComponent', [instance]);
+  return _TestUtils.callMethod('isCompositeComponent', [instance])
+         // Workaround for DOM components being detected as composite: https://github.com/facebook/react/pull/3839
+         && instance['tagName'] == null;
 }
 
 /// Returns true if instance is a composite component.
@@ -303,7 +309,7 @@ bool isCompositeComponent(JsObject instance) {
 bool isCompositeComponentWithType(
     JsObject instance, ReactComponentFactory componentClass) {
   return _TestUtils.callMethod(
-      'isCompositeComponentWithType', [instance, getFactory(componentClass)]);
+      'isCompositeComponentWithType', [instance, getComponentType(componentClass)]);
 }
 
 /// Returns true if instance is a DOM component (such as a <div> or <span>).
@@ -311,23 +317,23 @@ bool isDOMComponent(JsObject instance) {
   return _TestUtils.callMethod('isDOMComponent', [instance]);
 }
 
-/// Returns true if element is any ReactElement.
-bool isElement(JsObject element) {
-  return _TestUtils.callMethod('isElement', [element]);
+/// Returns true if [object] is a valid React component.
+bool isElement(JsObject object) {
+  return _TestUtils.callMethod('isElement', [object]);
 }
 
 /// Returns true if element is a ReactElement whose type is of a
 /// React componentClass.
 bool isElementOfType(JsObject element, ReactComponentFactory componentClass) {
   return _TestUtils.callMethod(
-      'isElementOfType', [element, getFactory(componentClass)]);
+      'isElementOfType', [element, getComponentType(componentClass)]);
 }
 
 /// Finds all instances of components with type equal to componentClass.
 JsObject scryRenderedComponentsWithType(
     JsObject tree, ReactComponentFactory componentClass) {
   return _TestUtils.callMethod(
-      'scryRenderedComponentsWithType', [tree, getFactory(componentClass)]);
+      'scryRenderedComponentsWithType', [tree, getComponentType(componentClass)]);
 }
 
 /// Finds all instances of components in the rendered tree that are DOM

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -132,13 +132,13 @@ void main() {
   });
 
   group('isCompositeComponent', () {
-    test('returns true when element is a React component', () {
+    test('returns true when element is a composite component (created with React.createClass())', () {
       component = renderIntoDocument(eventComponent({}));
 
       expect(isCompositeComponent(component), isTrue);
     });
 
-    test('returns false when element is not a React component', () {
+    test('returns false when element is not a composite component (created with React.createClass())', () {
       component = renderIntoDocument(div({}));
 
       expect(isCompositeComponent(component), isFalse);
@@ -148,12 +148,12 @@ void main() {
   group('isCompositeComponentWithType', () {
     var renderedInstance = renderIntoDocument(sampleComponent({}));
 
-    test('returns true when element is a React component with class', () {
+    test('returns true when element is a composite component (created with React.createClass()) of the specified type', () {
       expect(isCompositeComponentWithType(
           renderedInstance, sampleComponent), isTrue);
     });
 
-    test('returns false when element is not a React component with class', () {
+    test('returns false when element is not a composite component (created with React.createClass()) of the specified type', () {
       expect(isCompositeComponentWithType(
           renderedInstance, eventComponent), isFalse);
     });
@@ -178,7 +178,7 @@ void main() {
     });
 
     test('returns false argument is not an element', () {
-      expect(isElement(div), isFalse);
+      expect(isElement(new JsObject.jsify({})), isFalse);
     });
   });
 


### PR DESCRIPTION
### Ultimate Problem
Currently, some of the methods in `react_test_utils.dart` don't work properly, and there are 4 failures and 2 errors in the related tests.

### Changes
* Pass component type instead of factory into various ReactTestUtils JS functions (factories don't work after the React JS 0.13 upgrade).
* Apply workaround needed for `isCompositeComponent` (see https://github.com/facebook/react/pull/3839)
* Fix test that wasn't passing in a `JsObject` when it should have been.
* Update test util comments and test descriptions.

### Testing
Run `pub serve`, navigate to http://localhost:8080/react_test_utils_test.html, and verify that all tests are passing.