### PR TITLE
Handle IE DataTransfer.dropEffect access failures gracefully

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -551,6 +551,8 @@ SyntheticDataTransfer syntheticDataTransferFactory(events.SyntheticDataTransfer 
     }
   }
   var effectAllowed;
+  var dropEffect;
+
   try {
     // Works around a bug in IE where dragging from outside the browser fails.
     // Trying to access this property throws the error "Unexpected call to method or property access.".
@@ -558,7 +560,16 @@ SyntheticDataTransfer syntheticDataTransferFactory(events.SyntheticDataTransfer 
   } catch (exception) {
     effectAllowed = 'uninitialized';
   }
-  return new SyntheticDataTransfer(dt.dropEffect, effectAllowed, files, types);
+
+  try {
+    // For certain types of drag events in IE (anything but ondragenter, ondragover, and ondrop), this fails.
+    // Trying to access this property throws the error "Unexpected call to method or property access.".
+    dropEffect = dt.dropEffect;
+  } catch (exception) {
+    dropEffect = 'uninitialized';
+  }
+
+  return new SyntheticDataTransfer(dropEffect, effectAllowed, files, types);
 }
 
 /// Wrapper for [SyntheticMouseEvent].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -566,7 +566,7 @@ SyntheticDataTransfer syntheticDataTransferFactory(events.SyntheticDataTransfer 
     // Trying to access this property throws the error "Unexpected call to method or property access.".
     dropEffect = dt.dropEffect;
   } catch (exception) {
-    dropEffect = 'uninitialized';
+    dropEffect = 'none';
   }
 
   return new SyntheticDataTransfer(dropEffect, effectAllowed, files, types);


### PR DESCRIPTION
# Ultimate Problem

In both Internet Explorer 10 and 11, accessing `DataTransfer.dropEffect` throws an exception for some drag event types.

# Solution

Handle `dropEffect` access failures the same way `effectAllowed` failures are handled.

---

Please review @greglittlefield-wf @jacehensley-wf @aaronlademann-wf 