### PR TITLE
React 4.5.0 finishing touches (Dart 2 Compatibility)

### DIFF
--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:html';
 
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
@@ -266,7 +266,7 @@ class _GeocodesApp extends react.Component {
             // If yes, query was `OK` and `shown_addresses` are replaced
             state['history'][id]['status']='OK';
 
-            var data = jsonDecode(raw);
+            var data = convert.json.decode(raw);
 
             // Calling `setState` will update the state and then repaint the component.
             //

--- a/example/geocodes/geocodes.html
+++ b/example/geocodes/geocodes.html
@@ -34,7 +34,7 @@
     <!-- Load React, your application code and Dart -->
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="geocodes.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="geocodes.dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/call_and_nosuchmethod_test.html
+++ b/example/test/call_and_nosuchmethod_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="call_and_nosuchmethod_test.dart"></script>
+    <script defer src="call_and_nosuchmethod_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/context_test.html
+++ b/example/test/context_test.html
@@ -12,7 +12,6 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="context_test.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script src="context_test.dart.js"></script>
   </body>
 </html>

--- a/example/test/get_dom_node_test.html
+++ b/example/test/get_dom_node_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="get_dom_node_test.dart"></script>
+    <script defer src="get_dom_node_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/order_test.html
+++ b/example/test/order_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="order_test.dart"></script>
+    <script defer src="order_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/react_test.html
+++ b/example/test/react_test.html
@@ -21,8 +21,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="react_test.dart"></script>
+    <script defer src="react_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/ref_test.html
+++ b/example/test/ref_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="ref_test.dart"></script>
+    <script defer src="ref_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/speed_test.html
+++ b/example/test/speed_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="speed_test.dart"></script>
+    <script defer src="speed_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/unmount_test.html
+++ b/example/test/unmount_test.html
@@ -21,8 +21,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="unmount_test.dart"></script>
+    <script defer src="unmount_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -667,7 +667,7 @@ class SyntheticWheelEvent extends SyntheticEvent {
 }
 
 /// Registers [componentFactory] on both client and server.
