### PR TITLE
Re-add setState callback support

### DIFF
--- a/example/test/speed_test.dart
+++ b/example/test/speed_test.dart
@@ -49,10 +49,6 @@ class _Hello extends react.Component {
     });
   }
 
-  void redraw(){
-    setState({});
-  }
-
   render() {
     timeprint("rendering start");
     List<List<String>> data = (props['data'] as List<List<String>>);

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -18,6 +18,16 @@ abstract class Component {
 
   dynamic _jsThis;
 
+  List _setStateCallbacks = [];
+
+  List _transactionalSetStateCallbacks = [];
+
+  /// The List of callbacks to be called after the component has been updated from a call to [setState].
+  List get setStateCallbacks => _setStateCallbacks;
+
+  /// The List of transactional `setState` callbacks to be called before the component updates.
+  List get transactionalSetStateCallbacks => _transactionalSetStateCallbacks;
+
   /// The JavaScript [`ReactComponent`](https://facebook.github.io/react/docs/top-level-api.html#reactdom.render)
   /// instance of this `Component` returned by [render].
   dynamic get jsThis => _jsThis;
@@ -86,28 +96,43 @@ abstract class Component {
 
   /// Force a call to [render] by calling [setState], which effectively "redraws" the `Component`.
   ///
+  /// Optionally accepts a callback that gets called after the component updates.
+  ///
   /// [A.k.a "forceUpdate"](https://facebook.github.io/react/docs/component-api.html#forceupdate)
-  void redraw() {
-    setState({});
+  void redraw([callback()]) {
+    setState({}, callback);
   }
 
   /// Set [_nextState] to provided [newState] value and force a re-render.
   ///
+  /// Optionally accepts a callback that gets called after the component updates.
+  ///
+  /// Also allows [newState] to be used as a transactional `setState` callback.
+  ///
   /// See: <https://facebook.github.io/react/docs/component-api.html#setstate>
-  void setState(Map newState) {
-    if (newState != null) {
+  void setState(dynamic newState, [callback()]) {
+    if (newState is Map) {
       _nextState.addAll(newState);
+    } else if (newState is _TransactionalSetStateCallback) {
+      _transactionalSetStateCallbacks.add(newState);
+    } else if (newState != null) {
+      throw new ArgumentError('setState expects its first parameter to either be a Map or a Function that accepts two parameters.');
     }
+
+    if (callback != null) _setStateCallbacks.add(callback);
 
     _jsRedraw();
   }
 
   /// Set [_nextState] to provided [newState] value and force a re-render.
   ///
+  /// Optionally accepts a callback that gets called after the component updates.
+  ///
   /// See: <https://facebook.github.io/react/docs/component-api.html#replacestate>
-  void replaceState(Map newState) {
+  void replaceState(Map newState, [callback()]) {
     Map nextState = newState == null ? {} : new Map.from(newState);
     _nextState = nextState;
+    if (callback != null) _setStateCallbacks.add(callback);
 
     _jsRedraw();
   }
@@ -202,6 +227,11 @@ abstract class Component {
   /// See: <https://facebook.github.io/react/docs/component-specs.html#render>
   dynamic render();
 }
+
+/// Typedef of a transactional [Component.setState] callback.
+///
+/// See: <https://facebook.github.io/react/docs/component-api.html#setstate>
+typedef Map _TransactionalSetStateCallback(Map prevState, Map props);
 
 
 /// A cross-browser wrapper around the browser's [nativeEvent].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -6,6 +6,7 @@
 library react_client;
 
 import "dart:async";
+import "dart:collection";
 import "dart:html";
 
 import "package:js/js.dart";
@@ -217,6 +218,19 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     component.transferComponentState();
   }
 
+  void _callSetStateCallbacks(Component component) {
+    component.setStateCallbacks.forEach((callback()) { callback(); });
+    component.setStateCallbacks.clear();
+  }
+
+  void _callSetStateTransactionalCallbacks(Component component) {
+    var nextState = component.nextState;
+    var props = new UnmodifiableMapView(component.props);
+
+    component.transactionalSetStateCallbacks.forEach((callback) { nextState.addAll(callback(nextState, props)); });
+    component.transactionalSetStateCallbacks.clear();
+  }
+
   /// Wrapper for [Component.componentWillReceiveProps].
   void handleComponentWillReceiveProps(ReactDartComponentInternal internal, ReactDartComponentInternal nextInternal) => zone.run(() {
     var nextProps = _getNextProps(internal.component, nextInternal);
@@ -228,14 +242,16 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
   /// Wrapper for [Component.shouldComponentUpdate].
   bool handleShouldComponentUpdate(ReactDartComponentInternal internal, ReactDartComponentInternal nextInternal) => zone.run(() {
     Component component = internal.component;
+    _callSetStateTransactionalCallbacks(component);
 
     if (component.shouldComponentUpdate(component.nextProps, component.nextState)) {
       return true;
     } else {
       // If component should not update, update props / transfer state because componentWillUpdate will not be called.
       _afterPropsChange(component, nextInternal);
+      _callSetStateCallbacks(component);
       return false;
-    }
+  }
   });
 
   /// Wrapper for [Component.componentWillUpdate].
@@ -252,6 +268,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     var prevInternalProps = prevInternal.props;
     Component component = internal.component;
     component.componentDidUpdate(prevInternalProps, component.prevState);
+    _callSetStateCallbacks(component);
   });
 
   /// Wrapper for [Component.componentWillUnmount].

--- a/test/ReactSetStateTestComponent.js
+++ b/test/ReactSetStateTestComponent.js
@@ -1,0 +1,88 @@
+function getUpdatingSetStateLifeCycleCalls() {
+  return _updatingSetStateLifeCycleCalls;
+}
+
+var _updatingSetStateLifeCycleCalls = [];
+
+function getNonUpdatingSetStateLifeCycleCalls() {
+  return _nonUpdatingSetStateLifeCycleCalls;
+}
+
+var _nonUpdatingSetStateLifeCycleCalls = [];
+
+var ReactSetStateTestComponent = React.createClass({
+  getDefaultProps: function() {
+    return {shouldUpdate: true};
+  },
+
+  getInitialState: function() {
+    return {counter: 0};
+  },
+
+  recordLifecyleCall: function(name) {
+    this.props.shouldUpdate ? _updatingSetStateLifeCycleCalls.push(name) : _nonUpdatingSetStateLifeCycleCalls.push(name)
+  },
+
+  componentWillReceiveProps: function(_) {
+    this.recordLifecyleCall("componentWillReceiveProps");
+  },
+
+  shouldComponentUpdate: function(_, __) {
+    this.recordLifecyleCall("shouldComponentUpdate");
+    return this.props.shouldUpdate;
+  },
+
+  componentWillUpdate: function(_, __) {
+    this.recordLifecyleCall("componentWillUpdate");
+  },
+
+  componentDidUpdate: function(_, __) {
+    this.recordLifecyleCall("componentDidUpdate");
+  },
+
+  outerSetStateCallback: function() {
+    this.recordLifecyleCall('outerSetStateCallback');
+  },
+
+  innerSetStateCallback: function() {
+    this.recordLifecyleCall('innerSetStateCallback');
+  },
+
+  outerTransactionalSetStateCallback: function(previousState, props) {
+    this.recordLifecyleCall('outerTransactionalSetStateCallback');
+    return {counter: previousState.counter + 1};
+  },
+
+  innerTransactionalSetStateCallback: function(previousState, props) {
+    this.recordLifecyleCall('innerTransactionalSetStateCallback');
+    return {counter: previousState.counter + 1};
+  },
+
+  handleOuterClick: function(_) {
+    this.setState(this.outerTransactionalSetStateCallback, this.outerSetStateCallback);
+  },
+
+  handleInnerClick: function(_) {
+    this.setState(this.innerTransactionalSetStateCallback, this.innerSetStateCallback);
+  },
+
+  render: function() {
+    return React.createElement("div", {onClick: this.handleOuterClick},
+      React.createElement("div", {onClick: this.handleInnerClick}, this.state.counter)
+    );
+  }
+});
+
+var updatingInstance = ReactDOM.render(
+  React.createElement(ReactSetStateTestComponent),
+  document.createElement("div")
+);
+
+var nonUpdatingInstance = ReactDOM.render(
+  React.createElement(ReactSetStateTestComponent, {shouldUpdate: false}),
+  document.createElement("div")
+);
+
+React.addons.TestUtils.Simulate.click(ReactDOM.findDOMNode(updatingInstance).children[0]);
+
+React.addons.TestUtils.Simulate.click(ReactDOM.findDOMNode(nonUpdatingInstance).children[0]);

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1,5 +1,9 @@
+@JS()
+library lifecycle_test;
+
 import 'dart:html';
 
+import "package:js/js.dart";
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
@@ -374,7 +378,116 @@ void main() {
         ]));
       });
     });
