### PR TITLE
Callback refs: return the Dart component, not the JsObject instance 

### DIFF
--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -1,7 +1,8 @@
+import "dart:html";
+import 'dart:js';
+
 import "package:react/react.dart" as react;
 import "package:react/react_client.dart";
-import "dart:html";
-
 
 var ChildComponent = react.registerComponent(() => new _ChildComponent());
 class _ChildComponent extends react.Component {
@@ -16,6 +17,7 @@ class _ChildComponent extends react.Component {
 
 var ParrentComponent = react.registerComponent(() => new _ParrentComponent());
 class _ParrentComponent extends react.Component {
+  // String refs
   showInputValue(_) {
     var input = react.findDOMNode(ref('inputRef')) as InputElement;
     print(input.value);
@@ -26,14 +28,40 @@ class _ParrentComponent extends react.Component {
   incrementChildValue(_) {
     ref("childRef").incrementValue();
   }
+
+  // Callback refs
+  JsObject _inputCallbackRef;
+  _ChildComponent _childCallbackRef;
+  showInputCallbackRefValue(_) {
+    var input = react.findDOMNode(_inputCallbackRef);
+    print(input.value);
+  }
+  showChildCallbackRefValue(_) {
+    print(_childCallbackRef.somevalue);
+  }
+  incrementChildCallbackRefValue(_) {
+    _childCallbackRef.incrementValue();
+  }
+
   render() =>
     react.div({},[
+      react.h1({}, "String refs"),
+      react.h4({}, "<input>"),
       react.input({"ref": "inputRef"}),
-      react.button({"onClick": showInputValue}, "print input element value"),
+      react.button({"onClick": showInputValue}, "Print input element value"),
+      react.h4({}, "ChildComponent"),
       ChildComponent({"ref": "childRef"}),
-      react.button({"onClick": showChildValue}, "Show child value"),
-      react.button({"onClick": incrementChildValue}, "Show child value"),
+      react.button({"onClick": showChildValue}, "Print child value"),
+      react.button({"onClick": incrementChildValue}, "Increment child value"),
 
+      react.h1({}, "Callback refs"),
+      react.h4({}, "<input>"),
+      react.input({"ref": (instance) => _inputCallbackRef = instance}),
+      react.button({"onClick": showInputCallbackRefValue}, "Print input element value"),
+      react.h4({}, "ChildComponent"),
+      ChildComponent({"ref": (instance) => _childCallbackRef = instance}),
+      react.button({"onClick": showChildCallbackRefValue}, "Print child value"),
+      react.button({"onClick": incrementChildCallbackRefValue}, "Increment child value"),
     ]);
 }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -42,6 +42,13 @@ typedef JsObject ReactComponentFactory(Map props, [dynamic children]);
 typedef Component ComponentFactory();
 
 /**
+ * The type of a ref specified as a callback.
+ *
+ * See <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>.
+ */
+typedef _CallbackRef(componentOrDomNode);
+
+/**
  * A Dart function that creates React JS component instances.
  */
 abstract class ReactComponentFactoryProxy implements Function {
@@ -128,7 +135,15 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
     }
 
     if (extendedProps.containsKey('ref')) {
-      jsProps['ref'] = extendedProps['ref'];
+      var ref = extendedProps['ref'];
+
+      // If the ref is a callback, pass React a function that will call it
+      // with the Dart component instance, not the JsObject instance.
+      if (ref is _CallbackRef) {
+        jsProps['ref'] = (JsObject instance) => ref(_getComponent(instance));
+      } else {
+        jsProps['ref'] = ref;
+      }
     }
 
     /**
@@ -355,7 +370,7 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   @override
   JsObject call(Map props, [dynamic children]) {
     convertProps(props);
-    
+
     // Convert Iterable children to JsArrays so that the JS can read them.
     // Use JsArrays instead of Lists, because automatic List conversion results in
     // react-id values being cluttered with ".$o:0:0:$_jsObject:" in dart2js-transpiled Dart.


### PR DESCRIPTION
## Ultimate Problem
Refs specified as callbacks were called with the `JsObject` instance, not the Dart component.

This behavior is different than that of `Component.ref(...)`, and makes it impossible to use Dart components with callback refs without knowledge of react-dart internals.

## Solution
When a ref is specified as a callback to a Dart component, wrap it in a callback that calls the original with the Dart component.

## Testing 
* Open `example/test/ref_test.html`
* Verify that the examples for both string and callback refs work as expected.

---

@hleumas @trentgrover-wf @maxwellpeterson-wf @aaronlademann-wf