### PR TITLE
Untype the componentClass param of _isElementOfType.

### DIFF
--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -190,12 +190,12 @@ external bool isDOMComponent(/* [1] */ instance);
 external bool isElement(dynamic object);
 
 @JS('React.addons.TestUtils.isElementOfType')
-external bool _isElementOfType(dynamic element, ReactComponentFactory componentClass);
+external bool _isElementOfType(dynamic element, dynamic componentClass);
 
 /// Returns true if [element] is a ReactElement whose type is of a
 /// React componentClass.
 bool isElementOfType(dynamic element, ReactComponentFactory componentClass) {
-  return _isElementOfType(element, getComponentType(componentClass) as ReactComponentFactory);
+  return _isElementOfType(element, getComponentType(componentClass));
 }
 
 @JS('React.addons.TestUtils.scryRenderedComponentsWithType')

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -194,8 +194,8 @@ external bool _isElementOfType(dynamic element, dynamic componentClass);
 
 /// Returns true if [element] is a ReactElement whose type is of a
 /// React componentClass.
-bool isElementOfType(dynamic element, ReactComponentFactory componentClass) {
-  return _isElementOfType(element, getComponentType(componentClass));
+bool isElementOfType(dynamic element, ReactComponentFactory componentFactory) {
+  return _isElementOfType(element, getComponentType(componentFactory));
 }
 
 @JS('React.addons.TestUtils.scryRenderedComponentsWithType')


### PR DESCRIPTION
## Ultimate problem:
When enabling Strong mode in https://github.com/cleandart/react-dart/pull/89 a return type was cast as a specific type while it actually has two valid return types.

## How it was fixed:
- Remove explicit cast
- Remove typing of the parameter.

## Testing suggestions:
- Verify all tests pass

## Areas of regression:
N/A

---
FYA: @hleumas @trentgrover-wf @greglittlefield-wf 