+
+    group('calls the setState callback, and transactional setState callback in the correct order', () {
+      test('when shouldComponentUpdate returns false', () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(SetStateTest({'shouldUpdate': false}), mountNode);
+        Element renderedNode = react_dom.findDOMNode(renderedInstance);
+        _SetStateTest component = getDartComponent(renderedInstance);
+
+        react_test_utils.Simulate.click(renderedNode.children.first);
+
+        // Check against the JS component to ensure no regressions.
+        expect(component.lifecycleCalls, orderedEquals(getNonUpdatingSetStateLifeCycleCalls()));
+        expect(renderedNode.children.first.text, '1');
+      });
+
+      test('when shouldComponentUpdate returns true', () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
+        Element renderedNode = react_dom.findDOMNode(renderedInstance);
+        _SetStateTest component = getDartComponent(renderedInstance);
+
+        react_test_utils.Simulate.click(renderedNode.children.first);
+
+        // Check against the JS component to ensure no regressions.
+        expect(component.lifecycleCalls, orderedEquals(getUpdatingSetStateLifeCycleCalls()));
+        expect(renderedNode.children.first.text, '3');
+      });
+    });
+
+    test('throws when setState is called with something other than a Map or Function that accepts two parameters', () {
+      var mountNode = new DivElement();
+      var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
+      _SetStateTest component = getDartComponent(renderedInstance);
+
+      expect(() => component.setState(new Map()), returnsNormally);
+      expect(() => component.setState((_, __) { return {}; }), returnsNormally);
+      expect(() => component.setState(null), returnsNormally);
+
+      expect(() => component.setState('Not A Valid Parameter'), throwsArgumentError);
+      expect(() => component.setState(5), throwsArgumentError);
+    });
   });
