### PR TITLE
Revert accidental breaking change / (HOTFIX - IMMEDIATE RELEASE)

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -299,23 +299,12 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
     _callSetStateCallbacks(component);
     // Clear out prevState after it's done being used so it's not retained
     _clearPrevState(component);
-    // Clear the old internal's reference to the component. It won't be used by it anymore,
-    // and we don't want it leaking.
-    // We leave props around so they can be used by `getProps` calls on the old [ReactElement]s.
-    if (prevInternal != internal) {
-      // Only clear if this is a props-triggered update, which is only the case when
-      // the internal objects are different.
-      prevInternal.component = null;
-    }
   });
 
   /// Wrapper for [Component.componentWillUnmount].
   void handleComponentWillUnmount(ReactDartComponentInternal internal) => zone.run(() {
     internal.isMounted = false;
     internal.component.componentWillUnmount();
-    // Clear the reference to the component. It won't be used by it anymore,
-    // and we don't want it leaking.
-    internal.component = null;
   });
 
   /// Wrapper for [Component.render].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 3.4.2
+version: 3.4.3
 author: Clean Team <clean@vacuumlabs.com>
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: http://cleandart.github.io/react-dart/

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -418,47 +418,6 @@ void main() {
       expect(() => component.setState('Not A Valid Parameter'), throwsArgumentError);
       expect(() => component.setState(5), throwsArgumentError);
     });
-
-    group('clears out the reference to the Dart component in all `internal` instances', () {
-      ReactElement element;
-      Element mountNode;
-      ReactComponent renderedInstance;
-
-      setUp(() {
-        element = SetStateTest({});
-        mountNode = new DivElement();
-        renderedInstance = react_dom.render(element, mountNode);
-
-        expect(renderedInstance.props.internal.component, isNotNull, reason: 'test setup sanity check');
-        expect(element.props.internal.component, isNotNull, reason: 'test setup sanity check');
-      });
-
-      test('when the component is unmounted', () {
-        react_dom.unmountComponentAtNode(mountNode);
-        expect(renderedInstance.props.internal.component, isNull);
-        expect(element.props.internal.component, isNull);
-      });
-
-      group('except for rerenders due to', () {
-        test('props changes', () {
-          renderedInstance = react_dom.render(element, mountNode);
-          expect(renderedInstance.props.internal.component, isNotNull);
-          // We don't care about the `element` in this case, with the current `internal` implementation.
-        });
-
-        test('state changes', () {
-          renderedInstance.props.internal.component.setState({});
-          expect(renderedInstance.props.internal.component, isNotNull);
-          // We don't care about the `element` in this case, with the current `internal` implementation.
-        });
-
-        test('redraws', () {
-          renderedInstance.props.internal.component.redraw();
-          expect(renderedInstance.props.internal.component, isNotNull);
-          // We don't care about the `element` in this case, with the current `internal` implementation.
-        });
-      });
-    });
   });
 }
 


### PR DESCRIPTION
## Ultimate problem:
#123 broke lifecycle methods where `internal.component` was null when being referenced. _(See #124 for more context)_

## How it was fixed:
Revert.

---

__FYA:__ @jacehensley-wf @greglittlefield-wf @clairesarsam-wf 
__FYI:__ @johncblandii @bencampbell-wf @trentgrover-wf 
