### PR TITLE
Deprecate soon to be removed (react 4.0.0) ReactDartComponentInternal fields

### DIFF
--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -182,12 +182,18 @@ class InteropProps {
 ///
 /// __For internal/advanced use only.__
 class ReactDartComponentInternal {
+  /// *__Deprecated.__ The component will soon be stored on the JS instance, not this object.*
+  ///
   /// The Dart component instance associated with this JS [ReactComponent].
   ///
   /// Null until the [ReactComponent]'s instantiation.
+  @Deprecated('4.0.0')
   Component component;
 
+  /// *__Deprecated.__ Instead of referencing this, you can track mounted state in an instance variable via component lifecycle methods.*
+  ///
   /// Whether the component is mounted.
+  @Deprecated('4.0.0')
   bool isMounted;
 
   /// For a `ReactElement`, this is the initial props with defaults merged.


### PR DESCRIPTION
These fields, soon to be removed in https://github.com/cleandart/react-dart/pull/127, shouldn't be used by most consumers, but it's good to have a deprecation notice anyways.