### PR TITLE
Validate variadic children passed to Dart components

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -88,6 +88,8 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       Map props = invocation.positionalArguments[0];
       List children = listifyChildren(invocation.positionalArguments.sublist(1));
 
+      markChildrenValidated(children);
+
       return reactComponentFactory(
         generateExtendedJsProps(props, children, defaultProps: defaultProps),
         children

--- a/test/child_key_warning_test.dart
+++ b/test/child_key_warning_test.dart
@@ -7,13 +7,24 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_test_utils.dart' as react_test_utils;
 
+int _nextFactoryId = 0;
+
+/// Renders the provided [render] function with an owner that will have a unique name.
+///
+/// This prevents React JS from not printing key warnings it deems as "duplicates".
+void renderWithUniqueOwnerName(ReactElement render()) {
+  ReactDartComponentFactoryProxy factory = react.registerComponent(() => new _OwnerHelperComponent());
+  factory.reactClass.displayName = 'OwnerHelperComponent_$_nextFactoryId';
+  _nextFactoryId++;
+
+  react_test_utils.renderIntoDocument(
+      factory({'render': render})
+  );
+}
+
 void main() {
   useHtmlConfiguration();
   setClientConfiguration();
-
-  void render(ReactElement reactElement) {
-    react_test_utils.renderIntoDocument(reactElement);
-  }
 
   group('Key/children validation', () {
     bool consoleErrorCalled;
@@ -39,7 +50,7 @@ void main() {
 
     group('warns when multiple children are passed as a list', () {
       test('when rendering DOM components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             react.div({}, [
               react.span({}),
               react.span({}),
@@ -52,7 +63,7 @@ void main() {
       });
 
       test('when rendering custom Dart components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             CustomComponent({}, [
               react.span({}),
               react.span({}),
@@ -67,7 +78,7 @@ void main() {
 
     group('does not warn when multiple children are passed as variadic args', () {
       test('when rendering DOM components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             react.div({},
               react.span({}),
               react.span({}),
@@ -79,7 +90,7 @@ void main() {
       });
 
       test('when rendering custom Dart components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             CustomComponent({},
               react.span({}),
               react.span({}),
@@ -93,7 +104,7 @@ void main() {
 
     group('does not warn when a single child is passed', () {
       test('when rendering DOM components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             react.div({},
               react.span({})
             )
@@ -103,7 +114,7 @@ void main() {
       });
 
       test('when rendering custom Dart components', () {
-        render(
+        renderWithUniqueOwnerName(() =>
             CustomComponent({},
               react.span({})
             )
@@ -118,4 +129,8 @@ void main() {
 Function CustomComponent = react.registerComponent(() => new _CustomComponent());
 class _CustomComponent extends react.Component {
   render() => react.div({}, []);
+}
+
+class _OwnerHelperComponent extends react.Component {
+  render() => props['render']();
 }


### PR DESCRIPTION
## Ultimate Problem
Variadic children passed into Dart component factories were not being validated (via `markChildrenValidated`).

There was also an issue with that caused the accompanying tests to pass when they should have failed.

## Solution
* Update tests to ensure that React always emits warnings.
* Validate variadic children passed to Dart components

## Testing
* Verify that child_key_warning_test passes.
* Comment out the added call to `markChildrenValidated` and verify that the test fails.

---

@hleumas @trentgrover-wf @maxwellpeterson-wf @evanweible-wf @jacehensley-wf @leviwith-wf