### PR TITLE
Remove quiver dependency to slim down dependency tree

### DIFF
--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 
 import 'package:react/react.dart';
 import 'package:react/react_dom_server.dart';
-import 'package:quiver/iterables.dart';
 
 // ReactJS constants needed to create correct checksum
 String _SEPARATOR = '.';
@@ -96,15 +95,18 @@ ReactComponentFactory _reactDom(String name) {
       // If it's not a self-closing tag, add children
       if (!_selfClosingElementTags.contains(name)) {
         if (children is Iterable) {
-          enumerate(children.where((child) => child != null)).forEach((value) {
-            num i = value.index;
-            var component = value.value;
+          var i = 0;
+          for (var component in children) {
+            if (component == null) continue;
+
             if (component is String) {
               result.write(span({}, component)(thisId, i));
             } else {
               result.write(component(thisId, i));
             }
-          });
+
+            i++;
+          }
         } else if (children != null) {
           if (children is String) {
             result.write(_escapeTextForBrowser(children));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,5 @@ environment:
 dependencies:
   browser: '>=0.9.0 <0.11.0'
   js: '^0.6.0'
-  quiver: '>=0.18.2 <0.23.0'
 dev_dependencies:
   test: '^0.12.18+1'


### PR DESCRIPTION
## Problem
quiver is <1.0.0 and breaking changes come more frequently, which requires upkeep of the upper version bound in pubspec.yaml.

Only one utility from quiver is used, so there isn't much benefit to keeping it as a dependency.

## Solution
* Remove quiver dependency
* Replace usage of `enumerate` with equivalent iteration

## Testing
* Verify that `data-reactid` values of siblings increment as just like they do in master in `react_test_server.dart` output:
    ```bash
    pub run example/test/react_test_server.dart | tidy -imq
    ```

    Examples:

    *  `<span data-reactid="foo.bar.0" /> <span data-reactid="foo.bar.1" />` 👍 
    *  `<span data-reactid="foo.baz.$0" /> <span data-reactid="foo.baz.$1" />` 👍 