### PR TITLE
Upgrade quiver dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,6 @@ environment:
   sdk: '>=0.8.10+6 <2.0.0'
 dependencies:
   browser: '>=0.9.0 <0.11.0'
-  quiver: '>=0.18.2 < 0.19.0'
+  quiver: '>=0.18.2 <0.22.0'
 dev_dependencies:
   unittest: '>=0.11.0'


### PR DESCRIPTION
## Issue
- The quiver dependency is outdated and the current range is restrictive (`>=0.18.2 <0.19.0`)
- The only use of quiver is in `react_server.dart` for the `enumerate()` function: 
  - https://github.com/cleandart/react-dart/blob/ca6ec7213e185735adc4c50ebeab3fe1a23c3de2/lib/react_server.dart#L9
  - https://github.com/cleandart/react-dart/blob/ca6ec7213e185735adc4c50ebeab3fe1a23c3de2/lib/react_server.dart#L142
- The `enumerate()` function has not had any breaking changes since 0.18, and the latest version should still work

## Changes
Extend the quiver version range to include the latest.

---

@hleumas @trentgrover-wf @greglittlefield-wf 
fyi: @georgelesica-wf