### PR TITLE
Change react_test_util.Simulate method parameters to accept DOM nodes

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -49,110 +49,110 @@ typedef bool ComponentTestFunction(JsObject componentInstance);
 /// Provides methods for each type of event that can be handled by a React
 /// component.  All methods are used in the same way:
 ///
-///   Simulate.{eventName}([JsObject] element, [Map] eventData)
+///   Simulate.{eventName}(dynamic instanceOrNode, [Map] eventData)
 ///
 /// This should include all events documented at:
 /// http://facebook.github.io/react/docs/events.html
 class Simulate {
 
-  static void blur(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('blur', [element, new JsObject.jsify(eventData)]);
+  static void blur(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('blur', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void change(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('change', [element, new JsObject.jsify(eventData)]);
+  static void change(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('change', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void click(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('click', [element, new JsObject.jsify(eventData)]);
-      
-  static void contextMenu(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('contextMenu', [element, new JsObject.jsify(eventData)]);
-      
-  static void copy(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('copy', [element, new JsObject.jsify(eventData)]);
-      
-  static void cut(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('cut', [element, new JsObject.jsify(eventData)]);
-      
-  static void doubleClick(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('doubleClick', [element, new JsObject.jsify(eventData)]);
-      
-  static void drag(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('drag', [element, new JsObject.jsify(eventData)]);
-      
-  static void dragEnd(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragEnd', [element, new JsObject.jsify(eventData)]);
-      
-  static void dragEnter(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragEnter', [element, new JsObject.jsify(eventData)]);
+  static void click(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('click', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragExit(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragExit', [element, new JsObject.jsify(eventData)]);
+  static void contextMenu(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('contextMenu', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragLeave(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragLeave', [element, new JsObject.jsify(eventData)]);
+  static void copy(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('copy', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragOver(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragOver', [element, new JsObject.jsify(eventData)]);
+  static void cut(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('cut', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragStart(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragStart', [element, new JsObject.jsify(eventData)]);
+  static void doubleClick(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('doubleClick', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void drop(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('drop', [element, new JsObject.jsify(eventData)]);
+  static void drag(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('drag', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void focus(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('focus', [element, new JsObject.jsify(eventData)]);
+  static void dragEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void input(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('input', [element, new JsObject.jsify(eventData)]);
+  static void dragEnter(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragEnter', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void keyDown(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyDown', [element, new JsObject.jsify(eventData)]);
+  static void dragExit(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragExit', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void keyPress(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyPress', [element, new JsObject.jsify(eventData)]);
+  static void dragLeave(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragLeave', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void keyUp(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyUp', [element, new JsObject.jsify(eventData)]);
+  static void dragOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragOver', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseDown(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseDown', [element, new JsObject.jsify(eventData)]);
+  static void dragStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('dragStart', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseMove(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseMove', [element, new JsObject.jsify(eventData)]);
+  static void drop(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('drop', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseOut(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseOut', [element, new JsObject.jsify(eventData)]);
+  static void focus(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('focus', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseOver(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseOver', [element, new JsObject.jsify(eventData)]);
+  static void input(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('input', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseUp(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseUp', [element, new JsObject.jsify(eventData)]);
+  static void keyDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('keyDown', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void paste(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('paste', [element, new JsObject.jsify(eventData)]);
+  static void keyPress(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('keyPress', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void scroll(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('scroll', [element, new JsObject.jsify(eventData)]);
+  static void keyUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('keyUp', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void submit(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('submit', [element, new JsObject.jsify(eventData)]);
+  static void mouseDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('mouseDown', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchCancel(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchCancel', [element, new JsObject.jsify(eventData)]);
+  static void mouseMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('mouseMove', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchEnd(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchEnd', [element, new JsObject.jsify(eventData)]);
+  static void mouseOut(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('mouseOut', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchMove(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchMove', [element, new JsObject.jsify(eventData)]);
+  static void mouseOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('mouseOver', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchStart(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchStart', [element, new JsObject.jsify(eventData)]);
+  static void mouseUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('mouseUp', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void wheel(JsObject element, [Map eventData = const{}]) =>
-      _Simulate.callMethod('wheel', [element, new JsObject.jsify(eventData)]);
+  static void paste(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('paste', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void scroll(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('scroll', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void submit(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('submit', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void touchCancel(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('touchCancel', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void touchEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('touchEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void touchMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('touchMove', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void touchStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('touchStart', [instanceOrNode, new JsObject.jsify(eventData)]);
+
+  static void wheel(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _Simulate.callMethod('wheel', [instanceOrNode, new JsObject.jsify(eventData)]);
 
 }
 
@@ -163,102 +163,102 @@ class Simulate {
 /// Provides methods for each type of event that can be handled by a React
 /// component.  All methods are used in the same way:
 ///
-///   SimulateNative.{eventName}([JsObject] element, [Map] eventData)
+///   SimulateNative.{eventName}(dynamic instanceOrNode, [Map] eventData)
 
 class SimulateNative {
 
-  static void blur(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('blur', [element, new JsObject.jsify(eventData)]);
+  static void blur(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('blur', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void click(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('click', [element, new JsObject.jsify(eventData)]);
+  static void click(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('click', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void contextMenu(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('contextMenu', [element, new JsObject.jsify(eventData)]);
+  static void contextMenu(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('contextMenu', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void copy(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('copy', [element, new JsObject.jsify(eventData)]);
+  static void copy(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('copy', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void cut(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('cut', [element, new JsObject.jsify(eventData)]);
+  static void cut(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('cut', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void doubleClick(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('doubleClick', [element, new JsObject.jsify(eventData)]);
+  static void doubleClick(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('doubleClick', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void drag(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('drag', [element, new JsObject.jsify(eventData)]);
+  static void drag(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('drag', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragEnd(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragEnd', [element, new JsObject.jsify(eventData)]);
+  static void dragEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragEnter(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragEnter', [element, new JsObject.jsify(eventData)]);
+  static void dragEnter(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragEnter', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragExit(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragExit', [element, new JsObject.jsify(eventData)]);
+  static void dragExit(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragExit', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragLeave(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragLeave', [element, new JsObject.jsify(eventData)]);
+  static void dragLeave(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragLeave', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragOver(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragOver', [element, new JsObject.jsify(eventData)]);
+  static void dragOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragOver', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void dragStart(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragStart', [element, new JsObject.jsify(eventData)]);
+  static void dragStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('dragStart', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void drop(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('drop', [element, new JsObject.jsify(eventData)]);
+  static void drop(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('drop', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void focus(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('focus', [element, new JsObject.jsify(eventData)]);
+  static void focus(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('focus', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void input(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('input', [element, new JsObject.jsify(eventData)]);
+  static void input(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('input', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void keyDown(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('keyDown', [element, new JsObject.jsify(eventData)]);
+  static void keyDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('keyDown', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void keyUp(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('keyUp', [element, new JsObject.jsify(eventData)]);
+  static void keyUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('keyUp', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseDown(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseDown', [element, new JsObject.jsify(eventData)]);
+  static void mouseDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseDown', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseMove(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseMove', [element, new JsObject.jsify(eventData)]);
+  static void mouseMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseMove', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseOut(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseOut', [element, new JsObject.jsify(eventData)]);
+  static void mouseOut(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOut', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseOver(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseOver', [element, new JsObject.jsify(eventData)]);
+  static void mouseOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseOver', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void mouseUp(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseUp', [element, new JsObject.jsify(eventData)]);
+  static void mouseUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('mouseUp', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void paste(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('paste', [element, new JsObject.jsify(eventData)]);
+  static void paste(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('paste', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void scroll(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('scroll', [element, new JsObject.jsify(eventData)]);
+  static void scroll(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('scroll', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void submit(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('submit', [element, new JsObject.jsify(eventData)]);
+  static void submit(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('submit', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchCancel(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchCancel', [element, new JsObject.jsify(eventData)]);
+  static void touchCancel(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchCancel', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchEnd(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchEnd', [element, new JsObject.jsify(eventData)]);
+  static void touchEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchMove(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchMove', [element, new JsObject.jsify(eventData)]);
+  static void touchMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchMove', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void touchStart(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchStart', [element, new JsObject.jsify(eventData)]);
+  static void touchStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('touchStart', [instanceOrNode, new JsObject.jsify(eventData)]);
 
-  static void wheel(JsObject element, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('wheel', [element, new JsObject.jsify(eventData)]);
+  static void wheel(dynamic instanceOrNode, [Map eventData = const{}]) =>
+      _SimulateNative.callMethod('wheel', [instanceOrNode, new JsObject.jsify(eventData)]);
 
 }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -19,96 +19,108 @@ void main() {
   var _React = context['React'];
   var _Object = context['Object'];
 
-  void testEvent(Function event, String eventName) {
-    component = renderIntoDocument(eventComponent({}));
-    domNode = getDomNode(component);
-    expect(domNode.text, equals(''));
-
-    int fakeTimeStamp = eventName.hashCode;
-    Map eventData = {
-      'type': eventName,
-      'timeStamp': fakeTimeStamp
-    };
-    event(findRenderedDOMComponentWithTag(component, 'div'), eventData);
-    expect(domNode.text, equals('$eventName $fakeTimeStamp'));
-  }
-
-  group('Simulate event', () {
-    tearDown(() {
-      component = null;
-      domNode = null;
-    });
-
-    test('blur', () => testEvent(Simulate.blur, 'blur'));
-    test('change', () => testEvent(Simulate.change, 'change'));
-    test('click', () => testEvent(Simulate.click, 'click'));
-    test('copy', () => testEvent(Simulate.copy, 'copy'));
-    test('cut', () => testEvent(Simulate.cut, 'cut'));
-    test('doubleClick', () => testEvent(Simulate.doubleClick, 'doubleClick'));
-    test('drag', () => testEvent(Simulate.drag, 'drag'));
-    test('dragEnd', () => testEvent(Simulate.dragEnd, 'dragEnd'));
-    test('dragEnter', () => testEvent(Simulate.dragEnter, 'dragEnter'));
-    test('dragExit', () => testEvent(Simulate.dragExit, 'dragExit'));
-    test('dragLeave', () => testEvent(Simulate.dragLeave, 'dragLeave'));
-    test('dragOver', () => testEvent(Simulate.dragOver, 'dragOver'));
-    test('dragStart', () => testEvent(Simulate.dragStart, 'dragStart'));
-    test('drop', () => testEvent(Simulate.drop, 'drop'));
-    test('focus', () => testEvent(Simulate.focus, 'focus'));
-    test('input', () => testEvent(Simulate.input, 'input'));
-    test('keyDown', () => testEvent(Simulate.keyDown, 'keyDown'));
-    test('keyPress', () => testEvent(Simulate.keyPress, 'keyPress'));
-    test('keyUp', () => testEvent(Simulate.keyUp, 'keyUp'));
-    test('mouseDown', () => testEvent(Simulate.mouseDown, 'mouseDown'));
-    test('mouseMove', () => testEvent(Simulate.mouseMove, 'mouseMove'));
-    test('mouseOut', () => testEvent(Simulate.mouseOut, 'mouseOut'));
-    test('mouseOver', () => testEvent(Simulate.mouseOver, 'mouseOver'));
-    test('mouseUp', () => testEvent(Simulate.mouseUp, 'mouseUp'));
-    test('paste', () => testEvent(Simulate.paste, 'paste'));
-    test('scroll', () => testEvent(Simulate.scroll, 'scroll'));
-    test('submit', () => testEvent(Simulate.submit, 'submit'));
-    test('touchCancel', () => testEvent(Simulate.touchCancel, 'touchCancel'));
-    test('touchEnd', () => testEvent(Simulate.touchEnd, 'touchEnd'));
-    test('touchMove', () => testEvent(Simulate.touchMove, 'touchMove'));
-    test('touchStart', () => testEvent(Simulate.touchStart, 'touchStart'));
-    test('wheel', () => testEvent(Simulate.wheel, 'wheel'));
+  tearDown(() {
+    component = null;
+    domNode = null;
   });
 
-  group('Simulate native event', () {
-    tearDown(() {
-      component = null;
-      domNode = null;
+  group('Simulate', () {
+    setUp(() {
+      component = renderIntoDocument(eventComponent({}));
+      domNode = getDomNode(component);
+      expect(domNode.text, equals(''));
     });
 
-    test('blur', () => testEvent(SimulateNative.blur, 'blur'));
-    test('click', () => testEvent(SimulateNative.click, 'click'));
-    test('copy', () => testEvent(SimulateNative.copy, 'copy'));
-    test('cut', () => testEvent(SimulateNative.cut, 'cut'));
-    test('doubleClick', () => testEvent(SimulateNative.doubleClick, 'doubleClick'));
-    test('drag', () => testEvent(SimulateNative.drag, 'drag'));
-    test('dragEnd', () => testEvent(SimulateNative.dragEnd, 'dragEnd'));
-    test('dragEnter', () => testEvent(SimulateNative.dragEnter, 'dragEnter'));
-    test('dragExit', () => testEvent(SimulateNative.dragExit, 'dragExit'));
-    test('dragLeave', () => testEvent(SimulateNative.dragLeave, 'dragLeave'));
-    test('dragOver', () => testEvent(SimulateNative.dragOver, 'dragOver'));
-    test('dragStart', () => testEvent(SimulateNative.dragStart, 'dragStart'));
-    test('drop', () => testEvent(SimulateNative.drop, 'drop'));
-    test('focus', () => testEvent(SimulateNative.focus, 'focus'));
-    test('input', () => testEvent(SimulateNative.input, 'input'));
-    test('keyDown', () => testEvent(SimulateNative.keyDown, 'keyDown'));
-    test('keyUp', () => testEvent(SimulateNative.keyUp, 'keyUp'));
-    test('mouseDown', () => testEvent(SimulateNative.mouseDown, 'mouseDown'));
-    test('mouseMove', () => testEvent(SimulateNative.mouseMove, 'mouseMove'));
-    test('mouseOut', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
-    test('mouseOver', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
-    test('mouseUp', () => testEvent(SimulateNative.mouseUp, 'mouseUp'));
-    test('paste', () => testEvent(SimulateNative.paste, 'paste'));
-    test('scroll', () => testEvent(SimulateNative.scroll, 'scroll'));
-    test('submit', () => testEvent(SimulateNative.submit, 'submit'));
-    test('touchCancel', () => testEvent(SimulateNative.touchCancel, 'touchCancel'));
-    test('touchEnd', () => testEvent(SimulateNative.touchEnd, 'touchEnd'));
-    test('touchMove', () => testEvent(SimulateNative.touchMove, 'touchMove'));
-    test('touchStart', () => testEvent(SimulateNative.touchStart, 'touchStart'));
-    test('wheel', () => testEvent(SimulateNative.wheel, 'wheel'));
+    void testEvent(void event(dynamic instanceOrNode, Map eventData), String eventName) {
+      int fakeTimeStamp;
+      Map eventData;
+
+      setUp(() {
+        fakeTimeStamp = eventName.hashCode;
+        eventData = {
+          'type': eventName,
+          'timeStamp': fakeTimeStamp
+        };
+      });
+
+      test('with React instance as arg', () {
+        event(findRenderedDOMComponentWithTag(component, 'div'), eventData);
+        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
+      });
+
+      test('with DOM Element as arg', () {
+        event(domNode, eventData);
+        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
+      });
+    };
+
+    group('event', () {
+      group('blur', () => testEvent(Simulate.blur, 'blur'));
+      group('change', () => testEvent(Simulate.change, 'change'));
+      group('click', () => testEvent(Simulate.click, 'click'));
+      group('copy', () => testEvent(Simulate.copy, 'copy'));
+      group('cut', () => testEvent(Simulate.cut, 'cut'));
+      group('doubleClick', () => testEvent(Simulate.doubleClick, 'doubleClick'));
+      group('drag', () => testEvent(Simulate.drag, 'drag'));
+      group('dragEnd', () => testEvent(Simulate.dragEnd, 'dragEnd'));
+      group('dragEnter', () => testEvent(Simulate.dragEnter, 'dragEnter'));
+      group('dragExit', () => testEvent(Simulate.dragExit, 'dragExit'));
+      group('dragLeave', () => testEvent(Simulate.dragLeave, 'dragLeave'));
+      group('dragOver', () => testEvent(Simulate.dragOver, 'dragOver'));
+      group('dragStart', () => testEvent(Simulate.dragStart, 'dragStart'));
+      group('drop', () => testEvent(Simulate.drop, 'drop'));
+      group('focus', () => testEvent(Simulate.focus, 'focus'));
+      group('input', () => testEvent(Simulate.input, 'input'));
+      group('keyDown', () => testEvent(Simulate.keyDown, 'keyDown'));
+      group('keyPress', () => testEvent(Simulate.keyPress, 'keyPress'));
+      group('keyUp', () => testEvent(Simulate.keyUp, 'keyUp'));
+      group('mouseDown', () => testEvent(Simulate.mouseDown, 'mouseDown'));
+      group('mouseMove', () => testEvent(Simulate.mouseMove, 'mouseMove'));
+      group('mouseOut', () => testEvent(Simulate.mouseOut, 'mouseOut'));
+      group('mouseOver', () => testEvent(Simulate.mouseOver, 'mouseOver'));
+      group('mouseUp', () => testEvent(Simulate.mouseUp, 'mouseUp'));
+      group('paste', () => testEvent(Simulate.paste, 'paste'));
+      group('scroll', () => testEvent(Simulate.scroll, 'scroll'));
+      group('submit', () => testEvent(Simulate.submit, 'submit'));
+      group('touchCancel', () => testEvent(Simulate.touchCancel, 'touchCancel'));
+      group('touchEnd', () => testEvent(Simulate.touchEnd, 'touchEnd'));
+      group('touchMove', () => testEvent(Simulate.touchMove, 'touchMove'));
+      group('touchStart', () => testEvent(Simulate.touchStart, 'touchStart'));
+      group('wheel', () => testEvent(Simulate.wheel, 'wheel'));
+    });
+
+    group('native event', () {
+      group('blur', () => testEvent(SimulateNative.blur, 'blur'));
+      group('click', () => testEvent(SimulateNative.click, 'click'));
+      group('copy', () => testEvent(SimulateNative.copy, 'copy'));
+      group('cut', () => testEvent(SimulateNative.cut, 'cut'));
+      group('doubleClick', () => testEvent(SimulateNative.doubleClick, 'doubleClick'));
+      group('drag', () => testEvent(SimulateNative.drag, 'drag'));
+      group('dragEnd', () => testEvent(SimulateNative.dragEnd, 'dragEnd'));
+      group('dragEnter', () => testEvent(SimulateNative.dragEnter, 'dragEnter'));
+      group('dragExit', () => testEvent(SimulateNative.dragExit, 'dragExit'));
+      group('dragLeave', () => testEvent(SimulateNative.dragLeave, 'dragLeave'));
+      group('dragOver', () => testEvent(SimulateNative.dragOver, 'dragOver'));
+      group('dragStart', () => testEvent(SimulateNative.dragStart, 'dragStart'));
+      group('drop', () => testEvent(SimulateNative.drop, 'drop'));
+      group('focus', () => testEvent(SimulateNative.focus, 'focus'));
+      group('input', () => testEvent(SimulateNative.input, 'input'));
+      group('keyDown', () => testEvent(SimulateNative.keyDown, 'keyDown'));
+      group('keyUp', () => testEvent(SimulateNative.keyUp, 'keyUp'));
+      group('mouseDown', () => testEvent(SimulateNative.mouseDown, 'mouseDown'));
+      group('mouseMove', () => testEvent(SimulateNative.mouseMove, 'mouseMove'));
+      group('mouseOut', () => testEvent(SimulateNative.mouseOut, 'mouseOut'));
+      group('mouseOver', () => testEvent(SimulateNative.mouseOver, 'mouseOver'));
+      group('mouseUp', () => testEvent(SimulateNative.mouseUp, 'mouseUp'));
+      group('paste', () => testEvent(SimulateNative.paste, 'paste'));
+      group('scroll', () => testEvent(SimulateNative.scroll, 'scroll'));
+      group('submit', () => testEvent(SimulateNative.submit, 'submit'));
+      group('touchCancel', () => testEvent(SimulateNative.touchCancel, 'touchCancel'));
+      group('touchEnd', () => testEvent(SimulateNative.touchEnd, 'touchEnd'));
+      group('touchMove', () => testEvent(SimulateNative.touchMove, 'touchMove'));
+      group('touchStart', () => testEvent(SimulateNative.touchStart, 'touchStart'));
+      group('wheel', () => testEvent(SimulateNative.wheel, 'wheel'));
+    });
   });
 
   test('findRenderedDOMComponentWithClass', () {


### PR DESCRIPTION
### Ultimate Problem
ReactTestUtils JS Simulate.* and SimulateNative.* supports simulating events on [either React component instances or DOM nodes corresponding to component instances](https://github.com/facebook/react/blob/cd15dc60b8551d72107f068d9e6cebb5c660105d/src/test/ReactTestUtils.js#L430-L442).

The wrappers in react_test_utils.dart, however, type the target of the simulated events to `JsObject`, so it's not possible to pass in an `Element` (DOM node).

### Changes
* Change parameters on react_test_utils Simulate.* and SimulateNative.* events to `dynamic` so that both `JsObject` component instances and `Element` component DOM nodes can be passed in.
* Update unit tests to verify that the simulated events also work when DOM nodes are passed in.

### Testing
Run `pub serve`, navigate to http://localhost:8080/react_test_utils_test.html, and verify that all tests are passing.