### PR TITLE
Add "onReset" form event

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -623,6 +623,7 @@ Set _syntheticKeyboardEvents = new Set.from(["onKeyDown", "onKeyPress",
 Set _syntheticFocusEvents = new Set.from(["onFocus", "onBlur",]);
 
 Set _syntheticFormEvents = new Set.from(["onChange", "onInput", "onSubmit",
+    "onReset",
 ]);
 
 Set _syntheticMouseEvents = new Set.from(["onClick", "onContextMenu",


### PR DESCRIPTION
The "onReset" form event was missing, which caused errors when providing a callback prop with the `'onReset'` key:
```
Uncaught Unhandled exception:
Closure call with mismatched arguments: function 'call'

NoSuchMethodError: incorrect number of arguments passed to method named 'call'
Receiver: Closure: (dynamic) => dynamic
Tried calling: call(Instance of 'JsObjectImpl', ".r[1xv2o].3")
Found: call(e)
#0      Object._noSuchMethod (dart:core-patch/object_patch.dart:42)
#1      Object.noSuchMethod (dart:core-patch/object_patch.dart:45)
```