### PR TITLE
Use helpers in package:js/js_util.dart

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -10,8 +10,9 @@ import "dart:collection";
 import "dart:html";
 
 import "package:js/js.dart";
+import 'package:js/js_util.dart' hide jsify;
 import "package:react/react.dart";
-import "package:react/react_client/js_interop_helpers.dart";
+import "package:react/react_client/js_interop_helpers.dart" show jsify;
 import 'package:react/react_client/react_interop.dart';
 import "package:react/react_dom.dart";
 import "package:react/react_dom_server.dart";
@@ -20,7 +21,7 @@ import 'package:react/src/typedefs.dart';
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory;
 
-final EmptyObject emptyJsMap = new EmptyObject();
+final dynamic emptyJsMap = newObject();
 
 /// Type of [children] must be child or list of children, when child is [ReactElement] or [String]
 typedef ReactElement ReactComponentFactory(Map props, [dynamic children]);

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -12,7 +12,7 @@ import "dart:html";
 import "package:js/js.dart";
 import 'package:js/js_util.dart' hide jsify;
 import "package:react/react.dart";
-import "package:react/react_client/js_interop_helpers.dart" show jsify;
+import "package:react/react_client/js_interop_helpers.dart" show jsify, EmptyObject;
 import 'package:react/react_client/react_interop.dart';
 import "package:react/react_dom.dart";
 import "package:react/react_dom_server.dart";
@@ -21,7 +21,8 @@ import 'package:react/src/typedefs.dart';
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory;
 
-final dynamic emptyJsMap = newObject();
+@Deprecated('4.0.0')
+final EmptyObject emptyJsMap = new EmptyObject();
 
 /// Type of [children] must be child or list of children, when child is [ReactElement] or [String]
 typedef ReactElement ReactComponentFactory(Map props, [dynamic children]);
@@ -157,6 +158,8 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
   }
 }
 
