### PR TITLE
Release 3.6.0: Allow retrieving the original converted event handlers

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -448,6 +448,24 @@ _convertBoundValues(Map args) {
   }
 }
 
+/// A mapping from converted/wrapped JS handler functions (the result of [_convertEventHandlers])
+/// to the original Dart functions (the input of [_convertEventHandlers]).
+final Expando<Function> _originalEventHandlers = new Expando();
+
+/// Returns the original Dart handler function that, within [_convertEventHandlers],
+/// was converted/wrapped into the function [jsConvertedEventHandler] to be passed to the JS.
+///
+/// Returns `null` if [jsConvertedEventHandler] is `null`.
+///
+/// Returns `null` if [jsConvertedEventHandler] does not represent such a function
+///
+/// Useful for chaining event handlers on DOM or JS composite [ReactElement]s.
+Function unconvertJsEventHandler(Function jsConvertedEventHandler) {
+  if (jsConvertedEventHandler == null) return null;
+
+  return _originalEventHandlers[jsConvertedEventHandler];
+}
+
 /// Convert packed event handler into wrapper and pass it only the Dart [SyntheticEvent] object converted from the
 /// [events.SyntheticEvent] event.
 _convertEventHandlers(Map args) {
@@ -455,9 +473,14 @@ _convertEventHandlers(Map args) {
   args.forEach((propKey, value) {
     var eventFactory = _eventPropKeyToEventFactory[propKey];
     if (eventFactory != null && value != null) {
-      args[propKey] = (events.SyntheticEvent e, [_, __]) => zone.run(() {
+      // Apply allowInterop here so that the function we store in [_originalEventHandlers]
+      // is the same one we'll retrieve from the JS props.
+      var reactDartConvertedEventHandler = allowInterop((events.SyntheticEvent e, [_, __]) => zone.run(() {
         value(eventFactory(e));
-      });
+      }));
+
+      args[propKey] = reactDartConvertedEventHandler;
+      _originalEventHandlers[reactDartConvertedEventHandler] = value;
     }
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,7 @@ dependencies:
   js: '^0.6.0'
 dev_dependencies:
   test: '^0.12.18+1'
+
+transformers:
+- test/pub_serve:
+    $include: test/**_test.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 3.5.0
+version: 3.6.0
 author: Clean Team <clean@vacuumlabs.com>
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: http://cleandart.github.io/react-dart/

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -8,6 +8,8 @@ import 'package:react/react_test_utils.dart' as rtu;
 import 'package:react/react.dart' as react;
 import "package:react/react_client/js_interop_helpers.dart";
 
+import '../util.dart';
+
 void commonFactoryTests(Function factory) {
   _childKeyWarningTests(factory);
 
@@ -95,6 +97,17 @@ void domEventHandlerWrappingTests(Function factory) {
     }));
 
     expect(() => rtu.Simulate.click(react_dom.findDOMNode(renderedInstance)), returnsNormally);
+  });
+  
+  test('stores the original function in a way that it can be retrieved from unconvertJsEventHandler', () {
+    final originalHandler = (event) {};
+
+    var instance = factory({'onClick': originalHandler});
+    var instanceProps = getProps(instance);
+
+    expect(instanceProps['onClick'], isNot(same(originalHandler)),
+        reason: 'test setup sanity check; should be different, converted function');
+    expect(unconvertJsEventHandler(instanceProps['onClick']), same(originalHandler));
   });
 }
 

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -1,0 +1,19 @@
+@TestOn('browser')
+library react_test_utils_test;
+
+import 'package:test/test.dart';
+
+import 'package:react/react_client.dart';
+
+main() {
+  group('unconvertJsEventHandler', () {
+    test('returns null when the input is null', () {
+      var result;
+      expect(() {
+        result = unconvertJsEventHandler(null);
+      }, returnsNormally);
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -1,10 +1,8 @@
 @TestOn('browser')
-@JS()
 library react_test_utils_test;
 
 import 'dart:html';
 
-import 'package:js/js.dart';
 import 'package:react/react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
@@ -13,10 +11,9 @@ import 'package:react/react_test_utils.dart';
 import 'package:test/test.dart';
 
 import 'test_components.dart';
-
+import 'util.dart';
 
 void main() {
-
   setClientConfiguration();
 
   var component;
@@ -30,13 +27,6 @@ void main() {
   group('Shallow Rendering', () {
     ReactElement content;
     ReactShallowRenderer shallowRenderer;
-
-    Map getProps(ReactElement element) {
-      var props = element.props;
-
-      return new Map.fromIterable(_objectKeys(props),
-          value: (key) => getProperty(props, key));
-    }
 
     setUp(() {
       content = sampleComponent({'className': 'test', 'id': 'createRendererTest'});
@@ -295,6 +285,3 @@ void main() {
     expect(react_dom.findDOMNode(spanElements[0]).text, equals(''));
   });
 }
-
-@JS('Object.keys')
-external List _objectKeys(obj);

--- a/test/util.dart
+++ b/test/util.dart
@@ -1,0 +1,15 @@
+@JS()
+library react.test.util;
+
+import 'package:js/js.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
+
+@JS('Object.keys')
+external List _objectKeys(obj);
+
+Map getProps(elementOrComponent) {
+  var props = elementOrComponent.props;
+
+  return new Map.fromIterable(_objectKeys(props),
+      value: (key) => getProperty(props, key));
+}


### PR DESCRIPTION
## Ultimate Problem
When event handlers are added to DOM components, those handlers are converted to functions that proxy the JS events to the Dart event handlers.

Those converted functions are what end up on the `ReactElement` props so that they work when passed to the JS side of React.

However, this causes problems when chaining event handlers that exist on DOM `ReactElement`s, since you need to chain the original Dart function and not the converted JS function.

## Solution
Allow retrieving the original function from converted event handlers via a helper function backed by an Expando.

## Testing
Verify that tests pass in:
- the Dart VM: `pub run test -p content-shell`
- dart2js: `pub run test -p chrome`
- ddc: 
    - In one terminal: `pub serve test --web-compiler=dartdevc`
    - In another: `pub run test -p chrome --pub-serve=8080 -x ddcFailure`