### PR TITLE
Pass along the component instance returned by React.render(...)

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -516,8 +516,8 @@ Set _syntheticUIEvents = new Set.from(["onScroll",]);
 Set _syntheticWheelEvents = new Set.from(["onWheel",]);
 
 
-void _render(JsObject component, HtmlElement element) {
-  _React.callMethod('render', [component, element]);
+JsObject _render(JsObject component, HtmlElement element) {
+  return _React.callMethod('render', [component, element]);
 }
 
 String _renderToString(JsObject component) {


### PR DESCRIPTION
`React.render` in JS returns the rendered component, but react_client doesn't pass along the wrapped result. 