### PR TITLE
Support setState Variations

### DIFF
--- a/example/test/speed_test.dart
+++ b/example/test/speed_test.dart
@@ -49,10 +49,6 @@ class _Hello extends react.Component {
     });
   }
 
-  void redraw(){
-    setState({});
-  }
-
   render() {
     timeprint("rendering start");
     List<List<String>> data = (props['data'] as List<List<String>>);

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -114,12 +114,12 @@ abstract class Component {
     if (newState is Map) {
       _nextState.addAll(newState);
     } else if (newState is _TransactionalSetStateCallback) {
-      _addTransactionalSetStateCallback(newState);
+      _transactionalSetStateCallbacks.add(newState);
     } else if (newState != null) {
       throw new ArgumentError('setState expects its first parameter to either be a Map or a Function that accepts two parameters.');
     }
 
-    if (callback != null) _addSetStateCallback(callback);
+    if (callback != null) _setStateCallbacks.add(callback);
 
     _jsRedraw();
   }
@@ -132,21 +132,9 @@ abstract class Component {
   void replaceState(Map newState, [callback()]) {
     Map nextState = newState == null ? {} : new Map.from(newState);
     _nextState = nextState;
-    if (callback != null) _addSetStateCallback(callback);
+    if (callback != null) _setStateCallbacks.add(callback);
 
     _jsRedraw();
-  }
-
-  void _addTransactionalSetStateCallback(Map callback(Map prevState, Map currentProps)) {
-    if (_transactionalSetStateCallbacks == null) _transactionalSetStateCallbacks = [];
-
-    _transactionalSetStateCallbacks.add(callback);
-  }
-
-  void _addSetStateCallback(callback()) {
-    if (_setStateCallbacks == null) _setStateCallbacks = [];
-
-    _setStateCallbacks.add(callback);
   }
 
   /// ReactJS lifecycle method that is invoked once, both on the client and server, immediately before the initial

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -218,12 +218,12 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     component.transferComponentState();
   }
 
-  _callSetStateCallbacks(Component component) {
+  void _callSetStateCallbacks(Component component) {
     component.setStateCallbacks.forEach((callback()) { callback(); });
     component.setStateCallbacks.clear();
   }
 
-  _callSetStateTransactionalCallbacks(Component component) {
+  void _callSetStateTransactionalCallbacks(Component component) {
     var nextState = component.nextState;
     var props = new UnmodifiableMapView(component.props);
 
@@ -251,7 +251,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
       _afterPropsChange(component, nextInternal);
       _callSetStateCallbacks(component);
       return false;
-    }
+  }
   });
 
   /// Wrapper for [Component.componentWillUpdate].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -6,6 +6,7 @@
 library react_client;
 
 import "dart:async";
+import "dart:collection";
 import "dart:html";
 
 import "package:js/js.dart";
@@ -217,6 +218,19 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     component.transferComponentState();
   }
 
+  _callSetStateCallbacks(Component component) {
+    component.setStateCallbacks.forEach((callback()) { callback(); });
+    component.setStateCallbacks.clear();
+  }
+
+  _callSetStateTransactionalCallbacks(Component component) {
+    var nextState = component.nextState;
+    var props = new UnmodifiableMapView(component.props);
+
+    component.transactionalSetStateCallbacks.forEach((callback) { nextState.addAll(callback(nextState, props)); });
+    component.transactionalSetStateCallbacks.clear();
+  }
+
   /// Wrapper for [Component.componentWillReceiveProps].
   void handleComponentWillReceiveProps(ReactDartComponentInternal internal, ReactDartComponentInternal nextInternal) => zone.run(() {
     var nextProps = _getNextProps(internal.component, nextInternal);
@@ -228,12 +242,14 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
   /// Wrapper for [Component.shouldComponentUpdate].
   bool handleShouldComponentUpdate(ReactDartComponentInternal internal, ReactDartComponentInternal nextInternal) => zone.run(() {
     Component component = internal.component;
+    _callSetStateTransactionalCallbacks(component);
 
     if (component.shouldComponentUpdate(component.nextProps, component.nextState)) {
       return true;
     } else {
       // If component should not update, update props / transfer state because componentWillUpdate will not be called.
       _afterPropsChange(component, nextInternal);
+      _callSetStateCallbacks(component);
       return false;
     }
   });
@@ -252,6 +268,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     var prevInternalProps = prevInternal.props;
     Component component = internal.component;
     component.componentDidUpdate(prevInternalProps, component.prevState);
+    _callSetStateCallbacks(component);
   });
 
   /// Wrapper for [Component.componentWillUnmount].