-ComponentRegistrar registerComponent = (ComponentFactory componentFactory, [Iterable<String> skipMethods]) {
+/*ComponentRegistrar*/Function registerComponent = (/*ComponentFactory*/componentFactory, [/*Iterable<String>*/ skipMethods]) {
   throw new Exception('setClientConfiguration must be called before registerComponent.');
 };
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -376,19 +376,37 @@ abstract class ReactComponentFactoryProxy implements Function {
   /// Returns a new rendered component instance with the specified [props] and [children].
   ///
   /// > The additional children arguments (c2, c3, et. al.) are a workaround for <https://github.com/dart-lang/sdk/issues/16030>.
-  dynamic/*ReactElement*/ call(Map props, [children, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #call && invocation.isMethod) {
-      Map props = invocation.positionalArguments[0];
-      List children = invocation.positionalArguments.sublist(1);
-
-      return build(props, children);
+  dynamic/*ReactElement*/ call(Map props, [c1 = _notSpecified, c2 = _notSpecified, c3 = _notSpecified, c4 = _notSpecified, c5 = _notSpecified, c6 = _notSpecified, c7 = _notSpecified, c8 = _notSpecified, c9 = _notSpecified, c10 = _notSpecified, c11 = _notSpecified, c12 = _notSpecified, c13 = _notSpecified, c14 = _notSpecified, c15 = _notSpecified, c16 = _notSpecified, c17 = _notSpecified, c18 = _notSpecified, c19 = _notSpecified, c20 = _notSpecified, c21 = _notSpecified, c22 = _notSpecified, c23 = _notSpecified, c24 = _notSpecified, c25 = _notSpecified, c26 = _notSpecified, c27 = _notSpecified, c28 = _notSpecified, c29 = _notSpecified, c30 = _notSpecified, c31 = _notSpecified, c32 = _notSpecified, c33 = _notSpecified, c34 = _notSpecified, c35 = _notSpecified, c36 = _notSpecified, c37 = _notSpecified, c38 = _notSpecified, c39 = _notSpecified, c40 = _notSpecified, c41 = _notSpecified, c42 = _notSpecified, c43 = _notSpecified, c44 = _notSpecified, c45 = _notSpecified, c46 = _notSpecified, c47 = _notSpecified, c48 = _notSpecified, c49 = _notSpecified, c50 = _notSpecified, c51 = _notSpecified, c52 = _notSpecified]) {
+    List childArguments;
+    // Use `identical` since it compiles down to `===` in dart2js instead of calling equality helper functions,
+    // and we don't want to allow any object overriding `operator==` to claim it's equal to `_notSpecified`.
+    if (identical(c1, _notSpecified)) {
+      childArguments = [];
+    } else if (identical(c2, _notSpecified)) {
+      childArguments = [c1];
+    } else if (identical(c3, _notSpecified)) {
+      childArguments = [c1, c2];
+    } else if (identical(c4, _notSpecified)) {
+      childArguments = [c1, c2, c3];
+    } else if (identical(c5, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4];
+    } else if (identical(c6, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4, c5];
+    } else if (identical(c7, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4, c5, c6];
+    } else {
+      childArguments = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52]
+        .takeWhile((child) => !identical(child, _notSpecified))
+        .toList();
     }
 
-    return super.noSuchMethod(invocation);
+    return build(props, childArguments);
   }
+}
+
+const _notSpecified = const NotSpecified();
+class NotSpecified {
+  const NotSpecified();
 }
 
 /// A cross-browser wrapper around the browser's [nativeEvent].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -64,7 +64,7 @@ dynamic listifyChildren(dynamic children) {
 }
 
 /// Creates ReactJS [Component] instances for Dart components.
-class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
+class ReactDartComponentFactoryProxy<TComponent extends Component> extends ReactComponentFactoryProxy {
   /// The ReactJS class used as the type for all [ReactElement]s built by
   /// this factory.
   final ReactClass reactClass;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -64,7 +64,7 @@ dynamic listifyChildren(dynamic children) {
 }
 
 /// Creates ReactJS [Component] instances for Dart components.
-class ReactDartComponentFactoryProxy<TComponent extends Component> extends ReactComponentFactoryProxy {
+class ReactDartComponentFactoryProxy extends ReactComponentFactoryProxy {
   /// The ReactJS class used as the type for all [ReactElement]s built by
   /// this factory.
   final ReactClass reactClass;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,5 @@ dev_dependencies:
   build_runner: ">=0.6.0 <1.0.0"
   build_test: ">=0.9.0 <1.0.0"
   build_web_compilers: ">=0.2.0 <1.0.0"
+  dart2_constant: ^1.0.0
   test: ">=0.12.30 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,4 @@ environment:
 dependencies:
   js: ^0.6.0
 dev_dependencies:
-  browser: any
-  test: ^0.12.32+1
-
-transformers:
-- test/pub_serve:
-    $include: test/**_test.dart
+  test: '^0.12.18+1'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 5.0.0-dev.alpha.1
+version: 5.0.0-dev.0
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,11 @@ authors:
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:
-  sdk: '>=2.0.0-dev.0 <=2.0.0-dev.49.0'
+  sdk: '>=1.24.3 <3.0.0'
 dependencies:
   js: ^0.6.0
 dev_dependencies:
-  test: '^0.12.18+1'
+  build_runner: ">=0.6.0 <1.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <1.0.0"
+  test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
Big changes (see commits for full list)

* [x] https://github.com/cleandart/react-dart/pull/149/commits/729a7e6d9b71f17c6b9ffb68852b28c0759aaf78 Make variadic children / `noSuchMethod` dart 2 friendly
* [x] https://github.com/cleandart/react-dart/pull/149/commits/7d0b5cb67cbd17dafd5a797487289f5f4b91ab2b Update deps to utilize dart 2 friendly stuff
* [x] Bump upper SDK bound to `<3.0.0`, lower bound to `>=1.24.3`

### Testing Suggestions

1. Pull this branch
2. Switch to the dart 2 sdk locally, and run `pub get`
    1. Run `pub run build_runner test -- -p vm -p chrome`
    All tests should pass
3. Switch to Dart 1.24.3, and run `pub get`
    1. Run `pub run test -p vm -p content-shell`
    All tests should pass.

---

@greglittlefield-wf @robbecker-wf @evanweible-wf @corwinsheahan-wf