+}
+
+@JS()
+external List getUpdatingSetStateLifeCycleCalls();
+
+@JS()
+external List getNonUpdatingSetStateLifeCycleCalls();
+
+ReactDartComponentFactoryProxy<_SetStateTest> SetStateTest = react.registerComponent(() => new _SetStateTest()) as ReactDartComponentFactoryProxy<_SetStateTest>;
+class _SetStateTest extends react.Component {
+  @override
+  Map getDefaultProps() => {'shouldUpdate': true};
+
+  @override
+  getInitialState() => {"counter": 1};
+
+  @override
+  componentWillReceiveProps(_) {
+    recordLifecyleCall('componentWillReceiveProps');
+  }
+
+  @override
+  componentWillUpdate(_, __) {
+    recordLifecyleCall('componentWillUpdate');
+  }
+
+  @override
+  componentDidUpdate(_, __) {
+    recordLifecyleCall('componentDidUpdate');
+  }
+
+  @override
+  shouldComponentUpdate(_, __) {
+    recordLifecyleCall('shouldComponentUpdate');
+    return props['shouldUpdate'] as bool;
+  }
+
+  Map outerTransactionalSetStateCallback(previousState, __) {
+    recordLifecyleCall('outerTransactionalSetStateCallback');
+    return {'counter': previousState['counter'] + 1};
+  }
+
+  Map innerTransactionalSetStateCallback(previousState, __) {
+    recordLifecyleCall('innerTransactionalSetStateCallback');
+    return {'counter': previousState['counter'] + 1};
+  }
+
+  void recordLifecyleCall(String name) {
+    lifecycleCalls.add(name);
+  }
+
+  render() {
+    return react.div({
+      'onClick': (_) {
+        setState(outerTransactionalSetStateCallback, () { recordLifecyleCall('outerSetStateCallback'); });
+      }
+    },
+      react.div({
+        'onClick': (_) {
+          setState(innerTransactionalSetStateCallback, () { recordLifecyleCall('innerSetStateCallback'); });
+        }
+      },
+        state['counter']
+      )
+    );
+  }
+
+  List lifecycleCalls = [];
 }
 
 class _DefaultPropsCachingTest extends react.Component {

--- a/test/lifecycle_test.html
+++ b/test/lifecycle_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="ReactSetStateTestComponent.js"></script>
     <script type="application/dart" src="lifecycle_test.dart"></script>
     <script src="packages/browser/dart.js"></script>
 </head>


### PR DESCRIPTION
## Ultimate Problem
We still want the setState callback variations

## Notes
- This will need to be breaking change release because anyone overriding `setState`, `replaceState`, or `redraw` will have to change the signatures of the overridden methods.

## Solution
- Re add the logic that was originally added in #100 and then removed in #101.

## Testing Suggestions
- Ensure that the changes made here are the same made in #100 
- Same testing suggestions that are in #100 

## Possible Areas of Regression
- None expected

---
FYA: @trentgrover-wf @hleumas @greglittlefield-wf @clairesarsam-wf 