### PR TITLE
Add support for renderToStaticMarkup

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -311,6 +311,14 @@ var render;
  */
 var renderToString;
 
+/**
+ * Similar to [renderToString], except this doesn't create extra DOM attributes such as
+ * `data-react-id`, that React uses internally. This is useful if you want to use React
+ * as a simple static page generator, as stripping away the extra attributes can save
+ * lots of bytes.
+ */
+var renderToStaticMarkup;
+
 
 /**
  * bool unmountComponentAtNode(HTMLElement);
@@ -489,10 +497,12 @@ _createDOMComponents(creator){
  *
  * It pass arguments to global variables and run DOM components creation by dom Creator.
  */
-setReactConfiguration(domCreator, customRegisterComponent, customRender, customRenderToString, customUnmountComponentAtNode, customFindDOMNode){
+setReactConfiguration(domCreator, customRegisterComponent, customRender, customRenderToString,
+    customRenderToStaticMarkup, customUnmountComponentAtNode, customFindDOMNode){
   registerComponent = customRegisterComponent;
   render = customRender;
   renderToString = customRenderToString;
+  renderToStaticMarkup = customRenderToStaticMarkup;
   unmountComponentAtNode = customUnmountComponentAtNode;
   findDOMNode = customFindDOMNode;
   // HTML Elements

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -520,6 +520,10 @@ void _render(JsObject component, HtmlElement element) {
   _React.callMethod('render', [component, element]);
 }
 
+String _renderToString(JsObject component) {
+  return _React.callMethod('renderToString', [component]);
+}
+
 bool _unmountComponentAtNode(HtmlElement element) {
   return _React.callMethod('unmountComponentAtNode', [element]);
 }
@@ -534,5 +538,5 @@ dynamic _findDomNode(component) {
 
 void setClientConfiguration() {
   _React.callMethod('initializeTouchEvents', [true]);
-  setReactConfiguration(_reactDom, _registerComponent, _render, null, _unmountComponentAtNode, _findDomNode);
+  setReactConfiguration(_reactDom, _registerComponent, _render, _renderToString, _unmountComponentAtNode, _findDomNode);
 }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -524,6 +524,10 @@ String _renderToString(JsObject component) {
   return _React.callMethod('renderToString', [component]);
 }
 
+String _renderToStaticMarkup(JsObject component) {
+  return _React.callMethod('renderToStaticMarkup', [component]);
+}
+
 bool _unmountComponentAtNode(HtmlElement element) {
   return _React.callMethod('unmountComponentAtNode', [element]);
 }
@@ -538,5 +542,6 @@ dynamic _findDomNode(component) {
 
 void setClientConfiguration() {
   _React.callMethod('initializeTouchEvents', [true]);
-  setReactConfiguration(_reactDom, _registerComponent, _render, _renderToString, _unmountComponentAtNode, _findDomNode);
+  setReactConfiguration(_reactDom, _registerComponent, _render, _renderToString,
+      _renderToStaticMarkup, _unmountComponentAtNode, _findDomNode);
 }

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -288,6 +288,10 @@ String _renderComponentToString(OwnerFactory component) {
   return _addChecksumToMarkup(component());
 }
 
+String _renderToStaticMarkup(OwnerFactory component) {
+  return _removeReactIdFromMarkup(component());
+}
+
 /**
  * creates random id based on id creation in react.js
  */
@@ -306,6 +310,11 @@ String _addChecksumToMarkup(String markup) {
       ' $_CHECKSUM_ATTR_NAME="$checksum">'
     );
 
+}
+
+String _removeReactIdFromMarkup(String markup) {
+  var matcher = new RegExp(' $_ID_ATTR_NAME=".+?"');
+  return markup.replaceAll(matcher, "");
 }
 
 /**
@@ -327,5 +336,5 @@ _adler32(String data) {
 }
 
 void setServerConfiguration() {
-  setReactConfiguration(_reactDom, _registerComponent, null, _renderComponentToString, null, null);
+  setReactConfiguration(_reactDom, _registerComponent, null, _renderComponentToString, _renderToStaticMarkup, null, null);
 }


### PR DESCRIPTION
This adds support for `React.renderToStaticMarkup` which is useful if you want to generate a DOM string without React's ID attributes. Use cases include static site generation, or generating HTML/SVG on the client to send to the server for processing.

I also added support for `renderToString` in the browser. The use-case for this method is probably small in client environments, but it's supported in ReactJS, so thought we should support it here too.