### PR TITLE
Expand quiver dependency range to include new 0.22

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,6 @@ environment:
 dependencies:
   browser: '>=0.9.0 <0.11.0'
   js: '^0.6.0'
-  quiver: '>=0.18.2 <0.22.0'
+  quiver: '>=0.18.2 <0.23.0'
 dev_dependencies:
   unittest: '>=0.11.0 <0.12.0'


### PR DESCRIPTION
Relax dependency range to include latest release of quiver.