### PR TITLE
Make adjustments necessary to support strong-mode compliance for over_react

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -10,49 +10,40 @@ import 'package:react/src/typedefs.dart';
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/react-component.html#reference)
 abstract class Component {
-  /// ReactJS [Component] props.
-  ///
   /// Currently private since the `@virtual` annotation within the meta package
   /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
   ///
   /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
-  ///
-  /// See: [props]
-  ///
-  /// Related: [_state]
   Map _props;
+
+  /// Currently private since the `@virtual` annotation within the meta package
+  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
+  ///
+  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  Map _state = {};
+
+  /// Currently private since the `@virtual` annotation within the meta package
+  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
+  ///
+  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  Ref _ref;
+
+  /// ReactJS [Component] props.
+  ///
+  /// Related: [state]
+  Map get props => _props;
+  set props(Map value) => _props = value;
 
   /// ReactJS [Component] state.
   ///
-  /// Currently private since the `@virtual` annotation within the meta package
-  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
-  ///
-  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
-  ///
-  /// See: [state]
-  ///
-  /// Related: [_props]
-  Map _state = {};
+  /// Related: [props]
+  Map get state => _state;
+  set state(Map value) => _state = value;
 
   /// Returns a component reference.
   ///
   /// * [Component] if it is a Dart component.
   /// * `Element` _(DOM node)_ if it is a React DOM component.
-  ///
-  /// Currently private since the `@virtual` annotation within the meta package
-  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
-  ///
-  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
-  ///
-  /// See: [ref]
-  Ref _ref;
-
-  Map get props => _props;
-  set props(Map value) => _props = value;
-
-  Map get state => _state;
-  set state(Map value) => _state = value;
-
   Ref get ref => _ref;
   set ref(Ref value) => _ref = value;
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -5,7 +5,7 @@
 /// A Dart library for building UI using ReactJS.
 library react;
 
-import 'dart:html';
+import 'dart:html' show Element;
 
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -5,8 +5,6 @@
 /// A Dart library for building UI using ReactJS.
 library react;
 
-import 'dart:html' show Element;
-
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
 abstract class Component {
@@ -24,7 +22,7 @@ abstract class Component {
 
   /// Returns the component of the specified [ref].
   ///
-  /// Returns a [Component] if it is a Dart component, otherwise returns an "Dom component" ([Element]).
+  /// Returns a [Component] if it is a Dart component, otherwise returns an "Dom component" (Dart `Element`).
   dynamic get ref => _ref;
   set ref(dynamic value) => _ref = value;
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -177,7 +177,7 @@ abstract class Component {
   /// Calling [setState] within this function will not trigger an additional [render].
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillreceiveprops>
-  void componentWillReceiveProps(newProps) {}
+  void componentWillReceiveProps(Map newProps) {}
 
   /// ReactJS lifecycle method that is invoked before rendering when [nextProps] or [nextState] are being received.
   ///
@@ -185,7 +185,7 @@ abstract class Component {
   /// will not require a component update.
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate>
-  bool shouldComponentUpdate(nextProps, nextState) => true;
+  bool shouldComponentUpdate(Map nextProps, Map nextState) => true;
 
   /// ReactJS lifecycle method that is invoked immediately before rendering when [nextProps] or [nextState] are being
   /// received.
@@ -195,7 +195,7 @@ abstract class Component {
   /// Use this as an opportunity to perform preparation before an update occurs.
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillupdate>
-  void componentWillUpdate(nextProps, nextState) {}
+  void componentWillUpdate(Map nextProps, Map nextState) {}
 
   /// ReactJS lifecycle method that is invoked immediately after the `Component`'s updates are flushed to the DOM.
   ///
@@ -205,7 +205,7 @@ abstract class Component {
   /// of the values of [prevProps] / [prevState].
   ///
   /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate>
-  void componentDidUpdate(prevProps, prevState) {}
+  void componentDidUpdate(Map prevProps, Map prevState) {}
 
   /// ReactJS lifecycle method that is invoked immediately before a `Component` is unmounted from the DOM.
   ///

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -5,12 +5,21 @@
 /// A Dart library for building UI using ReactJS.
 library react;
 
+import 'package:react/src/typedefs.dart';
+
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
 abstract class Component {
   Map _props;
   Map _state = {};
-  dynamic _ref;
+
+  /// Returns a component reference.
+  ///
+  /// * [Component] if it is a Dart component.
+  /// * `Element` _(DOM node)_ if it is a React DOM component.
+  ///
+  /// See: [ref]
+  Ref _ref;
 
   /// ReactJS `Component` props.
   Map get props => _props;
@@ -20,11 +29,8 @@ abstract class Component {
   Map get state => _state;
   set state(Map value) => _state = value;
 
-  /// Returns the component of the specified [ref].
-  ///
-  /// Returns a [Component] if it is a Dart component, otherwise returns an "Dom component" (Dart `Element`).
-  dynamic get ref => _ref;
-  set ref(dynamic value) => _ref = value;
+  Ref get ref => _ref;
+  set ref(Ref value) => _ref = value;
 
   dynamic _jsRedraw;
 
@@ -51,7 +57,7 @@ abstract class Component {
   /// Bind the value of input to [state[key]].
   bind(key) => [state[key], (value) => setState({key: value})];
 
-  initComponentInternal(props, _jsRedraw, [ref, _jsThis]) {
+  initComponentInternal(props, _jsRedraw, [Ref ref, _jsThis]) {
     this._jsRedraw = _jsRedraw;
     this.ref = ref;
     this._jsThis = _jsThis;

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -7,8 +7,8 @@ library react;
 
 import 'package:react/src/typedefs.dart';
 
-/// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
-/// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
+/// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
+/// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/react-component.html#reference)
 abstract class Component {
   /// ReactJS [Component] props.
   ///
@@ -74,7 +74,7 @@ abstract class Component {
   /// instance of this `Component` returned by [render].
   dynamic get jsThis => _jsThis;
 
-  /// Allows the [ReactJS `displayName` property](https://facebook.github.io/react/docs/component-specs.html#displayname)
+  /// Allows the [ReactJS `displayName` property](https://facebook.github.io/react/docs/react-component.html#displayname)
   /// to be set for debugging purposes.
   String get displayName => runtimeType.toString();
 
@@ -137,7 +137,7 @@ abstract class Component {
   ///
   /// Optionally accepts a callback that gets called after the component updates.
   ///
-  /// [A.k.a "forceUpdate"](https://facebook.github.io/react/docs/component-api.html#forceupdate)
+  /// [A.k.a "forceUpdate"](https://facebook.github.io/react/docs/react-component.html#forceupdate)
   void redraw([callback()]) {
     setState({}, callback);
   }
@@ -148,7 +148,7 @@ abstract class Component {
   ///
   /// Also allows [newState] to be used as a transactional `setState` callback.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-api.html#setstate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
   void setState(dynamic newState, [callback()]) {
     if (newState is Map) {
       _nextState.addAll(newState);
@@ -167,7 +167,7 @@ abstract class Component {
   ///
   /// Optionally accepts a callback that gets called after the component updates.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-api.html#replacestate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
   void replaceState(Map newState, [callback()]) {
     Map nextState = newState == null ? {} : new Map.from(newState);
     _nextState = nextState;
@@ -182,7 +182,7 @@ abstract class Component {
   /// If you call [setState] within this method, [render] will see the updated state and will be executed only once
   /// despite the [state] value change.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#mounting-componentwillmount>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#mounting-componentwillmount>
   void componentWillMount() {}
 
   /// ReactJS lifecycle method that is invoked once, only on the client _(not on the server)_, immediately after the
@@ -192,7 +192,7 @@ abstract class Component {
   ///
   /// The [componentDidMount] method of child `Component`s is invoked _before_ that of parent `Component`.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#mounting-componentdidmount>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#mounting-componentdidmount>
   void componentDidMount() {}
 
   /// ReactJS lifecycle method that is invoked when a `Component` is receiving [newProps].
@@ -204,7 +204,7 @@ abstract class Component {
   ///
   /// Calling [setState] within this function will not trigger an additional [render].
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillreceiveprops>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillreceiveprops>
   void componentWillReceiveProps(Map newProps) {}
 
   /// ReactJS lifecycle method that is invoked before rendering when [nextProps] or [nextState] are being received.
@@ -212,7 +212,7 @@ abstract class Component {
   /// Use this as an opportunity to return false when you're certain that the transition to the new props and state
   /// will not require a component update.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-shouldcomponentupdate>
   bool shouldComponentUpdate(Map nextProps, Map nextState) => true;
 
   /// ReactJS lifecycle method that is invoked immediately before rendering when [nextProps] or [nextState] are being
@@ -222,7 +222,7 @@ abstract class Component {
   ///
   /// Use this as an opportunity to perform preparation before an update occurs.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentwillupdate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillupdate>
   void componentWillUpdate(Map nextProps, Map nextState) {}
 
   /// ReactJS lifecycle method that is invoked immediately after the `Component`'s updates are flushed to the DOM.
@@ -232,7 +232,7 @@ abstract class Component {
   /// Use this as an opportunity to operate on the [rootNode] (DOM) when the `Component` has been updated as a result
   /// of the values of [prevProps] / [prevState].
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentdidupdate>
   void componentDidUpdate(Map prevProps, Map prevState) {}
 
   /// ReactJS lifecycle method that is invoked immediately before a `Component` is unmounted from the DOM.
@@ -240,12 +240,12 @@ abstract class Component {
   /// Perform any necessary cleanup in this method, such as invalidating timers or cleaning up any DOM [Element]s that
   /// were created in [componentDidMount].
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#unmounting-componentwillunmount>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#unmounting-componentwillunmount>
   void componentWillUnmount() {}
 
   /// Invoked once before the `Component` is mounted. The return value will be used as the initial value of [state].
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#getinitialstate>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#getinitialstate>
   Map getInitialState() => {};
 
   /// Invoked once and cached when [reactComponentClass] is called. Values in the mapping will be set on [props]
@@ -254,7 +254,7 @@ abstract class Component {
   /// This method is invoked before any instances are created and thus cannot rely on [props]. In addition, be aware
   /// that any complex objects returned by `getDefaultProps` will be shared across instances, not copied.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#getdefaultprops>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#getdefaultprops>
   Map getDefaultProps() => {};
 
   /// __Required.__
@@ -263,13 +263,13 @@ abstract class Component {
   /// be either a virtual representation of a native DOM component (such as [DivElement]) or another composite
   /// `Component` that you've defined yourself.
   ///
-  /// See: <https://facebook.github.io/react/docs/component-specs.html#render>
+  /// See: <https://facebook.github.io/react/docs/react-component.html#render>
   dynamic render();
 }
 
 /// Typedef of a transactional [Component.setState] callback.
 ///
-/// See: <https://facebook.github.io/react/docs/component-api.html#setstate>
+/// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
 typedef Map _TransactionalSetStateCallback(Map prevState, Map props);
 
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -10,7 +10,28 @@ import 'package:react/src/typedefs.dart';
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
 abstract class Component {
+  /// ReactJS [Component] props.
+  ///
+  /// Currently private since the `@virtual` annotation within the meta package
+  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
+  ///
+  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  ///
+  /// See: [props]
+  ///
+  /// Related: [_state]
   Map _props;
+
+  /// ReactJS [Component] state.
+  ///
+  /// Currently private since the `@virtual` annotation within the meta package
+  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
+  ///
+  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  ///
+  /// See: [state]
+  ///
+  /// Related: [_props]
   Map _state = {};
 
   /// Returns a component reference.
@@ -18,14 +39,17 @@ abstract class Component {
   /// * [Component] if it is a Dart component.
   /// * `Element` _(DOM node)_ if it is a React DOM component.
   ///
+  /// Currently private since the `@virtual` annotation within the meta package
+  /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
+  ///
+  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  ///
   /// See: [ref]
   Ref _ref;
 
-  /// ReactJS `Component` props.
   Map get props => _props;
   set props(Map value) => _props = value;
 
-  /// ReactJS `Component` state.
   Map get state => _state;
   set state(Map value) => _state = value;
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -5,14 +5,28 @@
 /// A Dart library for building UI using ReactJS.
 library react;
 
+import 'dart:html';
+
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/top-level-api.html#react.component)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/component-api.html)
 abstract class Component {
-  /// ReactJS `Component` props.
-  Map props;
+  Map _props;
+  Map _state = {};
+  dynamic _ref;
 
-  /// Provides access to the underlying DOM representation of the [render]ed `Component`.
-  dynamic ref;
+  /// ReactJS `Component` props.
+  Map get props => _props;
+  set props(Map value) => _props = value;
+
+  /// ReactJS `Component` state.
+  Map get state => _state;
+  set state(Map value) => _state = value;
+
+  /// Returns the component of the specified [ref].
+  ///
+  /// Returns a [Component] if it is a Dart component, otherwise returns an "Dom component" ([Element]).
+  dynamic get ref => _ref;
+  set ref(dynamic value) => _ref = value;
 
   dynamic _jsRedraw;
 
@@ -56,9 +70,6 @@ abstract class Component {
     // Call `transferComponentState` to get state also to `_prevState`
     transferComponentState();
   }
-
-  /// ReactJS `Component` state.
-  Map state = {};
 
   /// Private reference to the value of [state] from the previous render cycle.
   ///

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -10,22 +10,31 @@ import 'package:react/src/typedefs.dart';
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/react-component.html#reference)
 abstract class Component {
-  /// Currently private since the `@virtual` annotation within the meta package
+  /// A private field that backs [props], which is exposed via getter/setter so
+  /// it can be overridden in strong mode.
+  ///
+  /// Necessary since the `@virtual` annotation within the meta package
   /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
   ///
-  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  /// TODO: Switch back to a plain field once this issue is fixed.
   Map _props;
 
-  /// Currently private since the `@virtual` annotation within the meta package
+  /// A private field that backs [state], which is exposed via getter/setter so
+  /// it can be overridden in strong mode.
+  ///
+  /// Necessary since the `@virtual` annotation within the meta package
   /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
   ///
-  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  /// TODO: Switch back to a plain field once this issue is fixed.
   Map _state = {};
 
-  /// Currently private since the `@virtual` annotation within the meta package
+  /// A private field that backs [ref], which is exposed via getter/setter so
+  /// it can be overridden in strong mode.
+  ///
+  /// Necessary since the `@virtual` annotation within the meta package
   /// [doesn't work for overriding fields](https://github.com/dart-lang/sdk/issues/27452).
   ///
-  /// TODO: Make public once SDK issue / meta package allows field overriding in strong mode.
+  /// TODO: Switch back to a plain field once this issue is fixed.
   Ref _ref;
 
   /// ReactJS [Component] props.
@@ -40,7 +49,7 @@ abstract class Component {
   Map get state => _state;
   set state(Map value) => _state = value;
 
-  /// Returns a component reference.
+  /// A function that returns a component reference:
   ///
   /// * [Component] if it is a Dart component.
   /// * `Element` _(DOM node)_ if it is a React DOM component.

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -16,6 +16,7 @@ import 'package:react/react_client/react_interop.dart';
 import "package:react/react_dom.dart";
 import "package:react/react_dom_server.dart";
 import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
+import 'package:react/src/typedefs.dart';
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory;
 
@@ -167,7 +168,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
       }
     };
 
-    var getRef = (name) {
+    Ref getRef = (name) {
       var ref = getProperty(jsThis.refs, name);
       if (ref == null) return null;
       if (ref is Element) return ref;

--- a/lib/react_test.dart
+++ b/lib/react_test.dart
@@ -5,6 +5,7 @@
 library react_test;
 
 import 'package:react/react.dart';
+import 'package:react/src/typedefs.dart';
 
 class MarkupDescription {
   final String tag;
@@ -29,7 +30,7 @@ _reactDom(String name) {
   };
 }
 
-initializeComponent(Component component, [Map props = const {}, List children, redraw, ref]) {
+initializeComponent(Component component, [Map props = const {}, List children, redraw, Ref ref]) {
   if (redraw == null) redraw = () {};
   var extendedProps = new Map.from(component.getDefaultProps())
     ..addAll(props);

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -1,0 +1,7 @@
+library react.typedefs;
+
+/// Typedef for `react.Component.ref`, which should return one of the following specified by the provided [ref]:
+///
+/// * `react.Component` if it is a Dart component.
+/// * `Element` _(DOM node)_ if it is a React DOM component.
+typedef dynamic Ref(String ref);

--- a/test/child_key_warning_test.dart
+++ b/test/child_key_warning_test.dart
@@ -13,8 +13,8 @@ int _nextFactoryId = 0;
 ///
 /// This prevents React JS from not printing key warnings it deems as "duplicates".
 void renderWithUniqueOwnerName(ReactElement render()) {
-  ReactDartComponentFactoryProxy factory =
-      (react.registerComponent(() => new _OwnerHelperComponent())) as ReactDartComponentFactoryProxy;
+  final factory =
+    react.registerComponent(() => new _OwnerHelperComponent()) as ReactDartComponentFactoryProxy;
   factory.reactClass.displayName = 'OwnerHelperComponent_$_nextFactoryId';
   _nextFactoryId++;
 

--- a/test/child_key_warning_test.dart
+++ b/test/child_key_warning_test.dart
@@ -13,7 +13,8 @@ int _nextFactoryId = 0;
 ///
 /// This prevents React JS from not printing key warnings it deems as "duplicates".
 void renderWithUniqueOwnerName(ReactElement render()) {
-  ReactDartComponentFactoryProxy factory = react.registerComponent(() => new _OwnerHelperComponent());
+  ReactDartComponentFactoryProxy factory =
+      (react.registerComponent(() => new _OwnerHelperComponent())) as ReactDartComponentFactoryProxy;
   factory.reactClass.displayName = 'OwnerHelperComponent_$_nextFactoryId';
   _nextFactoryId++;
 
@@ -128,9 +129,11 @@ void main() {
 
 Function CustomComponent = react.registerComponent(() => new _CustomComponent());
 class _CustomComponent extends react.Component {
+  @override
   render() => react.div({}, []);
 }
 
 class _OwnerHelperComponent extends react.Component {
+  @override
   render() => props['render']();
 }


### PR DESCRIPTION
In order for [`over_react` to become strong mode compliant](https://github.com/Workiva/over_react/issues/14), a few changes are necessary in the wrapper:
1. In `react.Component`: 
   1. Remove public `props` and `state` fields in-favor of private fields with public getters and setters.
      1. This is so that `over_react` can add strong typing to `props` and `state` within `UiComponent` / `UiStatefulComponent`, respectively without generating Dart analyzer errors.
   2. Type the props / state arguments of lifecycle methods as `Map`

I also cleaned up a few analyzer errors showing in this repo as well.

---

**FYA** @greglittlefield-wf @jacehensley-wf @clairesarsam-wf @trentgrover-wf 