+final _emptyJsMap = newObject();
+
 /// The static methods that proxy JS component lifecycle methods to Dart components.
 final ReactDartInteropStatics _dartInteropStatics = (() {
   var zone = Zone.current;
@@ -165,7 +168,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
   void initComponent(ReactComponent jsThis, ReactDartComponentInternal internal, ComponentStatics componentStatics) => zone.run(() {
     var redraw = () {
       if (internal.isMounted) {
-        jsThis.setState(emptyJsMap);
+        jsThis.setState(_emptyJsMap);
       }
     };
 

--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -1,9 +1,13 @@
+/// __Deprecated: use `package:js/js_util.dart` instead.__
+///
 /// Utilities for reading/modifying dynamic keys on JavaScript objects
 /// and converting Dart [Map]s to JavaScript objects.
+@Deprecated('4.0.0')
 @JS()
 library react_client.js_interop_helpers;
 
 import "package:js/js.dart";
+import "package:js/js_util.dart" as js_util;
 
 @JS()
 external dynamic _getProperty(jsObj, String key);
@@ -25,7 +29,8 @@ class _MissingJsMemberError extends Error {
       '_MissingJsMemberError: The JS member `$name` is missing and thus '
       'cannot be used as expected. $message';
 }
-
+/// __Deprecated: use [js_util.getProperty] instead.
+///
 /// Returns the property at the given [_GetPropertyFn.key] on the
 /// specified JavaScript object [_GetPropertyFn.jsObj]
 ///
@@ -33,10 +38,11 @@ class _MissingJsMemberError extends Error {
 /// (see: https://github.com/dart-lang/sdk/issues/25053).
 ///
 /// __Defined in this package's React JS files.__
+@Deprecated('4.0.0')
 final _GetPropertyFn getProperty = (() {
   try {
     // If this throws, then the JS function isn't available.
-    _getProperty(new EmptyObject(), null);
+    _getProperty(js_util.newObject(), null);
   } catch(_) {
     throw new _MissingJsMemberError('_getProperty',
         'Be sure to include React JS files included in this package '
@@ -49,6 +55,8 @@ final _GetPropertyFn getProperty = (() {
   return _getProperty;
 })();
 
+/// __Deprecated: use [js_util.setProperty] instead.
+///
 /// Sets the property at the given [_SetPropertyFn.key] to [_SetPropertyFn.value]
 /// on the specified JavaScript object [_SetPropertyFn.jsObj]
 ///
@@ -56,10 +64,11 @@ final _GetPropertyFn getProperty = (() {
 /// (see: https://github.com/dart-lang/sdk/issues/25053).
 ///
 /// __Defined in this package's React JS files.__
+@Deprecated('4.0.0')
 final _SetPropertyFn setProperty = (() {
   try {
     // If this throws, then the JS function isn't available.
-    _setProperty(new EmptyObject(), null, null);
+    _setProperty(js_util.newObject(), null, null);
   } catch(_) {
     throw new _MissingJsMemberError('_setProperty',
         'Be sure to include React JS files included in this package '
@@ -73,19 +82,25 @@ final _SetPropertyFn setProperty = (() {
 })();
 
 
+/// __Deprecated: use [js_util.newObject] instead.
+///
 /// An interop class for an anonymous JavaScript object, with no properties.
 ///
 /// For use when dealing with dynamic properties via [getProperty]/[setProperty].
 @JS()
 @anonymous
+@Deprecated('4.0.0')
 class EmptyObject {
   external factory EmptyObject();
 }
 
+/// __Deprecated: use [js_util.jsify] instead.
+///
 /// Returns [map] converted to a JavaScript object, similar to
 /// `new JsObject.jsify` in `dart:js`.
 ///
 /// Recursively converts nested [Map]s, and wraps [Function]s with [allowInterop].
+@Deprecated('4.0.0')
 EmptyObject jsify(Map map) {
   var jsMap = new EmptyObject();
 

--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -1,8 +1,5 @@
-/// __Deprecated: use `package:js/js_util.dart` instead.__
-///
 /// Utilities for reading/modifying dynamic keys on JavaScript objects
 /// and converting Dart [Map]s to JavaScript objects.
-@Deprecated('4.0.0')
 @JS()
 library react_client.js_interop_helpers;
 
@@ -94,15 +91,14 @@ class EmptyObject {
   external factory EmptyObject();
 }
 
-/// __Deprecated: use [js_util.jsify] instead.
-///
 /// Returns [map] converted to a JavaScript object, similar to
 /// `new JsObject.jsify` in `dart:js`.
 ///
 /// Recursively converts nested [Map]s, and wraps [Function]s with [allowInterop].
-@Deprecated('4.0.0')
-EmptyObject jsify(Map map) {
-  var jsMap = new EmptyObject();
+///
+/// TODO: deprecate and switch over to using [js_util.jsify]
+dynamic jsify(Map map) {
+  var jsMap = js_util.newObject();
 
   map.forEach((key, value) {
     if (value is Map) {
@@ -111,7 +107,7 @@ EmptyObject jsify(Map map) {
       value = allowInterop(value);
     }
 
-    setProperty(jsMap, key, value);
+    js_util.setProperty(jsMap, key, value);
   });
 
   return jsMap;

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -6,8 +6,9 @@
 library react.test_utils;
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart' hide jsify;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/js_interop_helpers.dart' show jsify;
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/react_test_utils/simulate_wrappers.dart' as simulate_wrappers;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
   browser: '>=0.9.0 <0.11.0'
-  js: '^0.6.0'
+  js: '^0.6.1'
   quiver: '>=0.18.2 <0.23.0'
 dev_dependencies:
   unittest: '>=0.11.0 <0.12.0'

--- a/test/js_interop_helpers_test/js_function_test.dart
+++ b/test/js_interop_helpers_test/js_function_test.dart
@@ -2,6 +2,8 @@
 library js_function_test;
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart' show newObject;
+// TODO: remove in 4.0.0
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:unittest/html_config.dart';
@@ -11,6 +13,7 @@ void main() {
   useHtmlConfiguration();
 
   group('group', () {
+    // TODO: remove in 4.0.0
     group('getProperty', () {
       test('is function that does not throw upon initialization', () {
         expect(() => getProperty, const isInstanceOf<Function>());
@@ -24,6 +27,7 @@ void main() {
       });
     });
 
+    // TODO: remove in 4.0.0
     group('setProperty', () {
       test('is function that does not throw upon initialization', () {
         expect(() => getProperty, const isInstanceOf<Function>());
@@ -42,7 +46,7 @@ void main() {
 
     group('markChildValidated', () {
       test('is function that does not throw when called', () {
-        expect(() => markChildValidated(new EmptyObject()), returnsNormally);
+        expect(() => markChildValidated(newObject()), returnsNormally);
       });
     });
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -4,10 +4,10 @@ library react_test_utils_test;
 import 'dart:html';
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
 import 'package:react/react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_test_utils.dart';
 import 'package:unittest/html_config.dart';
 import 'package:unittest/unittest.dart';
@@ -230,7 +230,7 @@ void main() {
     });
 
     test('returns false argument is not an element', () {
-      expect(isElement(new EmptyObject()), isFalse);
+      expect(isElement(newObject()), isFalse);
     });
   });
 


### PR DESCRIPTION
Deprecate the helpers in `js_interop_helpers.dart` and use the equivalent helpers in `package:js/js_util.dart` instead, now that they're available.

Keep `jsify` around (for now) since it doesn't behave the same as the `package:js` version in regards to nested lists and functions.