--- a/test/ReactSetStateTestComponent.js
+++ b/test/ReactSetStateTestComponent.js
@@ -1,0 +1,88 @@
+function getUpdatingSetStateLifeCycleCalls() {
+  return _updatingSetStateLifeCycleCalls;
+}
+
+var _updatingSetStateLifeCycleCalls = [];
+
+function getNonUpdatingSetStateLifeCycleCalls() {
+  return _nonUpdatingSetStateLifeCycleCalls;
+}
+
+var _nonUpdatingSetStateLifeCycleCalls = [];
+
+var ReactSetStateTestComponent = React.createClass({
+  getDefaultProps: function() {
+    return {shouldUpdate: true};
+  },
+
+  getInitialState: function() {
+    return {counter: 0};
+  },
+
+  recordLifecyleCall: function(name) {
+    this.props.shouldUpdate ? _updatingSetStateLifeCycleCalls.push(name) : _nonUpdatingSetStateLifeCycleCalls.push(name)
+  },
+
+  componentWillReceiveProps: function(_) {
+    this.recordLifecyleCall("componentWillReceiveProps");
+  },
+
+  shouldComponentUpdate: function(_, __) {
+    this.recordLifecyleCall("shouldComponentUpdate");
+    return this.props.shouldUpdate;
+  },
+
+  componentWillUpdate: function(_, __) {
+    this.recordLifecyleCall("componentWillUpdate");
+  },
+
+  componentDidUpdate: function(_, __) {
+    this.recordLifecyleCall("componentDidUpdate");
+  },
+
+  outerSetStateCallback: function() {
+    this.recordLifecyleCall('outerSetStateCallback');
+  },
+
+  innerSetStateCallback: function() {
+    this.recordLifecyleCall('innerSetStateCallback');
+  },
+
+  outerTransactionalSetStateCallback: function(previousState, props) {
+    this.recordLifecyleCall('outerTransactionalSetStateCallback');
+    return {counter: previousState.counter + 1};
+  },
+
+  innerTransactionalSetStateCallback: function(previousState, props) {
+    this.recordLifecyleCall('innerTransactionalSetStateCallback');
+    return {counter: previousState.counter + 1};
+  },
+
+  handleOuterClick: function(_) {
+    this.setState(this.outerTransactionalSetStateCallback, this.outerSetStateCallback);
+  },
+
+  handleInnerClick: function(_) {
+    this.setState(this.innerTransactionalSetStateCallback, this.innerSetStateCallback);
+  },
+
+  render: function() {
+    return React.createElement("div", {onClick: this.handleOuterClick},
+      React.createElement("div", {onClick: this.handleInnerClick}, this.state.counter)
+    );
+  }
+});
+
+var updatingInstance = ReactDOM.render(
+  React.createElement(ReactSetStateTestComponent),
+  document.createElement("div")
+);
+
+var nonUpdatingInstance = ReactDOM.render(
+  React.createElement(ReactSetStateTestComponent, {shouldUpdate: false}),
+  document.createElement("div")
+);
+
+React.addons.TestUtils.Simulate.click(ReactDOM.findDOMNode(updatingInstance).children[0]);
+
+React.addons.TestUtils.Simulate.click(ReactDOM.findDOMNode(nonUpdatingInstance).children[0]);

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -459,12 +459,12 @@ class _SetStateTest extends react.Component {
 
   Map outerTransactionalSetStateCallback(previousState, __) {
     recordLifecyleCall('outerTransactionalSetStateCallback');
-    return {'counter': ++previousState['counter']};
+    return {'counter': previousState['counter'] + 1};
   }
 
   Map innerTransactionalSetStateCallback(previousState, __) {
     recordLifecyleCall('innerTransactionalSetStateCallback');
-    return {'counter': ++previousState['counter']};
+    return {'counter': ++previousState['counter'] + 1};
   }
 
   void recordLifecyleCall(String name) {

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -464,7 +464,7 @@ class _SetStateTest extends react.Component {
 
   Map innerTransactionalSetStateCallback(previousState, __) {
     recordLifecyleCall('innerTransactionalSetStateCallback');
-    return {'counter': ++previousState['counter'] + 1};
+    return {'counter': previousState['counter'] + 1};
   }
 
   void recordLifecyleCall(String name) {

--- a/test/lifecycle_test.html
+++ b/test/lifecycle_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="ReactSetStateTestComponent.js"></script>
     <script type="application/dart" src="lifecycle_test.dart"></script>
     <script src="packages/browser/dart.js"></script>
 </head>


### PR DESCRIPTION
## Ultimate Problem
ReactJs supports `setState` callbacks as well as a transactional `setState`. 

For more information on what those are see [here](https://facebook.github.io/react/docs/component-api.html#setstate).

## Solution
- Allow `setState`, `replaceState`, and `redraw` to accept an optional parameter that will be called after `componentDidUpdate` is called.
- Untype the `newState` param in `setState` so that is can accept and function that accepts two params.
  - This will be called before `shouldComponentUpdate`.
- Add tests that ensure the ordering of the callbacks and component methods match the JS order.

## Testing Suggestions
- Verify all tests pass.

## Possible Areas of Regression
- None expected, all new logic.

--
FYA: @trentgrover-wf @hleumas @greglittlefield-wf @clairesarsam-wf 