### PR TITLE
Add @JS() annotation to libraries using JS interop to support Dart 1.16

### DIFF
--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -1,5 +1,6 @@
 /// Utilities for reading/modifying dynamic keys on JavaScript objects
 /// and converting Dart [Map]s to JavaScript objects.
+@JS()
 library react_client.js_interop_helpers;
 
 import "package:js/js.dart";

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -1,6 +1,7 @@
 /// JS interop classes for main React JS APIs and react-dart internals.
 ///
 /// For use in `react_client.dart` and by advanced react-dart users.
+@JS()
 library react_client.react_interop;
 
 import 'dart:html';

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@JS()
 library react.test_utils;
 
 import 'dart:html';

--- a/lib/src/react_client/synthetic_event_wrappers.dart
+++ b/lib/src/react_client/synthetic_event_wrappers.dart
@@ -1,6 +1,7 @@
 /// JS interop classes for React synthetic events.
 ///
 /// For use in `react_client.dart` and by advanced react-dart users.
+@JS()
 library react_client.synthetic_event_wrappers;
 
 import 'dart:html';

--- a/lib/src/react_test_utils/simulate_wrappers.dart
+++ b/lib/src/react_test_utils/simulate_wrappers.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@JS()
 library react.test_utils.simulate_wrappers;
 
 import 'package:js/js.dart';

--- a/test/js_interop_helpers_test/js_function_test.dart
+++ b/test/js_interop_helpers_test/js_function_test.dart
@@ -1,3 +1,6 @@
+@JS()
+library js_function_test;
+
 import 'package:js/js.dart';
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:unittest/html_config.dart';

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -1,3 +1,6 @@
+@JS()
+library react_test_utils_test;
+
 import 'dart:html';
 
 import 'package:js/js.dart';


### PR DESCRIPTION
### Ultimate problem
Dart 1.16.0 requires that any libraries that use the `@JS` annotation also be annotated with `@JS`.

See: https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#javascript-interop

### Solution
* Add `@JS` annotation to libraries where required.
    * Add `library` directives for some test files that didn't have any.

### Testing 
Verify that all tests/examples load and run properly in Dartium with a Dart SDK of 1.16.0.

### Areas of regression
None; these changes should be backwards-compatible.

---

@trentgrover-wf @hleumas