### PR TITLE
Don't leak internal.component during unmount or rerender

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -299,12 +299,23 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     _callSetStateCallbacks(component);
     // Clear out prevState after it's done being used so it's not retained
     _clearPrevState(component);
+    // Clear the old internal's reference to the component. It won't be used by it anymore,
+    // and we don't want it leaking.
+    // We leave props around so they can be used by `getProps` calls on the old [ReactElement]s.
+    if (prevInternal != internal) {
+      // Only clear if this is a props-triggered update, which is only the case when
+      // the internal objects are different.
+      prevInternal.component = null;
+    }
   });
 
   /// Wrapper for [Component.componentWillUnmount].
   void handleComponentWillUnmount(ReactDartComponentInternal internal) => zone.run(() {
     internal.isMounted = false;
     internal.component.componentWillUnmount();
+    // Clear the reference to the component. It won't be used by it anymore,
+    // and we don't want it leaking.
+    internal.component = null;
   });
 
   /// Wrapper for [Component.render].

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -418,6 +418,47 @@ void main() {
       expect(() => component.setState('Not A Valid Parameter'), throwsArgumentError);
       expect(() => component.setState(5), throwsArgumentError);
     });
+
+    group('clears out the reference to the Dart component in all `internal` instances', () {
+      ReactElement element;
+      Element mountNode;
+      ReactComponent renderedInstance;
+
+      setUp(() {
+        element = SetStateTest({});
+        mountNode = new DivElement();
+        renderedInstance = react_dom.render(element, mountNode);
+
+        expect(renderedInstance.props.internal.component, isNotNull, reason: 'test setup sanity check');
+        expect(element.props.internal.component, isNotNull, reason: 'test setup sanity check');
+      });
+
+      test('when the component is unmounted', () {
+        react_dom.unmountComponentAtNode(mountNode);
+        expect(renderedInstance.props.internal.component, isNull);
+        expect(element.props.internal.component, isNull);
+      });
+
+      group('except for rerenders due to', () {
+        test('props changes', () {
+          renderedInstance = react_dom.render(element, mountNode);
+          expect(renderedInstance.props.internal.component, isNotNull);
+          // We don't care about the `element` in this case, with the current `internal` implementation.
+        });
+
+        test('state changes', () {
+          renderedInstance.props.internal.component.setState({});
+          expect(renderedInstance.props.internal.component, isNotNull);
+          // We don't care about the `element` in this case, with the current `internal` implementation.
+        });
+
+        test('redraws', () {
+          renderedInstance.props.internal.component.redraw();
+          expect(renderedInstance.props.internal.component, isNotNull);
+          // We don't care about the `element` in this case, with the current `internal` implementation.
+        });
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Ultimate Problem
Unmounted component instances were retained by the original `ReactElement`'s props via the `ReactDartComponentInternal` object, which is used to tie the Dart component instance to the JS component instance.

This leak is only known to happens in cases where the same ReactElement is held onto, and conditionally rendered. (example: a tabbable area component that conditionally renders its children). Another example is shown in the testing branch listed below:

## Solution

##### Short-term: 
Null-out references to the component that are no longer needed:
* when the component unmounts
* when the component updates and starts using a new `ReactDartComponentInternal` instance

##### Long-term:
Store Dart component on the JS component instance instead of the props, to ensure that the memory lifecycles of the Dart and JS components are in-sync, and simplify the code so that it's easier to spot issues. (planned for next major version)

## Testing
- Verify that all unit tests pass: `pub run test -p content-shell,chrome`
- Verify that all over_react tests pass when this branch is pulled in:
    ```yaml
    dependency_overrides:
      react:
        git:
          url: git@github.com:greglittlefield-wf/react-dart.git
          ref: c1e7afb3cc8b3276b0c1bf86b09996e76ba3b0df # from dart_component_leak
    ```
- Verify that the memory leak is fixed:
    - Check out test branch: https://github.com/greglittlefield-wf/react-dart/tree/dart_component_leak-test
    - Load `example/leak.html` with the dev tools open and following the instructions in the console

## Areas of Regression
Components and component lifecycle