### PR TITLE
Add support for capturing event handlers

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -439,59 +439,68 @@ _convertEventHandlers(Map args) {
 /// A mapping from event prop keys to their respective event factories.
 ///
 /// Used in [_convertEventHandlers] for efficient event handler conversion.
-const Map<String, Function> _eventPropKeyToEventFactory = const <String, Function>{
-  // SyntheticClipboardEvent
-  'onCopy': syntheticClipboardEventFactory,
-  'onCut': syntheticClipboardEventFactory,
-  'onPaste': syntheticClipboardEventFactory,
+final Map<String, Function> _eventPropKeyToEventFactory = (() {
+  var eventPropKeyToEventFactory = <String, Function>{
+    // SyntheticClipboardEvent
+    'onCopy': syntheticClipboardEventFactory,
+    'onCut': syntheticClipboardEventFactory,
+    'onPaste': syntheticClipboardEventFactory,
 
-  // SyntheticKeyboardEvent
-  'onKeyDown': syntheticKeyboardEventFactory,
-  'onKeyPress': syntheticKeyboardEventFactory,
-  'onKeyUp': syntheticKeyboardEventFactory,
+    // SyntheticKeyboardEvent
+    'onKeyDown': syntheticKeyboardEventFactory,
+    'onKeyPress': syntheticKeyboardEventFactory,
+    'onKeyUp': syntheticKeyboardEventFactory,
 
-  // SyntheticFocusEvent
-  'onFocus': syntheticFocusEventFactory,
-  'onBlur': syntheticFocusEventFactory,
+    // SyntheticFocusEvent
+    'onFocus': syntheticFocusEventFactory,
+    'onBlur': syntheticFocusEventFactory,
 
-  // SyntheticFormEvent
-  'onChange': syntheticFormEventFactory,
-  'onInput': syntheticFormEventFactory,
-  'onSubmit': syntheticFormEventFactory,
-  'onReset': syntheticFormEventFactory,
+    // SyntheticFormEvent
+    'onChange': syntheticFormEventFactory,
+    'onInput': syntheticFormEventFactory,
+    'onSubmit': syntheticFormEventFactory,
+    'onReset': syntheticFormEventFactory,
 
-  // SyntheticMouseEvent
-  'onClick': syntheticMouseEventFactory,
-  'onContextMenu': syntheticMouseEventFactory,
-  'onDoubleClick': syntheticMouseEventFactory,
-  'onDrag': syntheticMouseEventFactory,
-  'onDragEnd': syntheticMouseEventFactory,
-  'onDragEnter': syntheticMouseEventFactory,
-  'onDragExit': syntheticMouseEventFactory,
-  'onDragLeave': syntheticMouseEventFactory,
-  'onDragOver': syntheticMouseEventFactory,
-  'onDragStart': syntheticMouseEventFactory,
-  'onDrop': syntheticMouseEventFactory,
-  'onMouseDown': syntheticMouseEventFactory,
-  'onMouseEnter': syntheticMouseEventFactory,
-  'onMouseLeave': syntheticMouseEventFactory,
-  'onMouseMove': syntheticMouseEventFactory,
-  'onMouseOut': syntheticMouseEventFactory,
-  'onMouseOver': syntheticMouseEventFactory,
-  'onMouseUp': syntheticMouseEventFactory,
+    // SyntheticMouseEvent
+    'onClick': syntheticMouseEventFactory,
+    'onContextMenu': syntheticMouseEventFactory,
+    'onDoubleClick': syntheticMouseEventFactory,
+    'onDrag': syntheticMouseEventFactory,
+    'onDragEnd': syntheticMouseEventFactory,
+    'onDragEnter': syntheticMouseEventFactory,
+    'onDragExit': syntheticMouseEventFactory,
+    'onDragLeave': syntheticMouseEventFactory,
+    'onDragOver': syntheticMouseEventFactory,
+    'onDragStart': syntheticMouseEventFactory,
+    'onDrop': syntheticMouseEventFactory,
+    'onMouseDown': syntheticMouseEventFactory,
+    'onMouseEnter': syntheticMouseEventFactory,
+    'onMouseLeave': syntheticMouseEventFactory,
+    'onMouseMove': syntheticMouseEventFactory,
+    'onMouseOut': syntheticMouseEventFactory,
+    'onMouseOver': syntheticMouseEventFactory,
+    'onMouseUp': syntheticMouseEventFactory,
 
-  // SyntheticTouchEvent
-  'onTouchCancel': syntheticTouchEventFactory,
-  'onTouchEnd': syntheticTouchEventFactory,
-  'onTouchMove': syntheticTouchEventFactory,
-  'onTouchStart': syntheticTouchEventFactory,
+    // SyntheticTouchEvent
+    'onTouchCancel': syntheticTouchEventFactory,
+    'onTouchEnd': syntheticTouchEventFactory,
+    'onTouchMove': syntheticTouchEventFactory,
+    'onTouchStart': syntheticTouchEventFactory,
 
-  // SyntheticUIEvent
-  'onScroll': syntheticUIEventFactory,
+    // SyntheticUIEvent
+    'onScroll': syntheticUIEventFactory,
 
-  // SyntheticWheelEvent
-  'onWheel': syntheticWheelEventFactory,
-};
+    // SyntheticWheelEvent
+    'onWheel': syntheticWheelEventFactory,
+  };
+
+  // Add support for capturing variants; e.g., onClick/onClickCapture
+  for (var key in eventPropKeyToEventFactory.keys.toList()) {
+    eventPropKeyToEventFactory[key + 'Capture'] = eventPropKeyToEventFactory[key];
+  }
+
+  return eventPropKeyToEventFactory;
+})();
 
 /// Wrapper for [SyntheticEvent].
 SyntheticEvent syntheticEventFactory(events.SyntheticEvent e) {


### PR DESCRIPTION
From https://facebook.github.io/react/docs/events.html#supported-events
> To register an event handler for the capture phase, append Capture to the event name; for example, instead of using onClick, you would use onClickCapture to handle the click event in the capture phase.

Added support for this by adding -`Capture` keys to the event handling logic.

Diff best viewed ignoring whitespace: https://github.com/cleandart/react-dart/pull/114/files?w=1