### PR TITLE
Enable Strong Mode

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -59,7 +59,7 @@ class _ClockComponent extends react.Component {
 
   getInitialState() => {'secondsElapsed': 0};
 
-  dynamic getDefaultProps() => {'refreshRate': 1000};
+  Map getDefaultProps() => {'refreshRate': 1000};
 
 
   void componentWillMount() {
@@ -105,7 +105,7 @@ var clockComponent = react.registerComponent(() => new _ClockComponent());
 
 class _ListComponent extends react.Component {
 
-  dynamic getInitialState() {
+  Map getInitialState() {
     return {"items": new List.from([0, 1, 2, 3])};
   }
 

--- a/example/test/speed_test.dart
+++ b/example/test/speed_test.dart
@@ -54,7 +54,7 @@ class _Hello extends react.Component {
 
   render() {
     timeprint("rendering start");
-    List<List<String>> data = props['data'];
+    List<List<String>> data = (props['data'] as List<List<String>>);
     var children = [];
     for(var elem in data){
       children.add(

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -384,7 +384,7 @@ class SyntheticFormEvent extends SyntheticEvent {
 class SyntheticDataTransfer {
   final String dropEffect;
   final String effectAllowed;
-  final List/*<File>*/ files;
+  final List files;
   final List<String> types;
 
   SyntheticDataTransfer(this.dropEffect, this.effectAllowed, this.files, this.types);

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -80,7 +80,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
     return reactComponentFactory(
       generateExtendedJsProps(props, children, defaultProps: defaultProps),
       children
-    );
+    ) as ReactElement<TComponent>;
   }
 
   dynamic noSuchMethod(Invocation invocation) {

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -58,7 +58,7 @@ ReactComponentFactory _reactDom(String name) {
   return (Map args, [children]) {
     // Pack component string creation into function to easily pass owner id, position and key
     // (from its custom component owner)
-    return ([String ownerId, int position, String key]) {
+    return ([String ownerId, num position, String key]) {
       if (_selfClosingElementTags.contains(name) && (children != null && children.length > 0)) {
         throw new Exception('$name element does not accept children.');
       }
@@ -75,7 +75,7 @@ ReactComponentFactory _reactDom(String name) {
         thisId = _createRootId();
       } else {
         // If ownerId is set, append adequate string to parent id based on position and key.
-        thisId = ownerId + (key != null ? '.\$$key' : (position != null ? '.${position.toRadixString(36)}' : '.0'));
+        thisId = ownerId + (key != null ? '.\$$key' : (position != null ? '.${position.toInt().toRadixString(36)}' : '.0'));
       }
 
       // Create StringBuffer to build result, append open tag to it

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -195,7 +195,7 @@ external bool _isElementOfType(dynamic element, ReactComponentFactory componentC
 /// Returns true if [element] is a ReactElement whose type is of a
 /// React componentClass.
 bool isElementOfType(dynamic element, ReactComponentFactory componentClass) {
-  return _isElementOfType(element, getComponentType(componentClass));
+  return _isElementOfType(element, getComponentType(componentClass) as ReactComponentFactory);
 }
 
 @JS('React.addons.TestUtils.scryRenderedComponentsWithType')

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -390,7 +390,7 @@ class _DefaultPropsCachingTest extends react.Component {
   render() => false;
 }
 
-ReactDartComponentFactoryProxy<_DefaultPropsTest> DefaultPropsTest = react.registerComponent(() => new _DefaultPropsTest());
+ReactDartComponentFactoryProxy<_DefaultPropsTest> DefaultPropsTest = react.registerComponent(() => new _DefaultPropsTest()) as ReactDartComponentFactoryProxy<_DefaultPropsTest>;
 class _DefaultPropsTest extends react.Component {
   static int getDefaultPropsCallCount = 0;
 
@@ -401,7 +401,7 @@ class _DefaultPropsTest extends react.Component {
   render() => false;
 }
 
-ReactDartComponentFactoryProxy<_LifecycleTest> LifecycleTest = react.registerComponent(() => new _LifecycleTest());
+ReactDartComponentFactoryProxy<_LifecycleTest> LifecycleTest = react.registerComponent(() => new _LifecycleTest()) as ReactDartComponentFactoryProxy<_LifecycleTest>;
 class _LifecycleTest extends react.Component {
   List lifecycleCalls = [];
 
@@ -415,7 +415,9 @@ class _LifecycleTest extends react.Component {
 
     var lifecycleCallback = props == null ? null : props[memberName];
     if (lifecycleCallback != null) {
-      return Function.apply(lifecycleCallback, [this]..addAll(arguments));
+      return Function.apply(lifecycleCallback, []
+          ..add(this)
+          ..addAll(arguments));
     }
 
     if (defaultReturnValue != null) {

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -232,11 +232,11 @@ void main() {
 
   group('isElementOfType', () {
     test('returns true argument is an element of type', () {
-      expect(isElementOfType(div({}), div), isTrue);
+      expect(isElementOfType(div({}), div as ReactComponentFactory), isTrue);
     });
 
     test('returns false argument is not an element of type', () {
-      expect(isElementOfType(div({}), span), isFalse);
+      expect(isElementOfType(div({}), span as ReactComponentFactory), isFalse);
     });
   });
 

--- a/test/test_components.dart
+++ b/test/test_components.dart
@@ -46,7 +46,7 @@ class EventComponent extends Component {
   );
 }
 ReactComponentFactory eventComponent = registerComponent(() =>
-    new EventComponent());
+    new EventComponent()) as ReactComponentFactory;
 
 class SampleComponent extends Component {
   render() => div(props, [
@@ -58,11 +58,11 @@ class SampleComponent extends Component {
 }
 
 ReactComponentFactory sampleComponent = registerComponent(() =>
-    new SampleComponent());
+    new SampleComponent()) as ReactComponentFactory;
 
 class WrapperComponent extends Component {
   render() => div(props, props['children']);
 }
 
 ReactComponentFactory wrapperComponent = registerComponent(() =>
-    new WrapperComponent());
+    new WrapperComponent()) as ReactComponentFactory;


### PR DESCRIPTION
## Ultimate problem:
This package was not strong mode compliant (see: [here](https://github.com/dart-lang/dev_compiler/blob/master/STRONG_MODE.md) for more explanation).

And it looks like Dart SDK 1.16.0 will include the `dev_complier` so it would be good to get react-dart in compliance sooner rather than later.

## How it was fixed:
- Added `.analysis_options` file (see: [here](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer) for more explanation).
- Got rid of strong mode warnings.
  - Most fixes were just making explicit conversions rather than implicit.

## Testing suggestions:
- Pull this down in Atom or WebStrom there should be only one hint which is the use of getDomNode which is deprecated.
  - If not using Atom or WebStrom run `dartanalyzer --strong lib/**.dart`.

## Areas of regression:
N/A

---
FYA: @hleumas @trentgrover-wf
FYI: @aaronlademann-wf @greglittlefield-wf @clairesarsam-wf @joelleibow-wf @dianachen-wf 