### PR TITLE
Add null-check for DOM event handler props

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -463,6 +463,10 @@ _convertBoundValues(Map args) {
 _convertEventHandlers(Map args) {
   var zone = Zone.current;
   args.forEach((key, value) {
+    if (value == null) {
+      // If the handler is null, don't attempt to wrap/call it.
+      return;
+    }
     var eventFactory;
     if (_syntheticClipboardEvents.contains(key)) {
       eventFactory = syntheticClipboardEventFactory;


### PR DESCRIPTION
Previously, if a `null` event callback prop was passed into a DOM component, it would throw an error when that event is fired.

Now, `null` callbacks are skipped, preventing the issue.

@hleumas 