### PR TITLE
Clear out prevState once componentDidUpdate and callbacks complete

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -99,18 +99,18 @@ abstract class Component {
     transferComponentState();
   }
 
-  /// Private reference to the value of [state] from the previous render cycle.
-  ///
-  /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillUpdate] and [componentDidUpdate].
-  Map _prevState = null;
-
   /// Private reference to the value of [state] for the upcoming render cycle.
   ///
   /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillUpdate] and [componentDidUpdate].
   Map _nextState = null;
 
-  /// Public getter for [_prevState].
-  Map get prevState => _prevState;
+  /// Reference to the value of [state] from the previous render cycle, used internally for proxying
+  /// the ReactJS lifecycle method and [componentDidUpdate].
+  ///
+  /// Not available after [componentDidUpdate] is called.
+  ///
+  /// __DO NOT set__ from anywhere outside react-dart lifecycle internals.
+  Map prevState;
 
   /// Public getter for [_nextState].
   ///
@@ -119,14 +119,14 @@ abstract class Component {
 
   /// Reference to the value of [props] for the upcoming render cycle.
   ///
-  /// Useful for ReactJS lifecycle methods [shouldComponentUpdate], [componentWillReceiveProps], and [componentWillUpdate].
+  /// Used internally for proxying ReactJS lifecycle methods [shouldComponentUpdate], [componentWillReceiveProps], and [componentWillUpdate].
+  ///
+  /// __DO NOT set__ from anywhere outside react-dart lifecycle internals.
   Map nextProps;
 
-  /// Transfers `Component` [_nextState] to [state], and [state] to [_prevState].
-  ///
-  /// This is the only way to set the value of [_prevState].
+  /// Transfers `Component` [_nextState] to [state], and [state] to [prevState].
   void transferComponentState() {
-    _prevState = state;
+    prevState = state;
     if (_nextState != null) {
       state = _nextState;
     }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -197,7 +197,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     internal.component.componentDidMount();
   });
 
-  _getNextProps(Component component, ReactDartComponentInternal nextInternal) {
+  Map _getNextProps(Component component, ReactDartComponentInternal nextInternal) {
     var newProps = nextInternal.props;
     return newProps != null ? new Map.from(newProps) : {};
   }
@@ -206,7 +206,7 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
   /// 2. Update [Component.props] using the value stored to [Component.nextProps]
   ///    in `componentWillReceiveProps`.
   /// 3. Update [Component.state] by calling [Component.transferComponentState]
-  _afterPropsChange(Component component, ReactDartComponentInternal nextInternal) {
+  void _afterPropsChange(Component component, ReactDartComponentInternal nextInternal) {
     // [1]
     nextInternal.component = component;
 
@@ -215,6 +215,10 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
 
     // [3]
     component.transferComponentState();
+  }
+
+  void _clearPrevState(Component component) {
+    component.prevState = null;
   }
 
   void _callSetStateCallbacks(Component component) {
@@ -249,6 +253,8 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
       // If component should not update, update props / transfer state because componentWillUpdate will not be called.
       _afterPropsChange(component, nextInternal);
       _callSetStateCallbacks(component);
+      // Clear out prevState after it's done being used so it's not retained
+      _clearPrevState(component);
       return false;
   }
   });
@@ -268,6 +274,8 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     Component component = internal.component;
     component.componentDidUpdate(prevInternalProps, component.prevState);
     _callSetStateCallbacks(component);
+    // Clear out prevState after it's done being used so it's not retained
+    _clearPrevState(component);
   });
 
   /// Wrapper for [Component.componentWillUnmount].


### PR DESCRIPTION
## Ultimate Problem
A component's previous state values are stored in `_prevState` for use in `componentDidUpdate`.

However, after a state change completes, _prevState hangs around, leaking memory for any previous state values.

## Solution
Clear out `_prevState` after it's no longer needed.

## Testing
- Verify unit tests in CI pass.
- Verify via memory profiling that prevState is no longer leaked:
    - Load a page that renders [this OverReact component](https://gist.github.com/greglittlefield-wf/b6ceed11007f8db708a7eabddf8edb39) in dart2js
    - Perform a Heap Snapshot in Chrome
    - Search for `TestRetainedClass` and verify that no instances show up in the heap, meaning that the values of `prevState` were properly GC'd

## Areas of regression
Component lifecycle (covered by tests)