### PR TITLE
Fix memory leak caused by retained `internal` from first render

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -162,11 +162,9 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
 
   /// Wrapper for [Component.getInitialState].
   void initComponent(ReactComponent jsThis, ReactDartComponentInternal internal, ComponentStatics componentStatics) => zone.run(() {
-    var redraw = () {
-      if (internal.isMounted) {
-        jsThis.setState(emptyJsMap);
-      }
-    };
+    void jsRedraw() {
+      jsThis.setState(emptyJsMap);
+    }
 
     Ref getRef = (name) {
       var ref = getProperty(jsThis.refs, name);
@@ -177,7 +175,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     };
 
     Component component = componentStatics.componentFactory()
-        ..initComponentInternal(internal.props, redraw, getRef, jsThis);
+        ..initComponentInternal(internal.props, jsRedraw, getRef, jsThis);
 
     internal.component = component;
     internal.isMounted = false;


### PR DESCRIPTION
## Ultimate Problem

That `ReactDartComponentInternal ` instance from the first render *should* be GC'd in subsequent renders as it's replaced with a new instance.

However, this wasn't happening since it was retained by the `Component._jsRedraw` closure, which hangs around for the lifetime of the component.

This resulted in the props from the initial render of any given component being retained until the component unmounts.

Big thanks to @bencampbell-wf for discovering the presence of a memory leak and creating a reduced test case!

## Solution
- Don't reference `internal` inside that closure

## Testing
Verify via the attached test case that this memory leak has been fixed: [leak_test_case.zip](https://github.com/cleandart/react-dart/files/877003/leak_test_case.zip)

