### PR TITLE
ReactTestUtils shallow rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/docs/
 pubspec.lock
 .idea
 .pub/
+.packages

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Dart wrapper library for [facebook/react](http://facebook.github.io/)
 
+[![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dartlang.org/packages/react)
+
 ##Getting started
 
 If you are not familiar with React library read [react tutorial](http://facebook.github.io/react/docs/getting-started.html) first.
@@ -44,7 +46,7 @@ Inverse method to rendering component is unmountComponentAtNode
 
 ##Using browser native elements
 
-If you are familiar with React (without JSX extension) React-dart shouldn't surprise you much. All elements are defined as 
+If you are familiar with React (without JSX extension) React-dart shouldn't surprise you much. All elements are defined as
 functions that take `props` as first argument and `children` as optional second argument. `props` should implement `Map` and `children` is either one React element or `List` with multiple elements.
 
 ```dart
@@ -71,7 +73,7 @@ class MyComponent extends Component {
   render() => div({}, "MyComponent");
 }
 ```
-    
+
 Register this class so React can recognize it.
 
 ```dart
@@ -154,15 +156,15 @@ class _ParentComponent extends Component {
   componentDidMount(root) {
     var inputRef = ref("input"); //return react jsObject
     InputElement input = findDOMNode(inputRef); // return InputElement in dom
-    
+
     _DartComponent dartRef = ref("dart"); //return instance of _DartComponent
     dartRef.someData; // you can call methods or get values from it
     findDOMNode(dartRef); //return div element rendered from _DartComponent
-    
+
     findDOMNode(this); //return root dom element rendered from this component
   }
 }
-``` 
+```
 
 ## Geocodes Example
 

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -366,3 +366,41 @@ JsObject mockComponent(JsObject componentClass, String mockTagName) {
   return _TestUtils.callMethod(
       'mockComponent', [componentClass, mockTagName]);
 }
+
+/// Returns a ReactShallowRenderer instance
+///
+/// More info on using shallow rendering: https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
+ReactShallowRenderer createRenderer() {
+  return new ReactShallowRenderer.jsObject(_TestUtils.callMethod('createRenderer', []));
+}
+
+/// ReactShallowRenderer wrapper
+///
+/// Usage:
+/// ```
+/// ReactShallowRenderer shallowRenderer = createRenderer();
+/// shallowRenderer.render(div({'className': 'active'}));
+///
+/// JsObject renderedOutput = shallowRenderer.getRenderOutput();
+/// expect(renderedOutput['props']['className'], 'active');
+/// ```
+///
+/// See react_with_addons.js#ReactShallowRenderer
+class ReactShallowRenderer {
+  final JsObject jsRenderer;
+
+  ReactShallowRenderer.jsObject(JsObject this.jsRenderer);
+
+  /// Get the rendered output. [render] must be called first
+  JsObject getRenderOutput() => jsRenderer.callMethod('getRenderOutput', []);
+
+  render(JsObject element, [Map context]) {
+    JsObject c = context == null ? null : new JsObject.jsify(context);
+
+    jsRenderer.callMethod('render', [element, c]);
+  }
+
+  unmount() {
+    jsRenderer.callMethod('unmount', []);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   browser: '>=0.9.0 <0.11.0'
   quiver: '>=0.18.2 <0.22.0'
 dev_dependencies:
-  unittest: '>=0.11.0'
+  unittest: '>=0.11.0 <0.12.0'

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -24,6 +24,32 @@ void main() {
     domNode = null;
   });
 
+  group('Shallow Rendering', () {
+    JsObject content;
+    ReactShallowRenderer shallowRenderer;
+
+    setUp(() {
+      content = div({'className': 'test', 'id': 'createRendererTest'});
+
+      shallowRenderer = createRenderer();
+    });
+
+    tearDown(() {
+      JsObject renderedOutput = shallowRenderer.getRenderOutput();
+
+      expect(renderedOutput['props']['className'], 'test');
+      expect(renderedOutput['props']['id'], 'createRendererTest');
+    });
+
+    test('without context', () {
+      shallowRenderer.render(content);
+    });
+
+    test('with context', () {
+      shallowRenderer.render(content, {});
+    });
+  });
+
   group('Simulate', () {
     setUp(() {
       component = renderIntoDocument(eventComponent({}));


### PR DESCRIPTION
### Issue
ReactTestUtils has a shallow rendering method, `createRenderer`, that is not exposed through the dart port.

Tests fail to run on master as well.

README was missing the version.

### Changes
Added method to `react_test_utils.dart` with a small wrapper for ease of API access.

Also updated the `unittest` package. It should be replaced since it is deprecated, but I kept it to just an update for this PR.

Added pub version to README.

@hleumas @trentgrover-wf @greglittlefield-wf