### PR TITLE
Expose a reference to jsThis within Dart components

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -13,6 +13,12 @@ abstract class Component {
   dynamic ref;
   dynamic getDOMNode;
   dynamic _jsRedraw;
+  dynamic _jsThis;
+
+  /**
+   * The JavaScript `ReactComponent` instance associated with this component.
+   */
+  dynamic get jsThis => _jsThis;
 
   /**
    * Getter to allow the [displayName] React property to be set.
@@ -24,10 +30,11 @@ abstract class Component {
    */
   bind(key) => [state[key], (value) => setState({key: value})];
 
-  initComponentInternal(props, _jsRedraw, [ref = null, getDOMNode = null]) {
+  initComponentInternal(props, _jsRedraw, [ref, getDOMNode, _jsThis]) {
     this._jsRedraw = _jsRedraw;
     this.ref = ref;
     this.getDOMNode = getDOMNode;
+    this._jsThis = _jsThis;
     _initProps(props);
   }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -204,7 +204,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     };
 
     Component component = componentFactory()
-        ..initComponentInternal(internal[PROPS], redraw, getRef, getDOMNode);
+        ..initComponentInternal(internal[PROPS], redraw, getRef, getDOMNode, jsThis);
 
     internal[COMPONENT] = component;
     internal[IS_MOUNTED] = false;


### PR DESCRIPTION
Sometimes it's helpful, especially in testing, to get a reference to the JavaScript React component that backs the Dart component instance.

These changes store a reference to that instance on the Dart component and expose it as a getter for external use.