### PR TITLE
New JS interop, performance/lifecycle improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ class _ParentComponent extends Component {
       input({"ref": "input"}),
       DartComponent({"ref": "dart"})
     ]);
-  componentDidMount(root) {
+  componentDidMount() {
     InputElement input = ref("input"); // Returns the DOM node.
 
     _DartComponent dartRef = ref("dart"); // Returns instance of _DartComponent
@@ -189,11 +189,11 @@ explanation/spec. Their signatures in Dart are as:
 ```dart
 class MyComponent extends Component {
   void componentWillMount() {}
-  void componentDidMount(/*DOMElement*/rootNode) {}
+  void componentDidMount() {}
   void componentWillReceiveProps(newProps) {}
   bool shouldComponentUpdate(nextProps, nextState) => true;
   void componentWillUpdate(nextProps, nextState) {}
-  void componentDidUpdate(prevProps, prevState, /*DOMElement */ rootNode) {}
+  void componentDidUpdate(prevProps, prevState) {}
   void componentWillUnmount() {}
   Map getInitialState() => {};
   Map getDefaultProps() => {};

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ a ref name in component props and then call ref method to get the referenced ele
 Return values for Dart components, DOM components and JavaScript components are different.
 For a Dart component, you get an instance of the Dart class of the component.
 For primitive components (like DOM elements), you get the DOM node. For JavaScript composite components,
-you get a `JsObject` representing the react component.
+you get a `ReactElement` representing the react component.
 
 If you want to work with DOM nodes of dart or JS components instead, you can call top level method `findDOMNode` on anything the ref returns.
 

--- a/example/test/get_dom_node_test.dart
+++ b/example/test/get_dom_node_test.dart
@@ -29,10 +29,9 @@ class SimpleComponent extends react.Component {
 
   componentWillUnmount() => print("unmount");
 
-  componentDidMount(root) {
+  componentDidMount() {
     customAssert("ref to span return span ", (react.findDOMNode(ref("refToSpan")) as SpanElement).text == "Test");
-    customAssert("getDomNode is same as mounted element", root == getDOMNode());
-    customAssert("findDOMNode works on this", root == react.findDOMNode(this));
+    customAssert("findDOMNode works on this", react.findDOMNode(this) != null);
     customAssert("random ref resolves to null", react.findDOMNode(ref("someRandomRef")) == null);
   }
 

--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -73,8 +73,9 @@ class _ClockComponent extends react.Component {
     timer.cancel();
   }
 
-  void componentDidMount(rootNode) {
-      rootNode.style.backgroundColor = "#FFAAAA";
+  void componentDidMount() {
+    var rootNode = react.findDOMNode(this);
+    rootNode.style.backgroundColor = "#FFAAAA";
   }
 
   bool shouldComponentUpdate(nextProps, nextState) {
@@ -113,7 +114,7 @@ class _ListComponent extends react.Component {
       print("Adding " + nextState["items"].last.toString());
   }
 
-  void componentDidUpdate(prevProps, prevState, rootNode) {
+  void componentDidUpdate(prevProps, prevState) {
     if(prevState["items"].length > state["items"].length)
       print("Removed " + prevState["items"].first.toString());
   }

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -34,17 +34,16 @@ abstract class Component {
   /// Bind the value of input to [state[key]].
   bind(key) => [state[key], (value) => setState({key: value})];
 
-  initComponentInternal(props, _jsRedraw, [ref, getDOMNode, _jsThis]) {
+  initComponentInternal(props, defaultProps, _jsRedraw, [ref, getDOMNode, _jsThis]) {
     this._jsRedraw = _jsRedraw;
     this.ref = ref;
     this.getDOMNode = getDOMNode;
     this._jsThis = _jsThis;
-    _initProps(props);
+    _initProps(props, defaultProps);
   }
 
-  _initProps(props) {
-    this.props = {}
-      ..addAll(getDefaultProps())
+  _initProps(props, defaultProps) {
+    this.props = new Map.from(defaultProps)
       ..addAll(props);
   }
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -45,6 +45,7 @@ abstract class Component {
   _initProps(props, defaultProps) {
     this.props = new Map.from(defaultProps)
       ..addAll(props);
+    this.nextProps = this.props;
   }
 
   initStateInternal() {
@@ -73,6 +74,11 @@ abstract class Component {
   ///
   /// If `null`, then [_nextState] is equal to [state] - which is the value that will be returned.
   Map get nextState => _nextState == null ? state : _nextState;
+
+  /// Reference to the value of [props] for the upcoming render cycle.
+  ///
+  /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillReceiveProps], and [componentWillUpdate].
+  Map nextProps;
 
   /// Transfers `Component` [_nextState] to [state], and [state] to [_prevState].
   ///

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -130,7 +130,7 @@ abstract class Component {
   /// The [componentDidMount] method of child `Component`s is invoked _before_ that of parent `Component`.
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#mounting-componentdidmount>
-  void componentDidMount(/*DOMElement */ rootNode) {}
+  void componentDidMount() {}
 
   /// ReactJS lifecycle method that is invoked when a `Component` is receiving [newProps].
   ///
@@ -170,7 +170,7 @@ abstract class Component {
   /// of the values of [prevProps] / [prevState].
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate>
-  void componentDidUpdate(prevProps, prevState, /*DOMElement */ rootNode) {}
+  void componentDidUpdate(prevProps, prevState) {}
 
   /// ReactJS lifecycle method that is invoked immediately before a `Component` is unmounted from the DOM.
   ///

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -34,17 +34,16 @@ abstract class Component {
   /// Bind the value of input to [state[key]].
   bind(key) => [state[key], (value) => setState({key: value})];
 
-  initComponentInternal(props, defaultProps, _jsRedraw, [ref, getDOMNode, _jsThis]) {
+  initComponentInternal(props, _jsRedraw, [ref, getDOMNode, _jsThis]) {
     this._jsRedraw = _jsRedraw;
     this.ref = ref;
     this.getDOMNode = getDOMNode;
     this._jsThis = _jsThis;
-    _initProps(props, defaultProps);
+    _initProps(props);
   }
 
-  _initProps(props, defaultProps) {
-    this.props = new Map.from(defaultProps)
-      ..addAll(props);
+  _initProps(props) {
+    this.props = new Map.from(props);
     this.nextProps = this.props;
   }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -40,8 +40,13 @@ abstract class ReactComponentFactoryProxy implements Function {
   dynamic noSuchMethod(Invocation invocation);
 }
 
+/// Prepares [children] to be passed to ReactJS.
+///
+/// Currently only involves converting a top-level non-[List] [Iterable] to
+/// a non-growable [List]s, but this may be updated in the future to support
+/// advanced nesting and other kinds of children.
 dynamic jsifyChildren(dynamic children) {
-  if (children is Iterable) {
+  if (children is Iterable && children is! List) {
     return children.toList(growable: false);
   } else {
     return children;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -231,13 +231,15 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
 
   /// 1. Add [component] to [newArgs] to keep it in [INTERNAL]
   /// 2. Update [Component.props] using [newArgs] as second argument to [_getNextProps]
+  /// 2. Update [Component.props] using the value stored to [Component.nextProps]
+  ///    in `componentWillReceiveProps`.
   /// 3. Update [Component.state] by calling [Component.transferComponentState]
   _afterPropsChange(Component component, newArgs) {
     // [1]
     newArgs[INTERNAL][COMPONENT] = component;
 
     // [2]
-    component.props = _getNextProps(component, newArgs);
+    component.props = component.nextProps;
 
     // [3]
     component.transferComponentState();

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -447,38 +447,72 @@ _convertBoundValues(Map args) {
 /// [JsObject] event.
 _convertEventHandlers(Map args) {
   var zone = Zone.current;
-  args.forEach((key, value) {
-    if (value == null) {
-      // If the handler is null, don't attempt to wrap/call it.
-      return;
+  args.forEach((propKey, value) {
+    var eventFactory = _eventPropKeyToEventFactory[propKey];
+    if (eventFactory != null && value != null) {
+      args[propKey] = (JsObject e, [String domId, Event event]) => zone.run(() {
+        value(eventFactory(e));
+      });
     }
-    var eventFactory;
-
-    if (_syntheticClipboardEvents.contains(key)) {
-      eventFactory = syntheticClipboardEventFactory;
-    } else if (_syntheticKeyboardEvents.contains(key)) {
-      eventFactory = syntheticKeyboardEventFactory;
-    } else if (_syntheticFocusEvents.contains(key)) {
-      eventFactory = syntheticFocusEventFactory;
-    } else if (_syntheticFormEvents.contains(key)) {
-      eventFactory = syntheticFormEventFactory;
-    } else if (_syntheticMouseEvents.contains(key)) {
-      eventFactory = syntheticMouseEventFactory;
-    } else if (_syntheticTouchEvents.contains(key)) {
-      eventFactory = syntheticTouchEventFactory;
-    } else if (_syntheticUIEvents.contains(key)) {
-      eventFactory = syntheticUIEventFactory;
-    } else if (_syntheticWheelEvents.contains(key)) {
-      eventFactory = syntheticWheelEventFactory;
-    } else {
-      return;
-    }
-
-    args[key] = (JsObject e, [String domId, Event event]) => zone.run(() {
-      value(eventFactory(e));
-    });
   });
 }
+
+/// A mapping from event prop keys to their respective event factories.
+///
+/// Used in [_convertEventHandlers] for efficient event handler conversion.
+const Map<String, Function> _eventPropKeyToEventFactory = const <String, Function>{
+  // SyntheticClipboardEvent
+  'onCopy': syntheticClipboardEventFactory,
+  'onCut': syntheticClipboardEventFactory,
+  'onPaste': syntheticClipboardEventFactory,
+
+  // SyntheticKeyboardEvent
+  'onKeyDown': syntheticKeyboardEventFactory,
+  'onKeyPress': syntheticKeyboardEventFactory,
+  'onKeyUp': syntheticKeyboardEventFactory,
+
+  // SyntheticFocusEvent
+  'onFocus': syntheticFocusEventFactory,
+  'onBlur': syntheticFocusEventFactory,
+
+  // SyntheticFormEvent
+  'onChange': syntheticFormEventFactory,
+  'onInput': syntheticFormEventFactory,
+  'onSubmit': syntheticFormEventFactory,
+  'onReset': syntheticFormEventFactory,
+
+  // SyntheticMouseEvent
+  'onClick': syntheticMouseEventFactory,
+  'onContextMenu': syntheticMouseEventFactory,
+  'onDoubleClick': syntheticMouseEventFactory,
+  'onDrag': syntheticMouseEventFactory,
+  'onDragEnd': syntheticMouseEventFactory,
+  'onDragEnter': syntheticMouseEventFactory,
+  'onDragExit': syntheticMouseEventFactory,
+  'onDragLeave': syntheticMouseEventFactory,
+  'onDragOver': syntheticMouseEventFactory,
+  'onDragStart': syntheticMouseEventFactory,
+  'onDrop': syntheticMouseEventFactory,
+  'onMouseDown': syntheticMouseEventFactory,
+  'onMouseEnter': syntheticMouseEventFactory,
+  'onMouseLeave': syntheticMouseEventFactory,
+  'onMouseMove': syntheticMouseEventFactory,
+  'onMouseOut': syntheticMouseEventFactory,
+  'onMouseOver': syntheticMouseEventFactory,
+  'onMouseUp': syntheticMouseEventFactory,
+
+  // SyntheticTouchEvent
+  'onTouchCancel': syntheticTouchEventFactory,
+  'onTouchEnd': syntheticTouchEventFactory,
+  'onTouchMove': syntheticTouchEventFactory,
+  'onTouchStart': syntheticTouchEventFactory,
+
+  // SyntheticUIEvent
+  'onScroll': syntheticUIEventFactory,
+
+  // SyntheticWheelEvent
+  'onWheel': syntheticWheelEventFactory,
+};
 
 /// Wrapper for [SyntheticEvent].
 SyntheticEvent syntheticEventFactory(JsObject e) {
@@ -583,26 +617,6 @@ SyntheticWheelEvent syntheticWheelEventFactory(JsObject e) {
       () => e.callMethod('stopPropagation', []), e['eventPhase'], e['isTrusted'], e['nativeEvent'],
       e['target'], e['timeStamp'], e['type'], e['deltaX'], e['deltaMode'], e['deltaY'], e['deltaZ']);
 }
-
-Set _syntheticClipboardEvents = new Set.from(['onCopy', 'onCut', 'onPaste',]);
-
-Set _syntheticKeyboardEvents = new Set.from(['onKeyDown', 'onKeyPress', 'onKeyUp',]);
-
-Set _syntheticFocusEvents = new Set.from(['onFocus', 'onBlur',]);
-
-Set _syntheticFormEvents = new Set.from(['onChange', 'onInput', 'onSubmit', 'onReset',]);
-
-Set _syntheticMouseEvents = new Set.from(['onClick', 'onContextMenu', 'onDoubleClick', 'onDrag', 'onDragEnd',
-    'onDragEnter', 'onDragExit', 'onDragLeave', 'onDragOver', 'onDragStart', 'onDrop', 'onMouseDown', 'onMouseEnter',
-    'onMouseLeave', 'onMouseMove', 'onMouseOut', 'onMouseOver', 'onMouseUp',
-]);
-
-Set _syntheticTouchEvents = new Set.from(['onTouchCancel', 'onTouchEnd', 'onTouchMove', 'onTouchStart',]);
-
-Set _syntheticUIEvents = new Set.from(['onScroll',]);
-
-Set _syntheticWheelEvents = new Set.from(['onWheel',]);
-
 
 JsObject _render(JsObject component, Element element) {
   var renderedComponent = _ReactDom.callMethod('render', [component, element]);

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -246,14 +246,16 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
   /// Wrapper for [Component.componentWillReceiveProps].
   var componentWillReceiveProps = new JsFunction.withThis((jsThis, newArgs, [reactInternal]) => zone.run(() {
     Component component = _getComponent(jsThis);
-    component.componentWillReceiveProps(_getNextProps(component, newArgs));
+    var nextProps = _getNextProps(component, newArgs);
+    component.nextProps = nextProps;
+    component.componentWillReceiveProps(nextProps);
   }));
 
   /// Wrapper for [Component.shouldComponentUpdate].
   var shouldComponentUpdate = new JsFunction.withThis((jsThis, newArgs, nextState, nextContext) => zone.run(() {
     Component component  = _getComponent(jsThis);
 
-    if (component.shouldComponentUpdate(_getNextProps(component, newArgs), component.nextState)) {
+    if (component.shouldComponentUpdate(component.nextProps, component.nextState)) {
       return true;
     } else {
       // If component should not update, update props / transfer state because componentWillUpdate will not be called.
@@ -265,9 +267,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
   /// Wrapper for [Component.componentWillUpdate].
   var componentWillUpdate = new JsFunction.withThis((jsThis, newArgs, nextState, [reactInternal]) => zone.run(() {
     Component component  = _getComponent(jsThis);
-
-    component.componentWillUpdate(_getNextProps(component, newArgs), component.nextState);
-
+    component.componentWillUpdate(component.nextProps, component.nextState);
     _afterPropsChange(component, newArgs);
   }));
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -177,7 +177,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     };
 
     Component component = componentFactory()
-        ..initComponentInternal(internal.props, defaultProps, redraw, getRef, getDOMNode, jsThis);
+        ..initComponentInternal(internal.props, redraw, getRef, getDOMNode, jsThis);
 
     internal.component = component;
     internal.isMounted = false;
@@ -202,12 +202,8 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
   }));
 
   _getNextProps(Component component, InteropProps newArgs) {
-    var nextProps = new Map.from(defaultProps);
-
     var newProps = newArgs.internal.props;
-    if (newProps != null) nextProps.addAll(newProps);
-
-    return nextProps;
+    return newProps != null ? new Map.from(newProps) : {};
   }
 
   /// 1. Add [component] to [newArgs] to keep it in [InteropProps.internal]

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -217,9 +217,7 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
 
   /// Wrapper for [Component.componentDidMount].
   var componentDidMount = new JsFunction.withThis((JsObject jsThis) => zone.run(() {
-    //you need to get dom node by calling findDOMNode
-    var rootNode = _ReactDom.callMethod('findDOMNode', [jsThis]);
-    _getComponent(jsThis).componentDidMount(rootNode);
+    _getComponent(jsThis).componentDidMount();
   }));
 
   _getNextProps(Component component, newArgs) {
@@ -278,10 +276,8 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
   /// Uses [prevState] which was transferred from [Component.nextState] in [componentWillUpdate].
   var componentDidUpdate = new JsFunction.withThis((JsObject jsThis, prevProps, prevState, prevContext) => zone.run(() {
     var prevInternalProps = _getInternalProps(prevProps);
-    // You don't get rootNode as a parameter, so we need to get it directly
-    var rootNode = _ReactDom.callMethod('findDOMNode', [jsThis]);
     Component component = _getComponent(jsThis);
-    component.componentDidUpdate(prevInternalProps, component.prevState, rootNode);
+    component.componentDidUpdate(prevInternalProps, component.prevState);
   }));
 
   /// Wrapper for [Component.componentWillUnmount].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -43,7 +43,7 @@ abstract class ReactComponentFactoryProxy implements Function {
 /// Prepares [children] to be passed to ReactJS.
 ///
 /// Currently only involves converting a top-level non-[List] [Iterable] to
-/// a non-growable [List]s, but this may be updated in the future to support
+/// a non-growable [List], but this may be updated in the future to support
 /// advanced nesting and other kinds of children.
 dynamic jsifyChildren(dynamic children) {
   if (children is Iterable && children is! List) {

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -55,8 +55,15 @@ dynamic jsifyChildren(dynamic children) {
 
 /// Creates ReactJS [Component] instances for Dart components.
 class ReactDartComponentFactoryProxy<TComponent extends Component> extends ReactComponentFactoryProxy {
+  /// The ReactJS class used as the type for all [ReactElement]s built by
+  /// this factory.
   final ReactClass reactClass;
+
+  /// The JS component factory used by this factory to build [ReactElement]s.
   final Function reactComponentFactory;
+
+  /// The cached Dart default props retrieved from [reactClass] that are passed
+  /// into [generateExtendedJsProps] upon [ReactElement] creation.
   final Map defaultProps;
 
   ReactDartComponentFactoryProxy(ReactClass reactClass) :
@@ -306,14 +313,16 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   ///
   /// E.g. `'div'`, `'a'`, `'h1'`
   final String name;
+
+  /// The JS component factory used by this factory to build [ReactElement]s.
+  final Function factory;
+
   ReactDomComponentFactoryProxy(name) :
     this.name = name,
     this.factory = React.createFactory(name);
 
   @override
   String get type => name;
-
-  final Function factory;
 
   @override
   ReactElement call(Map props, [dynamic children]) {

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -114,24 +114,28 @@ class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
 
     // 1. Merge in defaults (if they were specified)
     // 2. Add specified props and children.
+    // 3. Remove "reserved" props that should not be visible to the rendered component.
 
     // [1]
     Map extendedProps = defaultProps != null ? new Map.from(defaultProps) : {};
     extendedProps
       // [2]
       ..addAll(props)
-      ..['children'] = children;
+      ..['children'] = children
+      // [3]
+      ..remove('key')
+      ..remove('ref');
 
     JsObject jsProps = newJsObjectEmpty();
 
     // Transfer over `key` if specified so ReactJS knows about it.
-    if (extendedProps.containsKey('key')) {
-      jsProps['key'] = extendedProps['key'];
+    if (props.containsKey('key')) {
+      jsProps['key'] = props['key'];
     }
 
     // Transfer over `ref` if specified so ReactJS knows about it.
-    if (extendedProps.containsKey('ref')) {
-      var ref = extendedProps['ref'];
+    if (props.containsKey('ref')) {
+      var ref = props['ref'];
 
       // If the ref is a callback, pass ReactJS a function that will call it
       // with the Dart Component instance, not the JsObject instance.

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -113,8 +113,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
     // 3. Remove "reserved" props that should not be visible to the rendered component.
 
     // [1]
-    Map extendedProps = defaultProps != null ? new Map.from(defaultProps) : {};
-    extendedProps
+    Map extendedProps = (defaultProps != null ? new Map.from(defaultProps) : {})
       // [2]
       ..addAll(props)
       ..['children'] = children

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -11,9 +11,9 @@ import "package:js/js.dart";
 import "package:react/react.dart";
 import "package:react/react_client/js_interop_helpers.dart";
 import 'package:react/react_client/react_interop.dart';
-import "package:react/react_client/synthetic_event_interop.dart" as events;
 import "package:react/react_dom.dart";
 import "package:react/react_dom_server.dart";
+import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
 
 export 'package:react/react_client/react_interop.dart' show ReactElement;
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -19,7 +19,7 @@ export 'package:react/react_client/react_interop.dart' show ReactElement;
 
 final EmptyObject emptyJsMap = new EmptyObject();
 
-/// Type of [children] must be child or list of children, when child is [JsObject] or [String]
+/// Type of [children] must be child or list of children, when child is [ReactElement] or [String]
 typedef ReactElement ReactComponentFactory(Map props, [dynamic children]);
 typedef Component ComponentFactory();
 
@@ -90,7 +90,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
     return super.noSuchMethod(invocation);
   }
 
-  /// Returns a [JsObject] version of the specified [props], preprocessed for consumption by ReactJS and prepared for
+  /// Returns a JavaScript version of the specified [props], preprocessed for consumption by ReactJS and prepared for
   /// consumption by the [react] library internals.
   static InteropProps generateExtendedJsProps(Map props, dynamic children, {Map defaultProps}) {
     if (children == null) {
@@ -128,7 +128,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       var ref = props['ref'];
 
       // If the ref is a callback, pass ReactJS a function that will call it
-      // with the Dart Component instance, not the JsObject instance.
+      // with the Dart Component instance, not the ReactComponent instance.
       if (ref is _CallbackRef) {
         interopProps.ref = allowInterop((ReactComponent instance) =>
             ref(instance == null ? null : instance.props.internal.component));
@@ -402,7 +402,7 @@ _convertBoundValues(Map args) {
 }
 
 /// Convert packed event handler into wrapper and pass it only the Dart [SyntheticEvent] object converted from the
-/// [JsObject] event.
+/// [events.SyntheticEvent] event.
 _convertEventHandlers(Map args) {
   var zone = Zone.current;
   args.forEach((propKey, value) {

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -62,10 +62,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
   ReactDartComponentFactoryProxy(ReactClass reactClass) :
       this.reactClass = reactClass,
       this.reactComponentFactory = React.createFactory(reactClass),
-      this.defaultProps = reactClass.dartDefaultProps
-  {
-    assert(defaultProps != null);
-  }
+      this.defaultProps = reactClass.dartDefaultProps;
 
   ReactClass get type => reactClass;
 

--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -47,7 +47,7 @@ final _SetPropertyFn setProperty = (() {
 })();
 
 
-/// A interop class for an anonymous JavaScript object, with no properties.
+/// An interop class for an anonymous JavaScript object, with no properties.
 ///
 /// For use when dealing with dynamic properties via [getProperty]/[setProperty].
 @JS()

--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -1,0 +1,60 @@
+library react_client.js_interop_helpers;
+
+import "package:js/js.dart";
+
+@JS('eval')
+external dynamic _eval(String source);
+
+@JS()
+external dynamic _getProperty(jsObj, String key);
+
+@JS()
+external dynamic _setProperty(jsObj, String key, value);
+
+typedef dynamic _GetPropertyFn(jsObj, String key);
+typedef dynamic _SetPropertyFn(jsObj, String key, value);
+
+// Necessary because `external operator[]` isn't allowed on JS interop classes https://github.com/dart-lang/sdk/issues/25053
+final _GetPropertyFn getProperty = (() {
+  _eval(r'''
+    function _getProperty(obj, key) {
+      return obj[key];
+    }
+  ''');
+
+  return _getProperty;
+})();
+
+// Necessary because `external operator[]=` isn't allowed on JS interop classes https://github.com/dart-lang/sdk/issues/25053
+final _SetPropertyFn setProperty = (() {
+  _eval(r'''
+    function _setProperty(obj, key, value) {
+      return obj[key] = value;
+    }
+  ''');
+
+  return _setProperty;
+})();
+
+
+@JS()
+@anonymous
+class EmptyObject {
+  external factory EmptyObject();
+}
+
+EmptyObject jsify(Map map) {
+  var jsMap = new EmptyObject();
+
+  map.forEach((key, value) {
+    if (value is Map) {
+      value = jsify(value);
+    } else if (value is Function) {
+      value = allowInterop(value);
+    }
+
+    setProperty(jsMap, key, value);
+  });
+
+  return jsMap;
+}

--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -1,3 +1,5 @@
+/// Utilities for reading/modifying dynamic keys on JavaScript objects
+/// and converting Dart [Map]s to JavaScript objects.
 library react_client.js_interop_helpers;
 
 import "package:js/js.dart";
@@ -14,7 +16,11 @@ external dynamic _setProperty(jsObj, String key, value);
 typedef dynamic _GetPropertyFn(jsObj, String key);
 typedef dynamic _SetPropertyFn(jsObj, String key, value);
 
-// Necessary because `external operator[]` isn't allowed on JS interop classes https://github.com/dart-lang/sdk/issues/25053
+/// Returns the property at the given [_GetPropertyFn.key] on the
+/// specified JavaScript object [_GetPropertyFn.jsObj]
+///
+/// Necessary because `external operator[]` isn't allowed on JS interop classes
+/// (see: https://github.com/dart-lang/sdk/issues/25053).
 final _GetPropertyFn getProperty = (() {
   _eval(r'''
     function _getProperty(obj, key) {
@@ -25,7 +31,11 @@ final _GetPropertyFn getProperty = (() {
   return _getProperty;
 })();
 
-// Necessary because `external operator[]=` isn't allowed on JS interop classes https://github.com/dart-lang/sdk/issues/25053
+/// Sets the property at the given [_SetPropertyFn.key] to [_SetPropertyFn.value]
+/// on the specified JavaScript object [_SetPropertyFn.jsObj]
+///
+/// Necessary because `external operator[]=` isn't allowed on JS interop classes
+/// (see: https://github.com/dart-lang/sdk/issues/25053).
 final _SetPropertyFn setProperty = (() {
   _eval(r'''
     function _setProperty(obj, key, value) {
@@ -37,12 +47,19 @@ final _SetPropertyFn setProperty = (() {
 })();
 
 
+/// A interop class for an anonymous JavaScript object, with no properties.
+///
+/// For use when dealing with dynamic properties via [getProperty]/[setProperty].
 @JS()
 @anonymous
 class EmptyObject {
   external factory EmptyObject();
 }
 
+/// Returns [map] converted to a JavaScript object, similar to
+/// `new JsObject.jsify` in `dart:js`.
+///
+/// Recursively converts nested [Map]s, and wraps [Function]s with [allowInterop].
 EmptyObject jsify(Map map) {
   var jsMap = new EmptyObject();
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -98,9 +98,9 @@ class ReactElement<TComponent extends Component> {
 
   /// The type of this element.
   ///
-  /// For DOM components, this will a [String] tagName (e.g., `'div'`, `'a'`).
+  /// For DOM components, this will be a [String] tagName (e.g., `'div'`, `'a'`).
   ///
-  /// For composite components (react-dart or pur JS), this will be a [ReactClass].
+  /// For composite components (react-dart or pure JS), this will be a [ReactClass].
   external dynamic get type;
 
   /// The props this element was created with.
@@ -142,9 +142,9 @@ class ReactComponent {
 
 /// A JavaScript interop class representing a React JS `props` object.
 ///
-/// Used for storing/accessing [ReactDartComponentInternal] objects for in
+/// Used for storing/accessing [ReactDartComponentInternal] objects in
 /// react-dart [ReactElement]s and [ReactComponent]s, as well as for preparing
-/// reserved props (`key` and `ref`)for consumption by ReactJS.
+/// reserved props (`key` and `ref`) for consumption by ReactJS.
 ///
 /// __For internal/advanced use only.__
 @JS()
@@ -175,12 +175,12 @@ class ReactDartComponentInternal {
 
   /// For a `ReactElement`, this is the initial props with defaults merged.
   ///
-  /// For a `ReactComponent`, this is props the component was last rendered with,
-  /// and is used to within props-related lifecycle internals.
+  /// For a `ReactComponent`, this is the props the component was last rendered with,
+  /// and is used within props-related lifecycle internals.
   Map props;
 }
 
-/// Mark each child in children as validated so that React doesn't emit key warnings.
+/// Mark each child in [children] as validated so that React doesn't emit key warnings.
 ///
 /// ___Only for use with variadic children.___
 ///

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -39,13 +39,25 @@ abstract class ReactDomServer {
 //   Types and data structures
 // ----------------------------------------------------------------------------
 
+/// A React class specification returned by [React.createClass].
+///
+/// To be used as the value of [ReactElement.type], which is set upon initialization
+/// by a component factory or by [React.createElement].
+///
+/// See: <http://facebook.github.io/react/docs/top-level-api.html#react.createclass>
 @JS()
 @anonymous
 class ReactClass {
+  /// The `displayName` string is used in debugging messages.
+  ///
+  /// See: <http://facebook.github.io/react/docs/component-specs.html#displayname>
   external String get displayName;
   external set displayName(String value);
 }
 
+/// A JS interop class used as an argument to [React.createClass].
+///
+/// See: <http://facebook.github.io/react/docs/top-level-api.html#react.createclass>.
 @JS()
 @anonymous
 class ReactClassConfig {
@@ -74,18 +86,43 @@ class ReactElementStore {
   external set validated(bool value);
 }
 
-
+/// A virtual instance of a React component that is returned by component
+/// factories and `Component.render` methods, and passed into [react.render].
+///
+/// See <http://facebook.github.io/react/docs/glossary.html#react-elements>
+/// and <http://facebook.github.io/react/docs/glossary.html#react-components>.
 @JS()
 @anonymous
 class ReactElement<TComponent extends Component> {
   external ReactElementStore get _store;
 
+  /// The type of this element.
+  ///
+  /// For DOM components, this will a [String] tagName (e.g., `'div'`, `'a'`).
+  ///
+  /// For composite components (react-dart or pur JS), this will be a [ReactClass].
   external dynamic get type;
+
+  /// The props this element was created with.
   external InteropProps get props;
+
+  /// This element's `key`, which is used to uniquely identify it among its siblings.
+  ///
+  /// Not needed when children are passed variadically.
+  ///
+  /// See: <http://facebook.github.io/react/docs/reconciliation.html#keys>.
   external String get key;
+
+  /// This element's `ref`, which can be used to access the associated
+  /// [Component]/[ReactComponent]/[Element] after it has been rendered.
+  ///
+  /// See: <http://facebook.github.io/react/docs/more-about-refs.html>.
   external dynamic get ref;
 }
 
+/// The JavaScript component instance, which backs each react-dart [Component].
+///
+/// See: <http://facebook.github.io/react/docs/glossary.html#react-components>
 @JS()
 @anonymous
 class ReactComponent {
@@ -103,6 +140,13 @@ class ReactComponent {
 //   Interop internals
 // ----------------------------------------------------------------------------
 
+/// A JavaScript interop class representing a React JS `props` object.
+///
+/// Used for storing/accessing [ReactDartComponentInternal] objects for in
+/// react-dart [ReactElement]s and [ReactComponent]s, as well as for preparing
+/// reserved props (`key` and `ref`)for consumption by ReactJS.
+///
+/// __For internal/advanced use only.__
 @JS()
 @anonymous
 class InteropProps {
@@ -116,9 +160,23 @@ class InteropProps {
   external factory InteropProps({ReactDartComponentInternal internal, String key, dynamic ref});
 }
 
+/// Internal react-dart information used to proxy React JS lifecycle to Dart
+/// [Component] instances.
+///
+/// __For internal/advanced use only.__
 class ReactDartComponentInternal {
+  /// The Dart component instance associated with this JS [ReactComponent].
+  ///
+  /// Null until the [ReactComponent]'s instantiation.
   Component component;
+
+  /// Whether the component is mounted.
   bool isMounted;
+
+  /// For a `ReactElement`, this is the initial props with defaults merged.
+  ///
+  /// For a `ReactComponent`, this is props the component was last rendered with,
+  /// and is used to within props-related lifecycle internals.
   Map props;
 }
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -1,0 +1,138 @@
+/// JS interop classes for main React JS APIs and react-dart internals.
+///
+/// For use in `react_client.dart` and by advanced react-dart users.
+library react_client.react_interop;
+
+import 'dart:html';
+
+import 'package:js/js.dart';
+import 'package:react/react.dart' show Component;
+
+// ----------------------------------------------------------------------------
+//   Top-level API
+// ----------------------------------------------------------------------------
+
+@JS()
+abstract class React {
+  external static ReactClass createClass(ReactClassConfig reactClassConfig);
+  external static Function createFactory(type);
+
+  external static ReactElement createElement(dynamic type, props, [dynamic children]);
+
+  external static bool isValidElement(dynamic object);
+}
+
+@JS('ReactDOM')
+abstract class ReactDom {
+  external static Element findDOMNode(object);
+  external static ReactComponent render(ReactElement component, Element element);
+  external static bool unmountComponentAtNode(Element element);
+}
+
+@JS('ReactDOMServer')
+abstract class ReactDomServer {
+  external static String renderToString(ReactElement component);
+  external static String renderToStaticMarkup(ReactElement component);
+}
+
+// ----------------------------------------------------------------------------
+//   Types and data structures
+// ----------------------------------------------------------------------------
+
+@JS()
+@anonymous
+class ReactClass {
+  external String get displayName;
+  external set displayName(String value);
+}
+
+@JS()
+@anonymous
+class ReactClassConfig {
+  external factory ReactClassConfig({
+    String displayName,
+    Function componentWillMount,
+    Function componentDidMount,
+    Function componentWillReceiveProps,
+    Function shouldComponentUpdate,
+    Function componentWillUpdate,
+    Function componentDidUpdate,
+    Function componentWillUnmount,
+    Function getDefaultProps,
+    Function getInitialState,
+    Function render
+  });
+}
+
+/// Interop class for the data structure at `ReactElement._store`.
+///
+/// Used to validate variadic children before they get to [React.createElement].
+@JS()
+@anonymous
+class ReactElementStore {
+  external bool get validated;
+  external set validated(bool value);
+}
+
+
+@JS()
+@anonymous
+class ReactElement<TComponent extends Component> {
+  external ReactElementStore get _store;
+
+  external dynamic get type;
+  external InteropProps get props;
+  external String get key;
+  external dynamic get ref;
+}
+
+@JS()
+@anonymous
+class ReactComponent {
+  external InteropProps get props;
+  external get refs;
+  external void setState(state, [callback]);
+  external void forceUpdate([callback]);
+  @deprecated
+  external setProps(props, [callback]);
+
+  external bool isMounted();
+}
+
+// ----------------------------------------------------------------------------
+//   Interop internals
+// ----------------------------------------------------------------------------
+
+@JS()
+@anonymous
+class InteropProps {
+  external ReactDartComponentInternal get internal;
+  external String get key;
+  external dynamic get ref;
+
+  external set key(String value);
+  external set ref(dynamic value);
+
+  external factory InteropProps({ReactDartComponentInternal internal, String key, dynamic ref});
+}
+
+class ReactDartComponentInternal {
+  Component component;
+  bool isMounted;
+  Map props;
+}
+
+/// Mark each child in children as validated so that React doesn't emit key warnings.
+///
+/// ___Only for use with variadic children.___
+///
+/// Needs to be in the same library as [ReactElement] since `ReactElement._store`
+/// is private due to package:js restrictions.
+void markChildrenValidated(List<dynamic> children) {
+  children.forEach((dynamic child) {
+    // Use `isValidElement` since `is ReactElement` doesn't behave as expected.
+    if (React.isValidElement(child)) {
+      (child as ReactElement)._store?.validated = true;
+    }
+  });
+}

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -107,10 +107,10 @@ class ReactComponent {
 @anonymous
 class InteropProps {
   external ReactDartComponentInternal get internal;
-  external String get key;
+  external dynamic get key;
   external dynamic get ref;
 
-  external set key(String value);
+  external set key(dynamic value);
   external set ref(dynamic value);
 
   external factory InteropProps({ReactDartComponentInternal internal, String key, dynamic ref});

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -6,7 +6,7 @@ library react_client.react_interop;
 import 'dart:html';
 
 import 'package:js/js.dart';
-import 'package:react/react.dart' show Component;
+import 'package:react/react.dart';
 
 // ----------------------------------------------------------------------------
 //   Top-level API
@@ -53,6 +53,14 @@ class ReactClass {
   /// See: <http://facebook.github.io/react/docs/component-specs.html#displayname>
   external String get displayName;
   external set displayName(String value);
+
+  /// The cached, unmodifiable copy of [Component.getDefaultProps] computed in
+  /// [registerComponent].
+  ///
+  /// For use in [ReactDartComponentFactoryProxy] when creating new [ReactElement]s,
+  /// or for external use involving inspection of Dart prop defaults.
+  external Map get dartDefaultProps;
+  external set dartDefaultProps(Map value);
 }
 
 /// A JS interop class used as an argument to [React.createClass].

--- a/lib/react_client/synthetic_event_interop.dart
+++ b/lib/react_client/synthetic_event_interop.dart
@@ -1,0 +1,115 @@
+/// JS interop classes for React synthetic events.
+///
+/// For use in `react_client.dart` and by advanced react-dart users.
+library react_client.synthetic_event;
+
+import 'dart:html';
+import 'package:js/js.dart';
+
+@JS()
+@anonymous
+class SyntheticEvent {
+  external bool get bubbles;
+  external bool get cancelable;
+  external get currentTarget;
+  external bool get defaultPrevented;
+  external num get eventPhase;
+  external bool get isTrusted;
+  external get nativeEvent;
+  external get target;
+  external num get timeStamp;
+  external String get type;
+
+  external void stopPropagation();
+  external void preventDefault();
+
+  external void persist();
+}
+
+@JS()
+@anonymous
+class SyntheticClipboardEvent extends SyntheticEvent {
+  external get clipboardData;
+}
+
+@JS()
+@anonymous
+class SyntheticKeyboardEvent extends SyntheticEvent {
+  external bool get altKey;
+  external String get char;
+  external bool get ctrlKey;
+  external String get locale;
+  external num get location;
+  external String get key;
+  external bool get metaKey;
+  external bool get repeat;
+  external bool get shiftKey;
+  external num get keyCode;
+  external num get charCode;
+}
+
+@JS()
+@anonymous
+class SyntheticFocusEvent extends SyntheticEvent {
+  external EventTarget get relatedTarget;
+}
+
+@JS()
+@anonymous
+class SyntheticFormEvent extends SyntheticEvent {}
+
+@JS()
+@anonymous
+class SyntheticDataTransfer {
+  external String get dropEffect;
+  external String get effectAllowed;
+  external List<File> get files;
+  external List<String> get types;
+}
+
+@JS()
+@anonymous
+class SyntheticMouseEvent extends SyntheticEvent {
+  external bool get altKey;
+  external num get button;
+  external num get buttons;
+  external num get clientX;
+  external num get clientY;
+  external bool get ctrlKey;
+  external SyntheticDataTransfer get dataTransfer;
+  external bool get metaKey;
+  external num get pageX;
+  external num get pageY;
+  external EventTarget get relatedTarget;
+  external num get screenX;
+  external num get screenY;
+  external bool get shiftKey;
+}
+
+@JS()
+@anonymous
+class SyntheticTouchEvent extends SyntheticEvent {
+  external bool get altKey;
+  external TouchList get changedTouches;
+  external bool get ctrlKey;
+  external bool get metaKey;
+  external bool get shiftKey;
+  external TouchList get targetTouches;
+  external TouchList get touches;
+}
+
+@JS()
+@anonymous
+class SyntheticUIEvent extends SyntheticEvent {
+  external num get detail;
+  external get view;
+}
+
+@JS()
+@anonymous
+class SyntheticWheelEvent extends SyntheticEvent {
+  external num get deltaX;
+  external num get deltaMode;
+  external num get deltaY;
+  external num get deltaZ;
+}

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -27,12 +27,15 @@ typedef Component ComponentFactory();
 /// Creates a method that creates a new [Component], runs lifecycle methods and returns the result of the
 /// [componentFactory] instance `render` method.
 ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Iterable<String> skipMethods = const []]) {
+  /// Cached default props.
+  final Map defaultProps = componentFactory().getDefaultProps();
+
   return (Map props, [dynamic children]) {
     Component component = componentFactory();
 
     // Get default props, add children to props and apply props from arguments
     props['children'] = children;
-    component.initComponentInternal(props, () {});
+    component.initComponentInternal(props, defaultProps, () {});
 
     // Get initial state
     component.initStateInternal();

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -34,8 +34,10 @@ ReactComponentFactory _registerComponent(ComponentFactory componentFactory, [Ite
     Component component = componentFactory();
 
     // Get default props, add children to props and apply props from arguments
-    props['children'] = children;
-    component.initComponentInternal(props, defaultProps, () {});
+    var extendedProps = new Map.from(defaultProps)
+      ..addAll(props)
+      ..['children'] = children;
+    component.initComponentInternal(extendedProps, () {});
 
     // Get initial state
     component.initStateInternal();

--- a/lib/react_test.dart
+++ b/lib/react_test.dart
@@ -31,7 +31,9 @@ _reactDom(String name) {
 
 initializeComponent(Component component, [Map props = const {}, List children, redraw, ref, getDOMNode]) {
   if (redraw == null) redraw = () {};
-  component.initComponentInternal(props, component.getDefaultProps(), redraw, ref, getDOMNode);
+  var extendedProps = new Map.from(component.getDefaultProps())
+    ..addAll(props);
+  component.initComponentInternal(extendedProps, redraw, ref, getDOMNode);
   component.initStateInternal();
   component.componentWillMount();
 }

--- a/lib/react_test.dart
+++ b/lib/react_test.dart
@@ -31,7 +31,7 @@ _reactDom(String name) {
 
 initializeComponent(Component component, [Map props = const {}, List children, redraw, ref, getDOMNode]) {
   if (redraw == null) redraw = () {};
-  component.initComponentInternal(props, redraw, ref, getDOMNode);
+  component.initComponentInternal(props, component.getDefaultProps(), redraw, ref, getDOMNode);
   component.initStateInternal();
   component.componentWillMount();
 }

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -4,59 +4,30 @@
 
 library react.test_utils;
 
-import 'dart:js';
 import 'dart:html';
+
+import 'package:js/js.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:react/src/react_test_utils/simulate_wrappers.dart' as simulate_wrappers;
 
+// Notes
+// ---------------------------------------------------------------------------
+//
+// 1.  This is of type `dynamic` out of necessity, since the actual type,
+//     `ReactComponent | Element`, cannot be expressed in Dart's type system.
+//
+//     React 0.14 augments DOM nodes with its own properties and uses them as
+//     DOM component instances. To Dart's JS interop, those instances look
+//     like DOM nodes, so they get converted to the corresponding DOM node
+//     interceptors, and thus cannot be used with a custom `@JS()` class.
+//
+//     So, React composite component instances will be of type
+//     `ReactComponent`, whereas DOM component instance will be of type
+//     `Element`.
 
-const missingAddonsMessage =
-    '''
-    React.addons.TestUtils not found. Ensure you've
-    included the React addons in your HTML file.
-
-    This:
-    <script src="packages/react/react-with-addons.js"></script>
-
-    Not this:
-    <script src="packages/react/react.js"></script>
-    ''';
-
-JsObject _TestUtils = _getNestedJsObject(context, ['React', 'addons', 'TestUtils'], missingAddonsMessage);
-
-JsObject _Simulate = _TestUtils['Simulate'];
-
-JsObject _SimulateNative = _TestUtils['SimulateNative'];
-
-_getNestedJsObject(JsObject base, List<String> keys, [String errorIfNotFound='']) {
-  JsObject object = base;
-
-  for (String key in keys) {
-    if (!object.hasProperty(key)) {
-      throw 'Unable to resolve $key in {$base.${keys.join('.')}}.\n$errorIfNotFound';
-    }
-    object = object[key];
-  }
-
-  return object;
-}
-
-/// Returns [component] if it is already a [JsObject], and converts [component] if
-/// it is an [Element]. If [component] is neither a [JsObject] or an [Element], throws an
-/// [ArgumentError].
-///
-/// React does not use the same type of object for primitive components as composite components,
-/// and Dart converts the React objects used for primitive components to [Element]s automatically.
-/// This is problematic in some cases - primarily the test utility methods that return [JsObject]s,
-/// and render, which also needs to return a [JsObject]. This method can be used for handling this
-/// by converting the [Element] back to a [JsObject].
-JsObject normalizeReactComponent(dynamic component) {
-  if (component is JsObject) return component;
-  if (component is Element) return new JsObject.fromBrowserObject(component);
-  if (component == null) return null;
-
-  throw new ArgumentError('$component component is not a valid ReactComponent');
-}
 
 /// Returns the 'type' of a component.
 ///
@@ -64,123 +35,56 @@ JsObject normalizeReactComponent(dynamic component) {
 /// For React.createClass()-based components, this with return the React class as a JsFunction.
 dynamic getComponentType(ReactComponentFactory componentFactory) {
   if (componentFactory is ReactComponentFactoryProxy) {
-    return (componentFactory as ReactComponentFactoryProxy).type;
+    return componentFactory.type;
   }
   return null;
 }
 
-typedef bool ComponentTestFunction(JsObject componentInstance);
+typedef bool ComponentTestFunction(/* [1] */ component);
 
 /// Event simulation interface.
 ///
 /// Provides methods for each type of event that can be handled by a React
 /// component.  All methods are used in the same way:
 ///
-///   Simulate.{eventName}(dynamic instanceOrNode, [Map] eventData)
+///   Simulate.{eventName}(ReactComponent|Element componentOrNode, [Map] eventData)
 ///
 /// This should include all events documented at:
 /// http://facebook.github.io/react/docs/events.html
 class Simulate {
-
-  static void blur(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('blur', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void change(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('change', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void click(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('click', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void contextMenu(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('contextMenu', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void copy(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('copy', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void cut(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('cut', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void doubleClick(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('doubleClick', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void drag(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('drag', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragEnter(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragEnter', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragExit(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragExit', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragLeave(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragLeave', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragOver', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('dragStart', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void drop(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('drop', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void focus(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('focus', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void input(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('input', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void keyDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyDown', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void keyPress(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyPress', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void keyUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('keyUp', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseDown', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseMove', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseOut(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseOut', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseOver', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('mouseUp', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void paste(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('paste', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void scroll(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('scroll', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void submit(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('submit', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchCancel(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchCancel', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchMove', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('touchStart', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void wheel(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _Simulate.callMethod('wheel', [instanceOrNode, new JsObject.jsify(eventData)]);
-
+  static void blur(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.blur(componentOrNode, jsify(eventData));
+  static void change(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.change(componentOrNode, jsify(eventData));
+  static void click(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.click(componentOrNode, jsify(eventData));
+  static void contextMenu(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.contextMenu(componentOrNode, jsify(eventData));
+  static void copy(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.copy(componentOrNode, jsify(eventData));
+  static void cut(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.cut(componentOrNode, jsify(eventData));
+  static void doubleClick(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.doubleClick(componentOrNode, jsify(eventData));
+  static void drag(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.drag(componentOrNode, jsify(eventData));
+  static void dragEnd(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragEnd(componentOrNode, jsify(eventData));
+  static void dragEnter(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragEnter(componentOrNode, jsify(eventData));
+  static void dragExit(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragExit(componentOrNode, jsify(eventData));
+  static void dragLeave(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragLeave(componentOrNode, jsify(eventData));
+  static void dragOver(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragOver(componentOrNode, jsify(eventData));
+  static void dragStart(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.dragStart(componentOrNode, jsify(eventData));
+  static void drop(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.drop(componentOrNode, jsify(eventData));
+  static void focus(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.focus(componentOrNode, jsify(eventData));
+  static void input(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.input(componentOrNode, jsify(eventData));
+  static void keyDown(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.keyDown(componentOrNode, jsify(eventData));
+  static void keyPress(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.keyPress(componentOrNode, jsify(eventData));
+  static void keyUp(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.keyUp(componentOrNode, jsify(eventData));
+  static void mouseDown(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.mouseDown(componentOrNode, jsify(eventData));
+  static void mouseMove(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.mouseMove(componentOrNode, jsify(eventData));
+  static void mouseOut(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.mouseOut(componentOrNode, jsify(eventData));
+  static void mouseOver(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.mouseOver(componentOrNode, jsify(eventData));
+  static void mouseUp(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.mouseUp(componentOrNode, jsify(eventData));
+  static void paste(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.paste(componentOrNode, jsify(eventData));
+  static void scroll(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.scroll(componentOrNode, jsify(eventData));
+  static void submit(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.submit(componentOrNode, jsify(eventData));
+  static void touchCancel(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.touchCancel(componentOrNode, jsify(eventData));
+  static void touchEnd(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.touchEnd(componentOrNode, jsify(eventData));
+  static void touchMove(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.touchMove(componentOrNode, jsify(eventData));
+  static void touchStart(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.touchStart(componentOrNode, jsify(eventData));
+  static void wheel(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.Simulate.wheel(componentOrNode, jsify(eventData));
 }
 
 /// Native event simulation interface.
@@ -190,103 +94,39 @@ class Simulate {
 /// Provides methods for each type of event that can be handled by a React
 /// component.  All methods are used in the same way:
 ///
-///   SimulateNative.{eventName}(dynamic instanceOrNode, [Map] eventData)
-
+///   SimulateNative.{eventName}(/* [1] */ componentOrNode, [Map] eventData)
 class SimulateNative {
-
-  static void blur(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('blur', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void click(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('click', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void contextMenu(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('contextMenu', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void copy(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('copy', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void cut(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('cut', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void doubleClick(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('doubleClick', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void drag(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('drag', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragEnter(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragEnter', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragExit(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragExit', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragLeave(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragLeave', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragOver', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void dragStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('dragStart', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void drop(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('drop', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void focus(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('focus', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void input(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('input', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void keyDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('keyDown', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void keyUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('keyUp', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseDown(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseDown', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseMove', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseOut(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseOut', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseOver(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseOver', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void mouseUp(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('mouseUp', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void paste(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('paste', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void scroll(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('scroll', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void submit(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('submit', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchCancel(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchCancel', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchEnd(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchEnd', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchMove(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchMove', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void touchStart(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('touchStart', [instanceOrNode, new JsObject.jsify(eventData)]);
-
-  static void wheel(dynamic instanceOrNode, [Map eventData = const{}]) =>
-      _SimulateNative.callMethod('wheel', [instanceOrNode, new JsObject.jsify(eventData)]);
-
+  static void blur(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.blur(componentOrNode, jsify(eventData));
+  static void click(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.click(componentOrNode, jsify(eventData));
+  static void contextMenu(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.contextMenu(componentOrNode, jsify(eventData));
+  static void copy(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.copy(componentOrNode, jsify(eventData));
+  static void cut(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.cut(componentOrNode, jsify(eventData));
+  static void doubleClick(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.doubleClick(componentOrNode, jsify(eventData));
+  static void drag(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.drag(componentOrNode, jsify(eventData));
+  static void dragEnd(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragEnd(componentOrNode, jsify(eventData));
+  static void dragEnter(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragEnter(componentOrNode, jsify(eventData));
+  static void dragExit(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragExit(componentOrNode, jsify(eventData));
+  static void dragLeave(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragLeave(componentOrNode, jsify(eventData));
+  static void dragOver(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragOver(componentOrNode, jsify(eventData));
+  static void dragStart(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.dragStart(componentOrNode, jsify(eventData));
+  static void drop(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.drop(componentOrNode, jsify(eventData));
+  static void focus(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.focus(componentOrNode, jsify(eventData));
+  static void input(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.input(componentOrNode, jsify(eventData));
+  static void keyDown(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.keyDown(componentOrNode, jsify(eventData));
+  static void keyUp(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.keyUp(componentOrNode, jsify(eventData));
+  static void mouseDown(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.mouseDown(componentOrNode, jsify(eventData));
+  static void mouseMove(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.mouseMove(componentOrNode, jsify(eventData));
+  static void mouseOut(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.mouseOut(componentOrNode, jsify(eventData));
+  static void mouseOver(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.mouseOver(componentOrNode, jsify(eventData));
+  static void mouseUp(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.mouseUp(componentOrNode, jsify(eventData));
+  static void paste(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.paste(componentOrNode, jsify(eventData));
+  static void scroll(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.scroll(componentOrNode, jsify(eventData));
+  static void submit(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.submit(componentOrNode, jsify(eventData));
+  static void touchCancel(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.touchCancel(componentOrNode, jsify(eventData));
+  static void touchEnd(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.touchEnd(componentOrNode, jsify(eventData));
+  static void touchMove(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.touchMove(componentOrNode, jsify(eventData));
+  static void touchStart(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.touchStart(componentOrNode, jsify(eventData));
+  static void wheel(/* [1] */ componentOrNode, [Map eventData = const {}]) => simulate_wrappers.SimulateNative.wheel(componentOrNode, jsify(eventData));
 }
 
 /// Traverse all components in tree and accumulate all components where
@@ -294,129 +134,108 @@ class SimulateNative {
 /// used as a primitive for other test utils
 ///
 /// Included in Dart for completeness
-List findAllInRenderedTree(JsObject tree, JsFunction test) {
-  var components = _TestUtils.callMethod('findAllInRenderedTree', [tree, test]);
-
-  components.map(normalizeReactComponent).toList();
-
-  return components;
-}
+@JS('React.addons.TestUtils.findAllInRenderedTree')
+external List<dynamic> findAllInRenderedTree(/* [1] */ tree, ComponentTestFunction test);
 
 /// Like scryRenderedDOMComponentsWithClass() but expects there to be one
 /// result, and returns that one result, or throws exception if there is
 /// any other number of matches besides one.
-JsObject findRenderedDOMComponentWithClass(JsObject tree, String className) {
-  var component = _TestUtils.callMethod(
-      'findRenderedDOMComponentWithClass', [tree, className]);
-
-  return normalizeReactComponent(component);
-}
+@JS('React.addons.TestUtils.findRenderedDOMComponentWithClass')
+external dynamic /* [1] */ findRenderedDOMComponentWithClass(/* [1] */ tree, String className);
 
 /// Like scryRenderedDOMComponentsWithTag() but expects there to be one result,
 /// and returns that one result, or throws exception if there is any other
 /// number of matches besides one.
-JsObject findRenderedDOMComponentWithTag(JsObject tree, String tag) {
-  var component = _TestUtils.callMethod(
-      'findRenderedDOMComponentWithTag', [tree, tag]);
+@JS('React.addons.TestUtils.findRenderedDOMComponentWithTag')
+external dynamic /* [1] */ findRenderedDOMComponentWithTag(/* [1] */ tree, String tag);
 
-  return normalizeReactComponent(component);
-}
+
+@JS('React.addons.TestUtils.findRenderedComponentWithType')
+external dynamic /* [1] */ _findRenderedComponentWithType(/* [1] */ tree, dynamic type);
 
 /// Same as scryRenderedComponentsWithType() but expects there to be one result
 /// and returns that one result, or throws exception if there is any other
 /// number of matches besides one.
-JsObject findRenderedComponentWithType(
-    JsObject tree, ReactComponentFactory componentType) {
-  return _TestUtils.callMethod(
-      'findRenderedComponentWithType', [tree, getComponentType(componentType)]);
+/* [1] */ findRenderedComponentWithType(
+    /* [1] */ tree, ReactComponentFactory componentType) {
+  return _findRenderedComponentWithType(tree, getComponentType(componentType));
 }
+
+@JS('React.addons.TestUtils.isCompositeComponent')
+external bool _isCompositeComponent(/* [1] */ instance);
 
 /// Returns true if element is a composite component.
 /// (created with React.createClass()).
-bool isCompositeComponent(JsObject instance) {
-  return _TestUtils.callMethod('isCompositeComponent', [instance])
+bool isCompositeComponent(/* [1] */ instance) {
+  return _isCompositeComponent(instance)
          // Workaround for DOM components being detected as composite: https://github.com/facebook/react/pull/3839
-         && instance['tagName'] == null;
+         && getProperty(instance, 'tagName') == null;
 }
+
+@JS('React.addons.TestUtils.isCompositeComponentWithType')
+external bool _isCompositeComponentWithType(/* [1] */ instance, dynamic type);
 
 /// Returns true if instance is a composite component.
 /// (created with React.createClass()) whose type is of a React componentClass.
-bool isCompositeComponentWithType(
-    JsObject instance, ReactComponentFactory componentClass) {
-  return _TestUtils.callMethod(
-      'isCompositeComponentWithType', [instance, getComponentType(componentClass)]);
+bool isCompositeComponentWithType(/* [1] */ instance, ReactComponentFactory componentClass) {
+  return _isCompositeComponentWithType(instance, getComponentType(componentClass));
 }
 
 /// Returns true if instance is a DOM component (such as a <div> or <span>).
-bool isDOMComponent(JsObject instance) {
-  return _TestUtils.callMethod('isDOMComponent', [instance]);
-}
+@JS('React.addons.TestUtils.isDOMComponent')
+external bool isDOMComponent(/* [1] */ instance);
 
 /// Returns true if [object] is a valid React component.
-bool isElement(JsObject object) {
-  return _TestUtils.callMethod('isElement', [object]);
+@JS('React.addons.TestUtils.isElement')
+external bool isElement(dynamic object);
+
+@JS('React.addons.TestUtils.isElementOfType')
+external bool _isElementOfType(dynamic element, ReactComponentFactory componentClass);
+
+/// Returns true if [element] is a ReactElement whose type is of a
+/// React componentClass.
+bool isElementOfType(dynamic element, ReactComponentFactory componentClass) {
+  return _isElementOfType(element, getComponentType(componentClass));
 }
 
-/// Returns true if element is a ReactElement whose type is of a
-/// React componentClass.
-bool isElementOfType(JsObject element, ReactComponentFactory componentClass) {
-  return _TestUtils.callMethod(
-      'isElementOfType', [element, getComponentType(componentClass)]);
-}
+@JS('React.addons.TestUtils.scryRenderedComponentsWithType')
+external List<dynamic> /* [1] */ _scryRenderedComponentsWithType(/* [1] */ tree, dynamic type);
 
 /// Finds all instances of components with type equal to componentClass.
-JsObject scryRenderedComponentsWithType(
-    JsObject tree, ReactComponentFactory componentClass) {
-  return _TestUtils.callMethod(
-      'scryRenderedComponentsWithType', [tree, getComponentType(componentClass)]);
+List<dynamic> /* [1] */ scryRenderedComponentsWithType(/* [1] */ tree, ReactComponentFactory componentClass) {
+  return _scryRenderedComponentsWithType(tree, getComponentType(componentClass));
 }
 
+@JS('React.addons.TestUtils.scryRenderedDOMComponentsWithClass')
 /// Finds all instances of components in the rendered tree that are DOM
 /// components with the class name matching className.
-List scryRenderedDOMComponentsWithClass(JsObject tree, String className) {
-  var components = _TestUtils.callMethod(
-      'scryRenderedDOMComponentsWithClass', [tree, className]);
+external List<dynamic> scryRenderedDOMComponentsWithClass(/* [1] */ tree, String className);
 
-  components = components.map(normalizeReactComponent).toList();
-
-  return components;
-}
-
+@JS('React.addons.TestUtils.scryRenderedDOMComponentsWithTag')
 /// Finds all instances of components in the rendered tree that are DOM
 /// components with the tag name matching tagName.
-List scryRenderedDOMComponentsWithTag(JsObject tree, String tagName) {
-  var components = _TestUtils.callMethod(
-      'scryRenderedDOMComponentsWithTag', [tree, tagName]);
-
-  components = components.map(normalizeReactComponent).toList();
-
-  return components;
-}
+external List<dynamic> scryRenderedDOMComponentsWithTag(/* [1] */ tree, String tagName);
 
 /// Render a Component into a detached DOM node in the document.
-JsObject renderIntoDocument(JsObject instance) {
-  var component = _TestUtils.callMethod('renderIntoDocument', [instance]);
+@JS('React.addons.TestUtils.renderIntoDocument')
+external /* [1] */ renderIntoDocument(ReactElement instance);
 
-  return normalizeReactComponent(component);
-}
-
-Element getDomNode(JsObject object) => object.callMethod('getDOMNode', []);
+// Use [findDOMNode] instead.
+@deprecated
+Element getDomNode(dynamic object) => findDOMNode(object);
 
 /// Pass a mocked component module to this method to augment it with useful
 /// methods that allow it to be used as a dummy React component. Instead of
 /// rendering as usual, the component will become a simple <div> (or other tag
 /// if mockTagName is provided) containing any provided children.
-JsObject mockComponent(JsObject componentClass, String mockTagName) {
-  return _TestUtils.callMethod(
-      'mockComponent', [componentClass, mockTagName]);
-}
+@JS('React.addons.TestUtils.mockComponent')
+external ReactClass mockComponent(ReactClass componentClass, String mockTagName);
 
 /// Returns a ReactShallowRenderer instance
 ///
 /// More info on using shallow rendering: https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
-ReactShallowRenderer createRenderer() {
-  return new ReactShallowRenderer.jsObject(_TestUtils.callMethod('createRenderer', []));
-}
+@JS('React.addons.TestUtils.createRenderer')
+external ReactShallowRenderer createRenderer();
 
 /// ReactShallowRenderer wrapper
 ///
@@ -425,26 +244,16 @@ ReactShallowRenderer createRenderer() {
 /// ReactShallowRenderer shallowRenderer = createRenderer();
 /// shallowRenderer.render(div({'className': 'active'}));
 ///
-/// JsObject renderedOutput = shallowRenderer.getRenderOutput();
-/// expect(renderedOutput['props']['className'], 'active');
+/// ReactElement renderedOutput = shallowRenderer.getRenderOutput();
+/// Map props = getProps(renderedOutput);
+/// expect(props['className'], 'active');
 /// ```
 ///
 /// See react_with_addons.js#ReactShallowRenderer
+@JS()
 class ReactShallowRenderer {
-  final JsObject jsRenderer;
-
-  ReactShallowRenderer.jsObject(JsObject this.jsRenderer);
-
   /// Get the rendered output. [render] must be called first
-  JsObject getRenderOutput() => jsRenderer.callMethod('getRenderOutput', []);
-
-  render(JsObject element, [Map context]) {
-    JsObject c = context == null ? null : new JsObject.jsify(context);
-
-    jsRenderer.callMethod('render', [element, c]);
-  }
-
-  unmount() {
-    jsRenderer.callMethod('unmount', []);
-  }
+  external ReactElement getRenderOutput();
+  external void render(ReactElement element, [context]);
+  external void unmount();
 }

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -32,7 +32,7 @@ import 'package:react/src/react_test_utils/simulate_wrappers.dart' as simulate_w
 /// Returns the 'type' of a component.
 ///
 /// For a DOM components, this with return the String corresponding to its tagName ('div', 'a', etc.).
-/// For React.createClass()-based components, this with return the React class as a JsFunction.
+/// For React.createClass()-based components, this with return the [ReactClass].
 dynamic getComponentType(ReactComponentFactory componentFactory) {
   if (componentFactory is ReactComponentFactoryProxy) {
     return componentFactory.type;

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -220,7 +220,7 @@ external List<dynamic> scryRenderedDOMComponentsWithTag(/* [1] */ tree, String t
 @JS('React.addons.TestUtils.renderIntoDocument')
 external /* [1] */ renderIntoDocument(ReactElement instance);
 
-// Use [findDOMNode] instead.
+/// Use [findDOMNode] instead.
 @deprecated
 Element getDomNode(dynamic object) => findDOMNode(object);
 

--- a/lib/src/react_client/synthetic_event_wrappers.dart
+++ b/lib/src/react_client/synthetic_event_wrappers.dart
@@ -1,7 +1,7 @@
 /// JS interop classes for React synthetic events.
 ///
 /// For use in `react_client.dart` and by advanced react-dart users.
-library react_client.synthetic_event;
+library react_client.synthetic_event_wrappers;
 
 import 'dart:html';
 import 'package:js/js.dart';

--- a/lib/src/react_test_utils/simulate_wrappers.dart
+++ b/lib/src/react_test_utils/simulate_wrappers.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2016, the Clean project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library react.test_utils.simulate_wrappers;
+
+import 'package:js/js.dart';
+
+@JS('React.addons.TestUtils.Simulate')
+abstract class Simulate {
+  external static void blur(componentOrNode, [eventData]);
+  external static void change(componentOrNode, [eventData]);
+  external static void click(componentOrNode, [eventData]);
+  external static void contextMenu(componentOrNode, [eventData]);
+  external static void copy(componentOrNode, [eventData]);
+  external static void cut(componentOrNode, [eventData]);
+  external static void doubleClick(componentOrNode, [eventData]);
+  external static void drag(componentOrNode, [eventData]);
+  external static void dragEnd(componentOrNode, [eventData]);
+  external static void dragEnter(componentOrNode, [eventData]);
+  external static void dragExit(componentOrNode, [eventData]);
+  external static void dragLeave(componentOrNode, [eventData]);
+  external static void dragOver(componentOrNode, [eventData]);
+  external static void dragStart(componentOrNode, [eventData]);
+  external static void drop(componentOrNode, [eventData]);
+  external static void focus(componentOrNode, [eventData]);
+  external static void input(componentOrNode, [eventData]);
+  external static void keyDown(componentOrNode, [eventData]);
+  external static void keyPress(componentOrNode, [eventData]);
+  external static void keyUp(componentOrNode, [eventData]);
+  external static void mouseDown(componentOrNode, [eventData]);
+  external static void mouseMove(componentOrNode, [eventData]);
+  external static void mouseOut(componentOrNode, [eventData]);
+  external static void mouseOver(componentOrNode, [eventData]);
+  external static void mouseUp(componentOrNode, [eventData]);
+  external static void paste(componentOrNode, [eventData]);
+  external static void scroll(componentOrNode, [eventData]);
+  external static void submit(componentOrNode, [eventData]);
+  external static void touchCancel(componentOrNode, [eventData]);
+  external static void touchEnd(componentOrNode, [eventData]);
+  external static void touchMove(componentOrNode, [eventData]);
+  external static void touchStart(componentOrNode, [eventData]);
+  external static void wheel(componentOrNode, [eventData]);
+}
+
+@JS('React.addons.TestUtils.SimulateNative')
+abstract class SimulateNative {
+  external static void blur(componentOrNode, [eventData]);
+  external static void click(componentOrNode, [eventData]);
+  external static void contextMenu(componentOrNode, [eventData]);
+  external static void copy(componentOrNode, [eventData]);
+  external static void cut(componentOrNode, [eventData]);
+  external static void doubleClick(componentOrNode, [eventData]);
+  external static void drag(componentOrNode, [eventData]);
+  external static void dragEnd(componentOrNode, [eventData]);
+  external static void dragEnter(componentOrNode, [eventData]);
+  external static void dragExit(componentOrNode, [eventData]);
+  external static void dragLeave(componentOrNode, [eventData]);
+  external static void dragOver(componentOrNode, [eventData]);
+  external static void dragStart(componentOrNode, [eventData]);
+  external static void drop(componentOrNode, [eventData]);
+  external static void focus(componentOrNode, [eventData]);
+  external static void input(componentOrNode, [eventData]);
+  external static void keyDown(componentOrNode, [eventData]);
+  external static void keyUp(componentOrNode, [eventData]);
+  external static void mouseDown(componentOrNode, [eventData]);
+  external static void mouseMove(componentOrNode, [eventData]);
+  external static void mouseOut(componentOrNode, [eventData]);
+  external static void mouseOver(componentOrNode, [eventData]);
+  external static void mouseUp(componentOrNode, [eventData]);
+  external static void paste(componentOrNode, [eventData]);
+  external static void scroll(componentOrNode, [eventData]);
+  external static void submit(componentOrNode, [eventData]);
+  external static void touchCancel(componentOrNode, [eventData]);
+  external static void touchEnd(componentOrNode, [eventData]);
+  external static void touchMove(componentOrNode, [eventData]);
+  external static void touchStart(componentOrNode, [eventData]);
+  external static void wheel(componentOrNode, [eventData]);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=0.8.10+6 <2.0.0'
 dependencies:
   browser: '>=0.9.0 <0.11.0'
+  js: '^0.6.0'
   quiver: '>=0.18.2 <0.22.0'
 dev_dependencies:
   unittest: '>=0.11.0 <0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Clean Team <clean@vacuumlabs.com>
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: http://cleandart.github.io/react-dart/
 environment:
-  sdk: '>=0.8.10+6 <2.0.0'
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   browser: '>=0.9.0 <0.11.0'
   js: '^0.6.0'

--- a/test/child_key_warning_test.dart
+++ b/test/child_key_warning_test.dart
@@ -11,7 +11,7 @@ void main() {
   useHtmlConfiguration();
   setClientConfiguration();
 
-  void render(JsObject reactElement) {
+  void render(ReactElement reactElement) {
     react_test_utils.renderIntoDocument(reactElement);
   }
 

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1,0 +1,458 @@
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_dom.dart' as react_dom;
+import 'package:react/react_test_utils.dart' as react_test_utils;
+import 'package:unittest/html_config.dart';
+import 'package:unittest/unittest.dart';
+
+void main() {
+  useHtmlConfiguration();
+  setClientConfiguration();
+
+  ReactComponent render(ReactElement reactElement) {
+    return react_test_utils.renderIntoDocument(reactElement);
+  }
+
+  react.Component getDartComponent(ReactComponent dartComponent) {
+    return dartComponent.props.internal.component;
+  }
+
+  Map getDartComponentProps(ReactComponent dartComponent) {
+    return getDartComponent(dartComponent).props;
+  }
+
+  Map getDartElementProps(ReactElement dartElement) {
+    return dartElement.props.internal.props;
+  }
+
+  /// Returns a new [Map.unmodifiable] with all argument maps merged in.
+  Map unmodifiableMap([Map map1, Map map2, Map map3, Map map4]) {
+    var merged = {};
+    if (map1 != null) merged.addAll(map1);
+    if (map2 != null) merged.addAll(map2);
+    if (map3 != null) merged.addAll(map3);
+    if (map4 != null) merged.addAll(map4);
+    return new Map.unmodifiable(merged);
+  }
+
+  group('React component lifecycle:', () {
+    group('default props', () {
+      test('getDefaultProps() is only called once per component class and cached', () {
+        expect(_DefaultPropsCachingTest.getDefaultPropsCallCount, 0);
+
+        var DefaultPropsComponent = react.registerComponent(() => new _DefaultPropsCachingTest());
+        var components = [
+          render(DefaultPropsComponent({})),
+          render(DefaultPropsComponent({})),
+          render(DefaultPropsComponent({})),
+        ];
+
+        expect(components.map(getDartComponentProps), everyElement(containsPair('getDefaultPropsCallCount', 1)));
+        expect(_DefaultPropsCachingTest.getDefaultPropsCallCount, 1);
+      });
+
+      group('are merged into props when the ReactElement is created when', () {
+        test('the specified props are empty', () {
+          var props = getDartElementProps(DefaultPropsTest({}));
+          expect(props, containsPair('defaultProp', 'default'));
+        });
+
+        test('the default props are overridden', () {
+          var props = getDartElementProps(DefaultPropsTest({'defaultProp': 'overridden'}));
+          expect(props, containsPair('defaultProp', 'overridden'));
+        });
+
+        test('non-default props are added', () {
+          var props = getDartElementProps(DefaultPropsTest({'otherProp': 'other'}));
+          expect(props, containsPair('defaultProp', 'default'));
+          expect(props, containsPair('otherProp', 'other'));
+        });
+      });
+
+      group('are merged into props by the time the Dart Component is rendered when', () {
+        test('the specified props are empty', () {
+          var props = getDartComponentProps(render(DefaultPropsTest({})));
+          expect(props, containsPair('defaultProp', 'default'));
+        });
+
+        test('the default props are overridden', () {
+          var props = getDartComponentProps(render(DefaultPropsTest({'defaultProp': 'overridden'})));
+          expect(props, containsPair('defaultProp', 'overridden'));
+        });
+
+        test('non-default props are added', () {
+          var props = getDartComponentProps(render(DefaultPropsTest({'otherProp': 'other'})));
+          expect(props, containsPair('defaultProp', 'default'));
+          expect(props, containsPair('otherProp', 'other'));
+        });
+      });
+    });
+  });
+
+  group('React component lifecycle:', () {
+    const Map defaultProps = const {
+      'defaultProp': 'default'
+    };
+    const Map emptyChildrenProps = const {
+      'children': const []
+    };
+
+    Map matchCall(String memberName, {args: anything, props: anything, state: anything}) {
+      return {
+        'memberName': memberName,
+        'arguments': args,
+        'props': props,
+        'state': state,
+      };
+    }
+
+    test('recieves correct lifecycle calls on component mount', () {
+      _LifecycleTest component = getDartComponent(
+          render(LifecycleTest({}))
+      );
+
+      expect(component.lifecycleCalls, equals([
+        matchCall('getInitialState'),
+        matchCall('componentWillMount'),
+        matchCall('render'),
+        matchCall('componentDidMount'),
+      ]));
+    });
+
+    test('recieves correct lifecycle calls on component unmount order', () {
+      var mountNode = new DivElement();
+      var instance = react_dom.render(LifecycleTest({}), mountNode);
+      _LifecycleTest component = getDartComponent(instance);
+
+      component.lifecycleCalls.clear();
+
+      react_dom.unmountComponentAtNode(mountNode);
+
+      expect(component.lifecycleCalls, equals([
+        matchCall('componentWillUnmount'),
+      ]));
+    });
+
+    test('recieves updated props with correct lifecycle calls and defaults properly merged in', () {
+      const Map initialProps = const {
+        'initialProp': 'initial',
+        'children': const []
+      };
+      const Map newProps = const {
+        'newProp': 'new',
+        'children': const []
+      };
+
+      final Map initialPropsWithDefaults = unmodifiableMap({}
+        ..addAll(defaultProps)
+        ..addAll(initialProps)
+      );
+      final Map newPropsWithDefaults = unmodifiableMap({}
+        ..addAll(defaultProps)
+        ..addAll(newProps)
+      );
+
+      const Map expectedState = const {};
+
+      var mountNode = new DivElement();
+      var instance = react_dom.render(LifecycleTest(initialProps), mountNode);
+      _LifecycleTest component = getDartComponent(instance);
+
+      component.lifecycleCalls.clear();
+
+      react_dom.render(LifecycleTest(newProps), mountNode);
+
+      expect(component.lifecycleCalls, equals([
+        matchCall('componentWillReceiveProps', args: [newPropsWithDefaults],                    props: initialPropsWithDefaults),
+        matchCall('shouldComponentUpdate',     args: [newPropsWithDefaults, expectedState],     props: initialPropsWithDefaults),
+        matchCall('componentWillUpdate',       args: [newPropsWithDefaults, expectedState],     props: initialPropsWithDefaults),
+        matchCall('render',                                                                     props: newPropsWithDefaults),
+        matchCall('componentDidUpdate',        args: [initialPropsWithDefaults, expectedState], props: newPropsWithDefaults),
+      ]));
+    });
+
+    test('updates state with correct lifecycle calls', () {
+      const Map initialState = const {
+        'initialState': 'initial',
+      };
+      const Map newState = const {
+        'initialState': 'initial',
+        'newState': 'new',
+      };
+      const Map stateDelta = const {
+        'newState': 'new',
+      };
+
+      final Map initialProps = unmodifiableMap({
+        'getInitialState': (_) => initialState
+      });
+
+      final Map expectedProps = unmodifiableMap(
+          defaultProps,
+          initialProps,
+          emptyChildrenProps
+      );
+
+      _LifecycleTest component = getDartComponent(render(LifecycleTest(initialProps)));
+
+      component.lifecycleCalls.clear();
+
+      component.setState(stateDelta);
+
+      expect(component.lifecycleCalls, equals([
+        matchCall('shouldComponentUpdate', args: [expectedProps, newState],     state: initialState),
+        matchCall('componentWillUpdate',   args: [expectedProps, newState],     state: initialState),
+        matchCall('render',                                                     state: newState),
+        matchCall('componentDidUpdate',    args: [expectedProps, initialState], state: newState),
+      ]));
+    });
+
+    test('properly handles a call to setState within componentWillReceiveProps', () {
+      const Map initialState = const {
+        'initialState': 'initial',
+      };
+      const Map newState = const {
+        'initialState': 'initial',
+        'newState': 'new',
+      };
+      const Map stateDelta = const {
+        'newState': 'new',
+      };
+
+      final Map lifecycleTestProps = unmodifiableMap({
+        'getInitialState': (_) => initialState,
+        'componentWillReceiveProps': (_LifecycleTest component, Map props) {
+          component.setState(stateDelta);
+        },
+      });
+      final Map initialProps = unmodifiableMap(
+          {'initialProp': 'initial'}, lifecycleTestProps
+      );
+      final Map newProps = unmodifiableMap(
+          {'newProp': 'new'}, lifecycleTestProps
+      );
+
+      final Map initialPropsWithDefaults = unmodifiableMap(
+        defaultProps, initialProps, emptyChildrenProps
+      );
+      final Map newPropsWithDefaults = unmodifiableMap(
+        defaultProps, newProps, emptyChildrenProps
+      );
+
+      var mountNode = new DivElement();
+      var instance = react_dom.render(LifecycleTest(initialProps), mountNode);
+      _LifecycleTest component = getDartComponent(instance);
+
+      component.lifecycleCalls.clear();
+
+      react_dom.render(LifecycleTest(newProps), mountNode);
+
+      expect(component.lifecycleCalls, equals([
+        matchCall('componentWillReceiveProps', args: [newPropsWithDefaults],           props: initialPropsWithDefaults, state: initialState),
+        matchCall('shouldComponentUpdate',     args: [newPropsWithDefaults, newState], props: initialPropsWithDefaults, state: initialState),
+        matchCall('componentWillUpdate',       args: [newPropsWithDefaults, newState], props: initialPropsWithDefaults, state: initialState),
+        matchCall('render',                                                                    props: newPropsWithDefaults, state: newState),
+        matchCall('componentDidUpdate',        args: [initialPropsWithDefaults, initialState], props: newPropsWithDefaults, state: newState),
+      ]));
+    });
+
+    group('when shouldComponentUpdate returns false:', () {
+      test('recieves updated props with correct lifecycle calls and does not rerender', () {
+        final Map initialProps = unmodifiableMap({
+          'shouldComponentUpdate': (_, __, ___) => false,
+          'initialProp': 'initial',
+          'children': const []
+        });
+        const Map newProps = const {
+          'newProp': 'new',
+          'children': const []
+        };
+
+        final Map initialPropsWithDefaults = unmodifiableMap(
+            defaultProps, initialProps
+        );
+        final Map newPropsWithDefaults = unmodifiableMap(
+            defaultProps, newProps
+        );
+
+        const Map expectedState = const {};
+
+        var mountNode = new DivElement();
+        var instance = react_dom.render(LifecycleTest(initialProps), mountNode);
+        _LifecycleTest component = getDartComponent(instance);
+
+        component.lifecycleCalls.clear();
+
+        react_dom.render(LifecycleTest(newProps), mountNode);
+
+        expect(component.lifecycleCalls, equals([
+          matchCall('componentWillReceiveProps', args: [newPropsWithDefaults],                props: initialPropsWithDefaults),
+          matchCall('shouldComponentUpdate',     args: [newPropsWithDefaults, expectedState], props: initialPropsWithDefaults),
+        ]));
+        expect(component.props, equals(newPropsWithDefaults));
+      });
+
+      test('updates state with correct lifecycle calls and does not rerender', () {
+        const Map initialState = const {
+          'initialState': 'initial',
+        };
+        const Map newState = const {
+          'initialState': 'initial',
+          'newState': 'new',
+        };
+        const Map stateDelta = const {
+          'newState': 'new',
+        };
+
+        final Map initialProps = unmodifiableMap({
+          'getInitialState': (_) => initialState,
+          'shouldComponentUpdate': (_, __, ___) => false,
+        });
+
+        final Map expectedProps = unmodifiableMap(
+            defaultProps, initialProps, emptyChildrenProps
+        );
+
+        _LifecycleTest component = getDartComponent(render(LifecycleTest(initialProps)));
+        component.lifecycleCalls.clear();
+
+        component.setState(stateDelta);
+
+        expect(component.lifecycleCalls, equals([
+          matchCall('shouldComponentUpdate', args: [expectedProps, newState], state: initialState),
+        ]));
+        expect(component.state, equals(newState));
+      });
+
+      test('properly handles a call to setState within componentWillReceiveProps and does not rerender', () {
+        const Map initialState = const {
+          'initialState': 'initial',
+        };
+        const Map newState = const {
+          'initialState': 'initial',
+          'newState': 'new',
+        };
+        const Map stateDelta = const {
+          'newState': 'new',
+        };
+
+        final Map lifecycleTestProps = unmodifiableMap({
+          'shouldComponentUpdate': (_, __, ___) => false,
+          'getInitialState': (_) => initialState,
+          'componentWillReceiveProps': (_LifecycleTest component, Map props) {
+            component.setState(stateDelta);
+          },
+        });
+        final Map initialProps = unmodifiableMap(
+            {'initialProp': 'initial'}, lifecycleTestProps
+        );
+        final Map newProps = unmodifiableMap(
+            {'newProp': 'new'}, lifecycleTestProps
+        );
+
+        final Map initialPropsWithDefaults = unmodifiableMap(
+          defaultProps, initialProps, emptyChildrenProps
+        );
+        final Map newPropsWithDefaults = unmodifiableMap(
+          defaultProps, newProps, emptyChildrenProps
+        );
+
+        var mountNode = new DivElement();
+        var instance = react_dom.render(LifecycleTest(initialProps), mountNode);
+        _LifecycleTest component = getDartComponent(instance);
+
+        component.lifecycleCalls.clear();
+
+        react_dom.render(LifecycleTest(newProps), mountNode);
+
+        expect(component.lifecycleCalls, equals([
+          matchCall('componentWillReceiveProps', args: [newPropsWithDefaults],           props: initialPropsWithDefaults, state: initialState),
+          matchCall('shouldComponentUpdate',     args: [newPropsWithDefaults, newState], props: initialPropsWithDefaults, state: initialState),
+        ]));
+      });
+    });
+  });
+}
+
+class _DefaultPropsCachingTest extends react.Component {
+  static int getDefaultPropsCallCount = 0;
+
+  Map getDefaultProps() {
+    getDefaultPropsCallCount++;
+    return {
+      'getDefaultPropsCallCount': getDefaultPropsCallCount
+    };
+  }
+
+  render() => false;
+}
+
+ReactDartComponentFactoryProxy<_DefaultPropsTest> DefaultPropsTest = react.registerComponent(() => new _DefaultPropsTest());
+class _DefaultPropsTest extends react.Component {
+  static int getDefaultPropsCallCount = 0;
+
+  Map getDefaultProps() => {
+    'defaultProp': 'default'
+  };
+
+  render() => false;
+}
+
+ReactDartComponentFactoryProxy<_LifecycleTest> LifecycleTest = react.registerComponent(() => new _LifecycleTest());
+class _LifecycleTest extends react.Component {
+  List lifecycleCalls = [];
+
+  dynamic lifecycleCall(String memberName, {List arguments: const [], defaultReturnValue()}) {
+    lifecycleCalls.add({
+      'memberName': memberName,
+      'arguments': arguments,
+      'props': props == null ? null : new Map.from(props),
+      'state': state == null ? null : new Map.from(state),
+    });
+
+    var lifecycleCallback = props == null ? null : props[memberName];
+    if (lifecycleCallback != null) {
+      return Function.apply(lifecycleCallback, [this]..addAll(arguments));
+    }
+
+    if (defaultReturnValue != null) {
+      return defaultReturnValue();
+    }
+
+    return null;
+  }
+
+  void componentWillMount() => lifecycleCall('componentWillMount');
+  void componentDidMount() => lifecycleCall('componentDidMount');
+  void componentWillUnmount() => lifecycleCall('componentWillUnmount');
+
+  void componentWillReceiveProps(newProps) =>
+    lifecycleCall('componentWillReceiveProps', arguments: [new Map.from(newProps)]);
+
+  void componentWillUpdate(nextProps, nextState) =>
+    lifecycleCall('componentWillUpdate', arguments: [new Map.from(nextProps), new Map.from(nextState)]);
+
+  void componentDidUpdate(prevProps, prevState) =>
+    lifecycleCall('componentDidUpdate', arguments: [new Map.from(prevProps), new Map.from(prevState)]);
+
+  bool shouldComponentUpdate(nextProps, nextState) =>
+    lifecycleCall('shouldComponentUpdate', arguments: [new Map.from(nextProps), new Map.from(nextState)],
+        defaultReturnValue: () => true);
+
+  dynamic render() =>
+    lifecycleCall('render', defaultReturnValue: () => react.div({}));
+
+  Map getInitialState() =>
+    lifecycleCall('getInitialState', defaultReturnValue: () => {});
+
+  Map getDefaultProps() {
+    lifecycleCall('getDefaultProps');
+
+    return {
+      'defaultProp': 'default'
+    };
+  }
+}

--- a/test/lifecycle_test.html
+++ b/test/lifecycle_test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title></title>
+    <script src="packages/react/react_with_addons.js"></script>
+    <script src="packages/react/react_dom.js"></script>
+    <script type="application/dart" src="lifecycle_test.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
# Description
Dart 1.13 introduced the new [`js` package](https://pub.dartlang.org/packages/js), which provides an alternate Dart-JS interop that is faster than `dart:js` interop.

react-dart currently uses `dart:js` interop, and could benefit from performance improvements in `package:js`.

This PR upgrades react-dart to use `package:js`, and also includes other changes that improve performance and increase parity with React JS.

## Performance data:
Performance tests were run on an earlier version of these changes, as well as for the current react-dart and React JS.

Full results available [in this doc](https://docs.google.com/spreadsheets/d/1GB8QZZGlgFNw4gx6AuRA242Ardfei0sDAYRcHv_osLU/edit?usp=sharing
). Includes data for:
* "unit"-style rendering performance: (https://github.com/greglittlefield-wf/react-dart_perf_unit)
* functional-style frame rate performance: (https://github.com/greglittlefield-wf/react-dart_perf/tree/new_react-dart_interop)

_See https://github.com/greglittlefield-wf/react-dart_perf_unit/blob/master/README.md#improvement-details for more details on which performance improvements were included while testing._

Note: these results also include numbers for a few potential dart2js optimizations (more details in the link above). I will follow up this PR with links to dart-lang/sdk GitHub issues regarding these potential optimizations.

#### Summary of results
###### react-dart Initial Rendering Time (in terms of pure JS time):
* current: 14.3x
* optimized: 5.7x
* optimized + dart2js tweaks: 3.5x

###### react-dart Frame Rate (% of pure JS React rate):
* current: 21.5%
* optimized: 46.5%
* optimized + dart2js tweaks: 60.9%

# Changes
##### Performance improvements:
* Use new `package:js` Dart-JS interop in `react_client` and `react_test_utils`.
    * Update SDK constraint in `pubspec.yaml`.
* Optimize event handler conversion by using a Map instead of if-else.
* Lifecycle-related changes: the following React component lifecycle changes were made for the sake of performance as well as better parity with React JS:
    * Remove `rootNode` argument from `componentDidMount`/`componentDidUpdate`.
        * Prevents unnecessary calls to `findDOMNode` and creation of dart2js interceptors for Elements, which affects performance.
    * Only call `getDefaultProps()` once and cache the result.
    * Merge default props only once, in the component factory.
    * Cache `nextProps` on the component to prevent excessive calls to `_getNextProps`.

##### Other changes
* Use a Dart class (`ReactDartComponentInternal`) instead of a Map for managing react-dart component internals.
* Store internal object in the JS props at the `internal` key, instead of `__internal__`.
    * `package:js` doesn't allow you to proxy fields starting with underscores without making them private.
* Don't expose `key`/`ref` in a rendered component's props (React JS started doing this [in 0.12](https://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#breaking-change-key-and-ref-removed-from-this.props)).
* Add `test/lifecycle_test` to verify the lifecycle behavior of Dart components.
* `shouldComponentUpdate`, `componentDidUpdate`, and `componentWillUnmount` are no longer skippable via `skipMethods`.

### Breaking Changes
From the changes mentioned above, the following are breaking:
* react-dart now requires a Dart SDK of `>=1.13.0`.
* `componentDidMount`/`componentDidUpdate` no longer have the `rootNode` argument. 
* `ReactElement`s now always have default props merged in.
* `package:js` interop-related:
    * React element instances are now of type `ReactElement`, not `JsObject`.
        * (These are the objects returned when invoking a component factory.) 
    * React component instances are now of type `ReactComponent`, not `JsObject`.
        * (These are the objects returned by `ref` and `react.render`.)
    * React component classes are now of type `ReactClass`, not `JsFunction`
    * JS props are now `package:js` interop objects, not `JsObject`.
* `props['children']` is now a non-growable `List`.
* Internals:
    * A Dart class (`ReactDartComponentInternal`) is used instead of a Map for managing react-dart component internals.
    * The react-dart "internal" object is stored in the JS props at the `internal` key, instead of `__internal__`.

# Testing
* In both Dartium and dart2js:
    * Verify that all tests in `test/` pass.
    * Verify that all examples in `example/test/` work as expected.

---

@hleumas @trentgrover-wf @evanweible-wf @maxwellpeterson-wf @timmccall-wf @todbachman-wf @aaronlademann-wf @clairesarsam-wf @jacehensley-wf @joelleibow-wf