### PR TITLE
Memory leak audit

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -305,6 +305,10 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
   void handleComponentWillUnmount(ReactDartComponentInternal internal) => zone.run(() {
     internal.isMounted = false;
     internal.component.componentWillUnmount();
+    // Clear these callbacks in case they retain anything;
+    // they definitely won't be called after this point.
+    internal.component.setStateCallbacks.clear();
+    internal.component.transactionalSetStateCallbacks.clear();
   });
 
   /// Wrapper for [Component.render].


### PR DESCRIPTION
This PR contains information around a memory leak audit of react-dart, as well as some changes made to reduce the risk of memory leaks.

## Audit Steps performed

Reviewed at-risk areas noted in ticket:
- Event handlers
- Transactional `setState` and `setState` callbacks
- Callback `ref`s
- component lifecycle - `shouldComponentUpdate` usage
- component lifecycle - proxying handler closures

Reviewed all other areas of prod code, including:
- component factory proxies and variadic children
- JS bindings
- `SyntheticEvent`s

Performed tests on [internal_instance_refactor](https://github.com/cleandart/react-dart/tree/internal_instance_refactor) branch (UIP-2492 fix, follow-up to https://github.com/cleandart/react-dart/pull/125), with no memory leaks found:
- Retention of component instances by ReactElements (original UIP-2492 issue)
- Retention of last props
- Retention of last state
- Retention of props after unmount
- Retention of state after unmount

## Issues found / Changes

setState and transactional setState callbacks can be retained when the component unmounts in the middle of a state change.

This isn't a big problem, since those callbacks are added within the component, but it doesn't hurt to clear them since:
- they're not generally expected to outlive the component
- they may contain references to globals

## Testing
Verify unit tests pass: `pub run test -p content-shel`