### PR TITLE
Fix strong mode warning

### DIFF
--- a/lib/react_client/js_interop_helpers.dart
+++ b/lib/react_client/js_interop_helpers.dart
@@ -90,13 +90,16 @@ EmptyObject jsify(Map map) {
   var jsMap = new EmptyObject();
 
   map.forEach((key, value) {
+    var jsValue;
     if (value is Map) {
-      value = jsify(value);
+      jsValue = jsify(value);
     } else if (value is Function) {
-      value = allowInterop(value);
+      jsValue = allowInterop(value);
+    } else {
+      jsValue = value;
     }
 
-    setProperty(jsMap, key, value);
+    setProperty(jsMap, key, jsValue);
   });
 
   return jsMap;


### PR DESCRIPTION
Fix for strong mode warning in js_interop_helpers.

Testing: pull down and verify there are no strong mode warnings.