### PR TITLE
Add displayName getter.

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -15,6 +15,11 @@ abstract class Component {
   dynamic _jsRedraw;
 
   /**
+   * Getter to allow the [displayName] React property to be set.
+   */
+  String get displayName => runtimeType.toString();
+
+  /**
    * Bind the value of input to [state[key]].
    */
   bind(key) => [state[key], (value) => setState({key: value})];

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -319,6 +319,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
    */
   JsFunction reactComponentClass = _React.callMethod('createClass', [newJsMap(
     removeUnusedMethods({
+      'displayName': componentFactory().displayName,
       'componentWillMount': componentWillMount,
       'componentDidMount': componentDidMount,
       'componentWillReceiveProps': componentWillReceiveProps,


### PR DESCRIPTION
## Problem

The `displayName` property isn't implemented by React-Dart. Implementing it would make the React Devtools far more useful.

## Solution

Add it and add a default implementation for the `Component` class that just returns the runtime type as a string.

## FYI

@evanweible-wf @greglittlefield-wf @travissanderson-wf 