### PR TITLE
AF-364: Support null return from render()

### DIFF
--- a/example/test/false_and_null_test.dart
+++ b/example/test/false_and_null_test.dart
@@ -6,6 +6,10 @@ import 'package:react/react_client.dart';
 
 class _Component extends react.Component {
   render() {
+    if (props['hardCodedNullReturn'] == true) {
+      return null;
+    }
+
     return props['returnValue'];
   }
 }
@@ -16,10 +20,13 @@ void main() {
   setClientConfiguration();
 
   var content = react.div({}, [
-    react.p({}, 'Testing a return value of "null"...'),
+    react.p({}, 'Testing a dynamic return value of "null"...'),
     component({'returnValue': null, 'key': 0}),
+    react.p({}, 'Testing a hard-coded return value of "null"...'),
+    component({'hardCodedNullReturn': true, 'key': 1}),
     react.p({}, 'Testing a return value of "false"...'),
-    component({'returnValue': false, 'key': 1}),
+    component({'returnValue': false, 'key': 2}),
   ]);
+
   react_dom.render(content, querySelector('#content'));
 }

--- a/example/test/false_and_null_test.dart
+++ b/example/test/false_and_null_test.dart
@@ -1,0 +1,25 @@
+import 'dart:html';
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_dom.dart' as react_dom;
+import 'package:react/react_client.dart';
+
+class _Component extends react.Component {
+  render() {
+    return props['returnValue'];
+  }
+}
+
+var component = react.registerComponent(() => new _Component());
+
+void main() {
+  setClientConfiguration();
+
+  var content = react.div({}, [
+    react.p({}, 'Testing a return value of "null"...'),
+    component({'returnValue': null, 'key': 0}),
+    react.p({}, 'Testing a return value of "false"...'),
+    component({'returnValue': false, 'key': 1}),
+  ]);
+  react_dom.render(content, querySelector('#content'));
+}

--- a/example/test/false_and_null_test.html
+++ b/example/test/false_and_null_test.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+
+    <title>React Dart Examples: false and null</title>
+  </head>
+  <body>
+    <div id="content" class="container"></div>
+    <script src="packages/react/react.js"></script>
+    <script src="packages/react/react_dom.js"></script>
+    <script type="application/dart" src="false_and_null_test.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>

--- a/js_src/dart_helpers.js
+++ b/js_src/dart_helpers.js
@@ -33,7 +33,9 @@ function _createReactDartComponentClassConfig(dartInteropStatics, componentStati
       dartInteropStatics.handleComponentWillUnmount(this.dartComponent);
     },
     render: function() {
-      return dartInteropStatics.handleRender(this.dartComponent);
+      var result = dartInteropStatics.handleRender(this.dartComponent);
+      if (typeof result === 'undefined') result = null;
+      return result;
     }
   };
 

--- a/lib/react.js
+++ b/lib/react.js
@@ -4353,7 +4353,9 @@ function _createReactDartComponentClassConfig(dartInteropStatics, componentStati
       dartInteropStatics.handleComponentWillUnmount(this.dartComponent);
     },
     render: function() {
-      return dartInteropStatics.handleRender(this.dartComponent);
+      var result = dartInteropStatics.handleRender(this.dartComponent);
+      if (typeof result === 'undefined') result = null;
+      return result;
     }
   };
 

--- a/lib/react_prod.js
+++ b/lib/react_prod.js
@@ -45,7 +45,9 @@ function _createReactDartComponentClassConfig(dartInteropStatics, componentStati
       dartInteropStatics.handleComponentWillUnmount(this.dartComponent);
     },
     render: function() {
-      return dartInteropStatics.handleRender(this.dartComponent);
+      var result = dartInteropStatics.handleRender(this.dartComponent);
+      if (typeof result === 'undefined') result = null;
+      return result;
     }
   };
 

--- a/lib/react_with_addons.js
+++ b/lib/react_with_addons.js
@@ -5994,7 +5994,9 @@ function _createReactDartComponentClassConfig(dartInteropStatics, componentStati
       dartInteropStatics.handleComponentWillUnmount(this.dartComponent);
     },
     render: function() {
-      return dartInteropStatics.handleRender(this.dartComponent);
+      var result = dartInteropStatics.handleRender(this.dartComponent);
+      if (typeof result === 'undefined') result = null;
+      return result;
     }
   };
 

--- a/lib/react_with_react_dom_prod.js
+++ b/lib/react_with_react_dom_prod.js
@@ -45,7 +45,9 @@ function _createReactDartComponentClassConfig(dartInteropStatics, componentStati
       dartInteropStatics.handleComponentWillUnmount(this.dartComponent);
     },
     render: function() {
-      return dartInteropStatics.handleRender(this.dartComponent);
+      var result = dartInteropStatics.handleRender(this.dartComponent);
+      if (typeof result === 'undefined') result = null;
+      return result;
     }
   };
 


### PR DESCRIPTION
# Ultimate problem

See <https://github.com/dart-lang/sdk/issues/27485>

# Solution

Normalize 'undefined' to 'null' in the js layer of interop.

# How to +10/QA

* Load the new test example (<http://localhost:8080/test/false_and_null_test.html>) in chrome and in dartium. It should execute without throwing exceptions.

---

Please review @greglittlefield-wf @aaronlademann-wf