### PR TITLE
Add SVG clipPath element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ packages
 lib/docs/
 pubspec.lock
 .idea
+.pub/

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -467,9 +467,9 @@ _createDOMComponents(creator){
   // SVG Elements
   circle = creator('circle');
   clipPath = creator('clipPath');
-  g = creator('g');
   defs = creator('defs');
   ellipse = creator('ellipse');
+  g = creator('g');
   line = creator('line');
   linearGradient = creator('linearGradient');
   mask = creator('mask');
@@ -479,8 +479,8 @@ _createDOMComponents(creator){
   polyline = creator('polyline');
   radialGradient = creator('radialGradient');
   rect = creator('rect');
-  svg = creator('svg');
   stop = creator('stop');
+  svg = creator('svg');
   text = creator('text');
   tspan = creator('tspan');
 }

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -343,7 +343,7 @@ span, strong, style, sub, summary, sup, table, tbody, td, textarea, tfoot, th, t
 title, tr, track, u, ul, variable, video, wbr;
 
 /** SVG elements */
-var circle, defs, ellipse, g, line, linearGradient, mask, path, pattern, polygon, polyline,
+var circle, clipPath, defs, ellipse, g, line, linearGradient, mask, path, pattern, polygon, polyline,
 radialGradient, rect, stop, svg, text, tspan;
 
 
@@ -466,6 +466,7 @@ _createDOMComponents(creator){
 
   // SVG Elements
   circle = creator('circle');
+  clipPath = creator('clipPath');
   g = creator('g');
   defs = creator('defs');
   ellipse = creator('ellipse');


### PR DESCRIPTION
This adds the missing SVG `clipPath` element.

I also added a `.pub/` to the .gitignore. Seems this file is created when running `pub get`, and probably shouldn't be committed to source control.