### PR TITLE
Add null-check to Dart component callback refs

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -140,7 +140,7 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
       // If the ref is a callback, pass React a function that will call it
       // with the Dart component instance, not the JsObject instance.
       if (ref is _CallbackRef) {
-        jsProps['ref'] = (JsObject instance) => ref(_getComponent(instance));
+        jsProps['ref'] = (JsObject instance) => ref(instance == null ? null : _getComponent(instance));
       } else {
         jsProps['ref'] = ref;
       }


### PR DESCRIPTION
When a Dart component is no longer rendered, its callback ref is called with `null`, which caused null errors when passed into `_getComponent`.

A null-check has been added to fix this case.