### PR TITLE
Release React 4.5.0 (Dart 2 Compatible!!!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 cache:
   directories:
   - $HOME/.pub-cache
+  - $HOME/.dart_tool
 
 script:
 - dartanalyzer .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ include:
     dart: stable
     script:
       - dartanalyzer .
+      - pub run dependency_validator -i build_runner,build_test,build_web_compilers
       - pub run test -p chrome
       - pub run build_runner test -- -p chrome
   - stage: Dart 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,17 @@ cache:
   - $HOME/.pub-cache
   - $HOME/.dart_tool
 
-include:
-  - stage: Dart 2
-    dart: stable
-    script:
-      - dartanalyzer .
-      - pub run dependency_validator -i build_runner,build_test,build_web_compilers
-      - pub run test -p chrome
-      - pub run build_runner test -- -p chrome
-  - stage: Dart 1
-    dart: 1.24.3
-    script:
-      - dartanalyzer .
-      - pub run test -p chrome
+jobs:
+  include:
+    - stage: Dart 2
+      dart: stable
+      script:
+        - dartanalyzer .
+        - pub run dependency_validator -i build_runner,build_test,build_web_compilers
+        - pub run test -p chrome
+        - pub run build_runner test -- -p chrome
+    - stage: Dart 1
+      dart: 1.24.3
+      script:
+        - dartanalyzer .
+        - pub run test -p chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: dart
 
-dart:
-  - stable
-  - 1.24.3
-
 # Workaround for issue with sandboxed Chrome in containerized Travis builds.
 sudo: required
 addons:
@@ -15,6 +11,15 @@ cache:
   - $HOME/.pub-cache
   - $HOME/.dart_tool
 
-script:
-- dartanalyzer .
-- pub run test -p chrome
+include:
+  - stage: Dart 2
+    dart: stable
+    script:
+      - dartanalyzer .
+      - pub run test -p chrome
+      - pub run build_runner test -- -p chrome
+  - stage: Dart 1
+    dart: 1.24.3
+    script:
+      - dartanalyzer .
+      - pub run test -p chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: dart
+
+dart:
+  - stable
+  - 1.24.3
+
+# Workaround for issue with sandboxed Chrome in containerized Travis builds.
+sudo: required
+addons:
+  chrome: stable
+
+# Re-use downloaded pub packages everywhere.
+cache:
+  directories:
+  - $HOME/.pub-cache
+
+script:
+- dartanalyzer .
+- pub run test -p chrome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [4.5.0](https://github.com/cleandart/react-dart/compare/4.4.2...4.5.0)
+
+- **Improvement:** Dart 2 compatible!

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ pub run test -p chrome
     ```
 2. In another terminal, run the tests, referencing the port the dev compiler is using to serve the test directory:
     ```bash
-    pub run test -p chrome --pub-serve=8090 --exclude-tags=ddcFailure
+    pub run test -p chrome --pub-serve=8090
     ``` 
 
 ### Build JS

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Dart wrapper library for [facebook/react](http://facebook.github.io/)
+# Dart wrapper for [React JS](https://reactjs.org/)
 
 [![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dartlang.org/packages/react)
+![ReactJS v15.6.0](https://img.shields.io/badge/React_JS-v15.6.0-green.svg)
 [![Build Status](https://travis-ci.com/cleandart/react-dart.svg?branch=master)](https://travis-ci.com/cleandart/react-dart)
-[![documentation](https://img.shields.io/badge/Documentation-react-blue.svg)](https://pub.dartlang.org/documentation/react/latest/)
+[![React Dart API Docs](https://img.shields.io/badge/api_docs-react-blue.svg)](https://pub.dartlang.org/documentation/react/latest/)
 
 ## Getting Started
 
@@ -112,7 +113,7 @@ var aButton = button({"onClick": (SyntheticMouseEvent event) => print(event)});
 1. Define custom class that extends Component and implements - at a minimum - `render`.
 
     ```dart
-    // your_component.dart
+    // cool_widget.dart
  
     import 'package:react/react.dart';
     
@@ -121,7 +122,7 @@ var aButton = button({"onClick": (SyntheticMouseEvent event) => print(event)});
     }
     ```
 
-2. Then register the class so React can recognize it.
+2. Then register the class so ReactJS can recognize it.
 
     ```dart
     var CoolWidget = registerComponent(() => new CoolWidgetComponent());
@@ -133,20 +134,19 @@ var aButton = button({"onClick": (SyntheticMouseEvent event) => print(event)});
 
     ```dart
     // app.dart
-    
+
     import 'dart:html';
 
     import 'package:react/react_client.dart' as react_client;
     import 'package:react/react.dart';
     import 'package:react/react_dom.dart' as react_dom;
- 
-    import 'your_component.dart';
+
+    import 'cool_widget.dart';
  
     main() {
       // This should be called once at the beginning of the application.
       react_client.setClientConfiguration();
-    
-    
+
       react_dom.render(CoolWidget({}), querySelector('#react_mount_point'));
     }
     ```
@@ -154,12 +154,15 @@ var aButton = button({"onClick": (SyntheticMouseEvent event) => print(event)});
 #### Custom component with props
 
 ```dart
-// your_component.dart
+// cool_widget.dart
 
 import 'package:react/react.dart';
 
 class CoolWidgetComponent extends Component {
-  render() => div({}, props['text']);
+  @override
+  render() {
+    return div({}, props['text']);
+  }
 }
 
 var CoolWidget = registerComponent(() => new CoolWidgetComponent());
@@ -174,7 +177,7 @@ import 'package:react/react_client.dart' as react_client;
 import 'package:react/react.dart';
 import 'package:react/react_dom.dart' as react_dom;
 
-import 'your_component.dart';
+import 'cool_widget.dart';
 
 main() {
   // This should be called once at the beginning of the application.
@@ -192,98 +195,156 @@ main() {
   makes creating statically-typed React UI components using Dart easy.
 
 ```dart
-typedef MyComponentType({String headline, String text});
+// cool_widget.dart
+typedef CoolWidgetType({String headline, String text, int counter});
 
-var _myComponent = registerComponent(() => new MyComponent());
+var _CoolWidget = registerComponent(() => new CoolWidgetComponent());
 
-MyComponentType myComponent = ({headline, text}) =>
-    _myComponent({'headline':headline, 'text':text});
-
-class MyComponent extends Component {
-  get headline => props['headline'];
-  get text => props['text'];
-  render() =>
-    div({},[
-      h1({}, headline),
-      span({}, text),
-    ]);
+CoolWidgetType CoolWidget({String headline, String text, int counter}) {
+  return _CoolWidget({'headline':headline, 'text':text});
 }
 
+class CoolWidgetComponent extends Component {
+  String get headline => props['headline'];
+  String get text => props['text'];
+  int get counter => props['counter'];
+  
+  @override
+  render() {
+    return div({}, 
+      h1({}, headline),
+      span({}, text),
+      span({}, counter),
+    );
+  }
+}
+```
+
+```dart
+// app.dart
+
+import 'dart:html';
+
+import 'package:react/react_client.dart' as react_client;
+import 'package:react/react.dart';
+import 'package:react/react_dom.dart' as react_dom;
+
+import 'cool_widget.dart';
+
 void main() {
+  // This should be called once at the beginning of the application.
   react_client.setClientConfiguration();
+
   react_dom.render(
-    myComponent(headline: "My custom headline",
-                text: "My custom text"),
-    querySelector('#content')
+    myComponent(
+        headline: "My custom headline",
+        text: "My custom text",
+        counter: 3,
+    ),
+    querySelector('#react_mount_point')
   );
 }
 ```
 
 #### React Component Lifecycle methods
 
-These are quite similar to React life-cycle methods, so refer to React tutorial for further
-explanation/spec. Their signatures in Dart are as:
+The `Component` class mirrors ReactJS' `React.Component` class, and contains all the same methods. 
+
+> See: [ReactJS Lifecycle Method Documentation](https://reactjs.org/docs/react-component.html) for more information.
 
 ```dart
 class MyComponent extends Component {
+  @override
   void componentWillMount() {}
+  
+  @override
   void componentDidMount() {}
-  void componentWillReceiveProps(newProps) {}
-  bool shouldComponentUpdate(nextProps, nextState) => true;
-  void componentWillUpdate(nextProps, nextState) {}
-  void componentDidUpdate(prevProps, prevState) {}
+  
+  @override
+  void componentWillReceiveProps(Map nextProps) {}
+  
+  @override
+  void componentWillUpdate(Map nextProps, Map nextState) {}
+  
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState) {}
+  
+  @override
   void componentWillUnmount() {}
+  
+  @override
+  bool shouldComponentUpdate(Map nextProps, Map nextState) => true;
+  
+  @override
   Map getInitialState() => {};
+  
+  @override
   Map getDefaultProps() => {};
+  
+  @override
   render() => div({}, props['text']);
 }
 ```
 
 #### Using refs and findDOMNode
 
-Proper usage of refs here is a little bit different from usage in react. You can specify
-a ref name in component props and then call ref method to get the referenced element.
-Return values for Dart components, DOM components and JavaScript components are different.
-For a Dart component, you get an instance of the Dart class of the component.
-For primitive components (like DOM elements), you get the DOM node. For JavaScript composite components,
-you get a `ReactElement` representing the react component.
+The use of component `ref`s in react-dart is a bit different from React JS. 
 
-If you want to work with DOM nodes of dart or JS components instead, you can call top level method `findDOMNode` on anything the ref returns.
+* You can specify a ref name in component props and then call ref method to get the referenced element.
+* Return values for Dart components, DOM components and JavaScript components are different.
+    * For a Dart component, you get an instance of the Dart class of the component.
+    * For primitive components (like DOM elements), you get the DOM node. 
+    * For JavaScript composite components, you get a `ReactElement` representing the react component.
+
+If you want to work with DOM nodes of dart or JS components instead, 
+you can call top level `findDOMNode` on anything the ref returns.
 
 ```dart
 var DartComponent = registerComponent(() => new _DartComponent());
 class _DartComponent extends Component {
-  var someData = 11;
+  @override
   render() => div({});
+  
+  void someInstanceMethod(int count) {
+    window.alert('count: $count');
+  }
 }
+
 var ParentComponent = registerComponent(() => new _ParentComponent());
 class _ParentComponent extends Component {
-  render() =>
-    div({},[
-      input({"ref": "input"}),
-      DartComponent({"ref": "dart"})
-    ]);
-  componentDidMount() {
+  @override
+  void componentDidMount() {
     InputElement input = ref("input"); // Returns the DOM node.
+    print(input.value); // Prints "hello" to the console.
 
-    _DartComponent dartRef = ref("dart"); // Returns instance of _DartComponent
-    dartRef.someData; // you can call methods or get values from it
-    react_dom.findDOMNode(dartRef); // return div element rendered from _DartComponent
+    _DartComponent dartComponentRef = ref("dartComponent"); // Returns instance of _DartComponent
+    dartComponentRef.someInstanceMethod(5); // Calls the method defined in _DartComponent
+    react_dom.findDOMNode(dartRef); // Returns div element rendered from _DartComponent
 
-    react_dom.findDOMNode(this); // return root dom element rendered from this component
+    react_dom.findDOMNode(this); // Returns root dom element rendered from this component
+  }
+  
+  @override
+  render() {
+    return div({},
+      input({"ref": "input", "value": "hello"}),
+      DartComponent({"ref": "dartComponent"}),
+    );
   }
 }
 ```
 
 ### Example Application
 
-For more robust example take a look at our [examples](https://github.com/cleandart/react-dart/tree/master/example).
+For more robust examples take a look at our [examples](https://github.com/cleandart/react-dart/tree/master/example).
 
 
 
 ## Unit Testing Utilities
 
-[lib/react_test_utils.dart](lib/react_test_utils.dart) is a Dart wrapper for the [React TestUtils](http://facebook.github.io/react/docs/test-utils.html) library allowing for tests to be made for React components in Dart.
+[lib/react_test_utils.dart](https://github.com/cleandart/react-dart/blob/master/lib/react_test_utils.dart) is a 
+Dart wrapper for the [ReactJS TestUtils](https://reactjs.org/docs/test-utils.html) library allowing for unit tests 
+to be made for React components in Dart.
 
 Here is an example of how to use React TestUtils within a Dart test.
 
@@ -295,12 +356,15 @@ import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 
 class MyTestComponent extends react.Component {
-  getInitialState() => {'text': 'testing...'};
+  @override
+  Map getInitialState() => {'text': 'testing...'};
+  
+  @override
   render() {
-    return react.div({}, [
-        react.button({'onClick': (e) => setState({'text': 'success'})}),
-        react.span({'className': 'spanText'}, state['text'])
-    ]);
+    return react.div({}, 
+        react.button({'onClick': (_) => setState({'text': 'success'})}),
+        react.span({'className': 'spanText'}, state['text']),
+    );
   }
 }
 
@@ -379,7 +443,7 @@ _Or any other browser platform, e.g. `-p firefox`._
     ``` 
     _DDC only works in chrome._
 
-### Build JS
+### Building React JS Source Files
 
 After modifying dart_helpers.js, run:
 

--- a/README.md
+++ b/README.md
@@ -261,19 +261,34 @@ To test the Dart wrapper, take a look at [test/react_test_utils_test.dart](test)
 
 ### Running Tests
 
-#### Dart VM 
+#### Dart 2: dart2js
+
+```bash
+pub run test -p chrome
+```
+_Or any other browser, e.g. `-p firefox`._
+
+#### Dart 2: Dart Dev Compiler ("DDC")
+
+```bash
+pub run build_runner test -- -p chrome
+```
+_DDC only works in chrome._
+
+#### Dart 1: Dart VM
 
 ```bash
 pub run test -p content-shell
 ```
 
-#### dart2js
+#### Dart 1: dart2js
 
 ```bash
 pub run test -p chrome
 ```
+_Or any other browser platform, e.g. `-p firefox`._
 
-#### Dart Dev Compiler ("DDC")
+#### Dart 1: Dart Dev Compiler ("DDC")
 
 1. In one terminal, serve the test directory using the dev compiler:
     ```bash
@@ -283,6 +298,7 @@ pub run test -p chrome
     ```bash
     pub run test -p chrome --pub-serve=8090
     ``` 
+    _DDC only works in chrome._
 
 ### Build JS
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,7 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: true
+    implicit-dynamic: true
 linter:
   rules:
     - await_only_futures

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,7 +1,0 @@
-#
-# `test` package configuration
-#
-
-tags:
-  # tests that fail in ddc
-  ddcFailure:

--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:html';
 
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
@@ -266,7 +266,7 @@ class _GeocodesApp extends react.Component {
             // If yes, query was `OK` and `shown_addresses` are replaced
             state['history'][id]['status']='OK';
 
-            var data = JSON.decode(raw);
+            var data = convert.json.decode(raw);
 
             // Calling `setState` will update the state and then repaint the component.
             //

--- a/example/geocodes/geocodes.html
+++ b/example/geocodes/geocodes.html
@@ -34,7 +34,7 @@
     <!-- Load React, your application code and Dart -->
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="geocodes.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="geocodes.dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/call_and_nosuchmethod_test.html
+++ b/example/test/call_and_nosuchmethod_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="call_and_nosuchmethod_test.dart"></script>
+    <script defer src="call_and_nosuchmethod_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/context_test.html
+++ b/example/test/context_test.html
@@ -12,7 +12,6 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="context_test.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script src="context_test.dart.js"></script>
   </body>
 </html>

--- a/example/test/get_dom_node_test.html
+++ b/example/test/get_dom_node_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="get_dom_node_test.dart"></script>
+    <script defer src="get_dom_node_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/order_test.html
+++ b/example/test/order_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="order_test.dart"></script>
+    <script defer src="order_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/react_test.html
+++ b/example/test/react_test.html
@@ -21,8 +21,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="react_test.dart"></script>
+    <script defer src="react_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import "package:react/react.dart" as react;
-import 'package:react/react_client.dart';
 import "package:react/react_dom.dart" as react_dom;
 
 

--- a/example/test/ref_test.html
+++ b/example/test/ref_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="ref_test.dart"></script>
+    <script defer src="ref_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/speed_test.html
+++ b/example/test/speed_test.html
@@ -14,8 +14,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="speed_test.dart"></script>
+    <script defer src="speed_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/example/test/unmount_test.html
+++ b/example/test/unmount_test.html
@@ -21,8 +21,8 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
-    <script type="application/dart" src="unmount_test.dart"></script>
+    <script defer src="unmount_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
-    <script src="packages/browser/dart.js"></script>
+    
   </body>
 </html>

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -7,6 +7,9 @@ library react;
 
 import 'package:react/src/typedefs.dart';
 
+typedef Component ComponentFactory();
+typedef ReactComponentFactoryProxy ComponentRegistrar(ComponentFactory componentFactory, [Iterable<String> skipMethods]);
+
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
 /// which provides the [ReactJS Component API](https://facebook.github.io/react/docs/react-component.html#reference)
 abstract class Component {
@@ -359,6 +362,36 @@ abstract class Component {
   dynamic render();
 }
 
+/// Creates ReactJS [ReactElement] instances.
+abstract class ReactComponentFactoryProxy implements Function {
+  /// The type of component created by this factory.
+  get type;
+
+  /// Returns a new rendered component instance with the specified [props] and [children].
+  ///
+  /// Necessary to work around DDC `dart.dcall` issues in <https://github.com/dart-lang/sdk/issues/29904>,
+  /// since invoking the function directly doesn't work.
+  dynamic/*ReactElement*/ build(Map props, [List childrenArgs]);
+
+  /// Returns a new rendered component instance with the specified [props] and [children].
+  ///
+  /// We need a concrete implementation of this, as opposed to it just being handled by [noSuchMethod],
+  /// in order to work around DDC issue <https://github.com/dart-lang/sdk/issues/29917>.
+  dynamic/*ReactElement*/ call(Map props, [dynamic children]) => build(props, [children]);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #call && invocation.isMethod) {
+      Map props = invocation.positionalArguments[0];
+      List children = invocation.positionalArguments.sublist(1);
+
+      return build(props, children);
+    }
+
+    return super.noSuchMethod(invocation);
+  }
+}
+
 /// A cross-browser wrapper around the browser's [nativeEvent].
 ///
 /// It has the same interface as the browser's native event, including [stopPropagation] and [preventDefault], except
@@ -617,7 +650,7 @@ class SyntheticWheelEvent extends SyntheticEvent {
 }
 
 /// Registers [componentFactory] on both client and server.
-Function registerComponent = (componentFactory, [skipMethods]) {
+/*ComponentRegistrar*/Function registerComponent = (/*ComponentFactory*/componentFactory, [/*Iterable<String>*/ skipMethods]) {
   throw new Exception('setClientConfiguration must be called before registerComponent.');
 };
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -373,10 +373,10 @@ abstract class ReactComponentFactoryProxy implements Function {
   /// since invoking the function directly doesn't work.
   dynamic/*ReactElement*/ build(Map props, [List childrenArgs]);
 
-  /// Returns a new rendered component instance with the specified [props] and [children].
+  /// Returns a new rendered component instance with the specified [props] and `children` ([c1], [c2], et. al.).
   ///
   /// > The additional children arguments (c2, c3, et. al.) are a workaround for <https://github.com/dart-lang/sdk/issues/16030>.
-  dynamic/*ReactElement*/ call(Map props, [c1 = _notSpecified, c2 = _notSpecified, c3 = _notSpecified, c4 = _notSpecified, c5 = _notSpecified, c6 = _notSpecified, c7 = _notSpecified, c8 = _notSpecified, c9 = _notSpecified, c10 = _notSpecified, c11 = _notSpecified, c12 = _notSpecified, c13 = _notSpecified, c14 = _notSpecified, c15 = _notSpecified, c16 = _notSpecified, c17 = _notSpecified, c18 = _notSpecified, c19 = _notSpecified, c20 = _notSpecified, c21 = _notSpecified, c22 = _notSpecified, c23 = _notSpecified, c24 = _notSpecified, c25 = _notSpecified, c26 = _notSpecified, c27 = _notSpecified, c28 = _notSpecified, c29 = _notSpecified, c30 = _notSpecified, c31 = _notSpecified, c32 = _notSpecified, c33 = _notSpecified, c34 = _notSpecified, c35 = _notSpecified, c36 = _notSpecified, c37 = _notSpecified, c38 = _notSpecified, c39 = _notSpecified, c40 = _notSpecified, c41 = _notSpecified, c42 = _notSpecified, c43 = _notSpecified, c44 = _notSpecified, c45 = _notSpecified, c46 = _notSpecified, c47 = _notSpecified, c48 = _notSpecified, c49 = _notSpecified, c50 = _notSpecified, c51 = _notSpecified, c52 = _notSpecified]) {
+  dynamic/*ReactElement*/ call(Map props, [c1 = _notSpecified, c2 = _notSpecified, c3 = _notSpecified, c4 = _notSpecified, c5 = _notSpecified, c6 = _notSpecified, c7 = _notSpecified, c8 = _notSpecified, c9 = _notSpecified, c10 = _notSpecified, c11 = _notSpecified, c12 = _notSpecified, c13 = _notSpecified, c14 = _notSpecified, c15 = _notSpecified, c16 = _notSpecified, c17 = _notSpecified, c18 = _notSpecified, c19 = _notSpecified, c20 = _notSpecified, c21 = _notSpecified, c22 = _notSpecified, c23 = _notSpecified, c24 = _notSpecified, c25 = _notSpecified, c26 = _notSpecified, c27 = _notSpecified, c28 = _notSpecified, c29 = _notSpecified, c30 = _notSpecified, c31 = _notSpecified, c32 = _notSpecified, c33 = _notSpecified, c34 = _notSpecified, c35 = _notSpecified, c36 = _notSpecified, c37 = _notSpecified, c38 = _notSpecified, c39 = _notSpecified, c40 = _notSpecified]) {
     List childArguments;
     // Use `identical` since it compiles down to `===` in dart2js instead of calling equality helper functions,
     // and we don't want to allow any object overriding `operator==` to claim it's equal to `_notSpecified`.
@@ -395,7 +395,7 @@ abstract class ReactComponentFactoryProxy implements Function {
     } else if (identical(c7, _notSpecified)) {
       childArguments = [c1, c2, c3, c4, c5, c6];
     } else {
-      childArguments = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52]
+      childArguments = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]
         .takeWhile((child) => !identical(child, _notSpecified))
         .toList();
     }

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -362,7 +362,7 @@ abstract class Component {
   dynamic render();
 }
 
-/// Creates ReactJS [ReactElement] instances.
+/// Creates a ReactJS virtual DOM instance (`ReactElement` on the client).
 abstract class ReactComponentFactoryProxy implements Function {
   /// The type of component created by this factory.
   get type;
@@ -375,21 +375,38 @@ abstract class ReactComponentFactoryProxy implements Function {
 
   /// Returns a new rendered component instance with the specified [props] and [children].
   ///
-  /// We need a concrete implementation of this, as opposed to it just being handled by [noSuchMethod],
-  /// in order to work around DDC issue <https://github.com/dart-lang/sdk/issues/29917>.
-  dynamic/*ReactElement*/ call(Map props, [dynamic children]) => build(props, [children]);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #call && invocation.isMethod) {
-      Map props = invocation.positionalArguments[0];
-      List children = invocation.positionalArguments.sublist(1);
-
-      return build(props, children);
+  /// > The additional children arguments (c2, c3, et. al.) are a workaround for <https://github.com/dart-lang/sdk/issues/16030>.
+  dynamic/*ReactElement*/ call(Map props, [c1 = _notSpecified, c2 = _notSpecified, c3 = _notSpecified, c4 = _notSpecified, c5 = _notSpecified, c6 = _notSpecified, c7 = _notSpecified, c8 = _notSpecified, c9 = _notSpecified, c10 = _notSpecified, c11 = _notSpecified, c12 = _notSpecified, c13 = _notSpecified, c14 = _notSpecified, c15 = _notSpecified, c16 = _notSpecified, c17 = _notSpecified, c18 = _notSpecified, c19 = _notSpecified, c20 = _notSpecified, c21 = _notSpecified, c22 = _notSpecified, c23 = _notSpecified, c24 = _notSpecified, c25 = _notSpecified, c26 = _notSpecified, c27 = _notSpecified, c28 = _notSpecified, c29 = _notSpecified, c30 = _notSpecified, c31 = _notSpecified, c32 = _notSpecified, c33 = _notSpecified, c34 = _notSpecified, c35 = _notSpecified, c36 = _notSpecified, c37 = _notSpecified, c38 = _notSpecified, c39 = _notSpecified, c40 = _notSpecified, c41 = _notSpecified, c42 = _notSpecified, c43 = _notSpecified, c44 = _notSpecified, c45 = _notSpecified, c46 = _notSpecified, c47 = _notSpecified, c48 = _notSpecified, c49 = _notSpecified, c50 = _notSpecified, c51 = _notSpecified, c52 = _notSpecified]) {
+    List childArguments;
+    // Use `identical` since it compiles down to `===` in dart2js instead of calling equality helper functions,
+    // and we don't want to allow any object overriding `operator==` to claim it's equal to `_notSpecified`.
+    if (identical(c1, _notSpecified)) {
+      childArguments = [];
+    } else if (identical(c2, _notSpecified)) {
+      childArguments = [c1];
+    } else if (identical(c3, _notSpecified)) {
+      childArguments = [c1, c2];
+    } else if (identical(c4, _notSpecified)) {
+      childArguments = [c1, c2, c3];
+    } else if (identical(c5, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4];
+    } else if (identical(c6, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4, c5];
+    } else if (identical(c7, _notSpecified)) {
+      childArguments = [c1, c2, c3, c4, c5, c6];
+    } else {
+      childArguments = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, c50, c51, c52]
+        .takeWhile((child) => !identical(child, _notSpecified))
+        .toList();
     }
 
-    return super.noSuchMethod(invocation);
+    return build(props, childArguments);
   }
+}
+
+const _notSpecified = const NotSpecified();
+class NotSpecified {
+  const NotSpecified();
 }
 
 /// A cross-browser wrapper around the browser's [nativeEvent].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -21,6 +21,7 @@ import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
+export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 
 final EmptyObject emptyJsMap = new EmptyObject();
 
@@ -43,36 +44,6 @@ typedef Component ComponentFactory();
 ///
 /// See: <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>
 typedef _CallbackRef(componentOrDomNode);
-
-/// Creates ReactJS [ReactElement] instances.
-abstract class ReactComponentFactoryProxy implements Function {
-  /// The type of component created by this factory.
-  get type;
-
-  /// Returns a new rendered component instance with the specified [props] and [children].
-  ///
-  /// Necessary to work around DDC `dart.dcall` issues in <https://github.com/dart-lang/sdk/issues/29904>,
-  /// since invoking the function directly doesn't work.
-  ReactElement build(Map props, [List childrenArgs]);
-
-  /// Returns a new rendered component instance with the specified [props] and [children].
-  ///
-  /// We need a concrete implementation of this, as opposed to it just being handled by [noSuchMethod],
-  /// in order to work around DDC issue <https://github.com/dart-lang/sdk/issues/29917>.
-  ReactElement call(Map props, [dynamic children]) => build(props, [children]);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #call && invocation.isMethod) {
-      Map props = invocation.positionalArguments[0];
-      List children = invocation.positionalArguments.sublist(1);
-
-      return build(props, children);
-    }
-
-    return super.noSuchMethod(invocation);
-  }
-}
 
 /// Prepares [children] to be passed to the ReactJS [React.createElement] and
 /// the Dart [react.Component].

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -38,7 +38,6 @@ final EmptyObject emptyJsMap = new EmptyObject();
 /// > Type of [children] must be child or list of children, when child is [ReactElement] or [String]
 @Deprecated('5.0.0')
 typedef ReactElement ReactComponentFactory(Map props, [dynamic children]);
-typedef Component ComponentFactory();
 
 /// The type of [Component.ref] specified as a callback.
 ///

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -400,9 +400,12 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
     var children = _convertArgsToChildren(childrenArgs);
     children = listifyChildren(children);
 
-    convertProps(props);
+    // We can't mutate the original since we can't be certain that the value of the
+    // the converted event handler will be compatible with the Map's type parameters.
+    var convertibleProps = {}..addAll(props);
+    convertProps(convertibleProps);
 
-    return factory(jsify(props), children);
+    return factory(jsify(convertibleProps), children);
   }
 
   /// Prepares the bound values, event handlers, and style props for consumption by ReactJS DOM components.

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -7,8 +7,7 @@ library react_client.react_interop;
 import 'dart:html';
 
 import 'package:js/js.dart';
-import 'package:react/react.dart' hide ComponentFactory;
-import 'package:react/react_client.dart' show ComponentFactory;
+import 'package:react/react.dart';
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
 
 typedef ReactElement ReactJsComponentFactory(props, children);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -9,6 +9,7 @@ import 'dart:html';
 import 'package:js/js.dart';
 import 'package:react/react.dart' hide ComponentFactory;
 import 'package:react/react_client.dart' show ComponentFactory;
+import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
 
 typedef ReactElement ReactJsComponentFactory(props, children);
 
@@ -26,11 +27,10 @@ abstract class React {
   external static bool isValidElement(dynamic object);
 }
 
-@JS('ReactDOM')
 abstract class ReactDom {
-  external static Element findDOMNode(object);
-  external static ReactComponent render(ReactElement component, Element element);
-  external static bool unmountComponentAtNode(Element element);
+  static Element findDOMNode(object) => ReactDOM.findDOMNode(object);
+  static ReactComponent render(ReactElement component, Element element) => ReactDOM.render(component, element);
+  static bool unmountComponentAtNode(Element element) => ReactDOM.unmountComponentAtNode(element);
 }
 
 @JS('ReactDOMServer')

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -7,7 +7,7 @@ library react_client.react_interop;
 import 'dart:html';
 
 import 'package:js/js.dart';
-import 'package:react/react.dart';
+import 'package:react/react.dart' hide ComponentFactory;
 import 'package:react/react_client.dart' show ComponentFactory;
 
 typedef ReactElement ReactJsComponentFactory(props, children);

--- a/lib/src/react_client/dart2_interop_workaround_bindings.dart
+++ b/lib/src/react_client/dart2_interop_workaround_bindings.dart
@@ -1,0 +1,14 @@
+@JS()
+library react_client.src.dart2_interop_workaround_bindings;
+
+import 'dart:html';
+
+import 'package:js/js.dart';
+import 'package:react/react_client/react_interop.dart';
+
+@JS()
+abstract class ReactDOM {
+  external static Element findDOMNode(object);
+  external static ReactComponent render(ReactElement component, Element element);
+  external static bool unmountComponentAtNode(Element element);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,5 @@ dev_dependencies:
   build_test: ">=0.9.0 <1.0.0"
   build_web_compilers: ">=0.2.0 <1.0.0"
   dart2_constant: ^1.0.0
+  dependency_validator: ^1.2.0
   test: ">=0.12.30 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,12 @@ authors:
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 dependencies:
-  browser: '>=0.9.0 <0.11.0'
-  js: '^0.6.0'
+  js: ^0.6.0
 dev_dependencies:
-  test: '^0.12.18+1'
-
-transformers:
-- test/pub_serve:
-    $include: test/**_test.dart
+  build_runner: ">=0.6.0 <1.0.0"
+  build_test: ">=0.9.0 <1.0.0"
+  build_web_compilers: ">=0.2.0 <1.0.0"
+  dart2_constant: ^1.0.0
+  test: ">=0.12.30 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 4.4.2
+version: 4.5.0
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -10,13 +10,13 @@ import "package:react/react_client/js_interop_helpers.dart";
 
 import '../util.dart';
 
-void commonFactoryTests(Function factory) {
+void commonFactoryTests(ReactComponentFactoryProxy factory) {
   _childKeyWarningTests(factory);
 
   test('renders an instance with the corresponding `type`', () {
     var instance = factory({});
 
-    expect(instance.type, equals((factory as ReactComponentFactoryProxy).type));
+    expect(instance.type, equals(factory.type));
   });
 
   group('passes children to the component when specified as', () {
@@ -59,7 +59,7 @@ void commonFactoryTests(Function factory) {
   });
 }
 
-void domEventHandlerWrappingTests(Function factory) {
+void domEventHandlerWrappingTests(ReactDomComponentFactoryProxy factory) {
   setUpAll(() {
     var called = false;
 
@@ -98,7 +98,7 @@ void domEventHandlerWrappingTests(Function factory) {
 
     expect(() => rtu.Simulate.click(react_dom.findDOMNode(renderedInstance)), returnsNormally);
   });
-  
+
   test('stores the original function in a way that it can be retrieved from unconvertJsEventHandler', () {
     final originalHandler = (event) {};
 

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -21,21 +21,40 @@ void commonFactoryTests(ReactComponentFactoryProxy factory) {
 
   group('passes children to the component when specified as', () {
     dynamic getJsChildren(ReactElement instance) => getProperty(instance.props, 'children');
+    
+    // There are different code paths for 0, 1, 2, 3, 4, 5, 6, and 6+ arguments.
+    // Test all of them.
+    group('a number of variadic children:', () {
+      test('0', () {
+        final instance = factory({});
+        expect(getJsChildren(instance), isNull);
+      });
 
-    test('no arguments', () {
-      var instance = factory({});
-      expect(getJsChildren(instance), isNull);
+      test('1', () {
+        final instance = factory({}, 1);
+        expect(getJsChildren(instance), equals(1));
+      });
+
+      const firstGeneralCaseVariadicChildCount = 2;
+      const maxSupportedVariadicChildCount = 40;
+      for (var i = firstGeneralCaseVariadicChildCount; i < maxSupportedVariadicChildCount; i++) {
+        final childrenCount = i;
+
+        test('$childrenCount', () {
+          final expectedChildren = new List.generate(childrenCount, (i) => i + 1);
+          final arguments = <dynamic>[{}]..add(expectedChildren);
+          final instance = Function.apply(factory, arguments);
+          expect(getJsChildren(instance), expectedChildren);
+        });
+      }
+
+      test('$maxSupportedVariadicChildCount (and passes static analysis)', () {
+        final instance = factory({}, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40);
+        // Generate these instead of hard coding them to ensure the arguments passed into this test match maxSupportedVariadicChildCount
+        final expectedChildren = new List.generate(maxSupportedVariadicChildCount, (i) => i + 1);
+        expect(getJsChildren(instance), equals(expectedChildren));
+      });
     });
-
-    test('a single argument', () {
-      var instance = factory({}, 'single',);
-      expect(getJsChildren(instance), equals('single'));
-    });
-
-    test('multiple arguments', () {
-      var instance = factory({}, 'one', 'two');
-      expect(getJsChildren(instance), equals(['one', 'two']));
-    }, tags: 'ddcFailure'); // This test cannot be run using ddc until https://github.com/dart-lang/sdk/issues/29904 is resolved
 
     test('a List', () {
       var instance = factory({}, ['one', 'two',]);

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -187,7 +187,7 @@ void _childKeyWarningTests(Function factory) {
       );
 
       expect(consoleErrorCalled, isFalse, reason: 'should not have outputted a warning');
-    }, tags: 'ddcFailure'); // This test cannot be run using ddc until https://github.com/dart-lang/sdk/issues/29904 is resolved
+    });
 
     test('when rendering custom Dart components', () {
       _renderWithUniqueOwnerName(() =>

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -164,18 +164,10 @@ void main() {
     expect(getProperty(h1Component, 'tagName'), equals('H1'));
   });
 
-  test('findRenderedComponentWithType (deprecated)', () {
-    component = renderIntoDocument(wrapperComponent({}, [sampleComponent({})]));
-    // ignore: deprecated_member_use
-    var result = findRenderedComponentWithType(component, sampleComponent);
-    // ignore: deprecated_member_use
-    expect(isCompositeComponentWithType(result, sampleComponent), isTrue);
-  });
-
   test('findRenderedComponentWithTypeV2', () {
-    component = renderIntoDocument(wrapperComponent({}, [sampleComponentV2({})]));
-    var result = findRenderedComponentWithTypeV2(component, sampleComponentV2);
-    expect(isCompositeComponentWithTypeV2(result, sampleComponentV2), isTrue);
+    component = renderIntoDocument(wrapperComponent({}, [sampleComponent({})]));
+    var result = findRenderedComponentWithTypeV2(component, sampleComponent);
+    expect(isCompositeComponentWithTypeV2(result, sampleComponent), isTrue);
   });
 
   group('isCompositeComponent', () {
@@ -192,33 +184,17 @@ void main() {
     });
   });
 
-  group('isCompositeComponentWithType (deprecated)', () {
+  group('isCompositeComponentWithTypeV2', () {
     var renderedInstance = renderIntoDocument(sampleComponent({}));
 
     test('returns true when element is a composite component (created with React.createClass()) of the specified type', () {
-      // ignore: deprecated_member_use
-      expect(isCompositeComponentWithType(
+      expect(isCompositeComponentWithTypeV2(
           renderedInstance, sampleComponent), isTrue);
     });
 
     test('returns false when element is not a composite component (created with React.createClass()) of the specified type', () {
-      // ignore: deprecated_member_use
-      expect(isCompositeComponentWithType(
+      expect(isCompositeComponentWithTypeV2(
           renderedInstance, eventComponent), isFalse);
-    });
-  });
-
-  group('isCompositeComponentWithTypeV2', () {
-    var renderedInstance = renderIntoDocument(sampleComponentV2({}));
-
-    test('returns true when element is a composite component (created with React.createClass()) of the specified type', () {
-      expect(isCompositeComponentWithTypeV2(
-          renderedInstance, sampleComponentV2), isTrue);
-    });
-
-    test('returns false when element is not a composite component (created with React.createClass()) of the specified type', () {
-      expect(isCompositeComponentWithTypeV2(
-          renderedInstance, eventComponentV2), isFalse);
     });
   });
 
@@ -245,18 +221,6 @@ void main() {
     });
   });
 
-  group('isElementOfType (deprecated)', () {
-    test('returns true argument is an element of type', () {
-      // ignore: deprecated_member_use
-      expect(isElementOfType(div({}), div as ReactComponentFactoryProxy), isTrue);
-    });
-
-    test('returns false argument is not an element of type', () {
-      // ignore: deprecated_member_use
-      expect(isElementOfType(div({}), span as ReactComponentFactoryProxy), isFalse);
-    });
-  });
-
   group('isElementOfTypeV2', () {
     test('returns true argument is an element of type', () {
       expect(isElementOfTypeV2(div({}), div), isTrue);
@@ -267,29 +231,15 @@ void main() {
     });
   });
 
-  test('scryRenderedComponentsWithType (deprecated)', () {
+  test('scryRenderedComponentsWithTypeV2', () {
     component = renderIntoDocument(wrapperComponent({}, [
         sampleComponent({}), sampleComponent({}), eventComponent({})]));
 
-    // ignore: deprecated_member_use
-    var results = scryRenderedComponentsWithType(component, sampleComponent);
+    var results = scryRenderedComponentsWithTypeV2(component, sampleComponent);
 
     expect(results.length, 2);
-    // ignore: deprecated_member_use
-    expect(isCompositeComponentWithType(results[0], sampleComponent), isTrue);
-    // ignore: deprecated_member_use
-    expect(isCompositeComponentWithType(results[1], sampleComponent), isTrue);
-  });
-
-  test('scryRenderedComponentsWithTypeV2', () {
-    component = renderIntoDocument(wrapperComponentV2({}, [
-        sampleComponentV2({}), sampleComponentV2({}), eventComponentV2({})]));
-
-    var results = scryRenderedComponentsWithTypeV2(component, sampleComponentV2);
-
-    expect(results.length, 2);
-    expect(isCompositeComponentWithTypeV2(results[0], sampleComponentV2), isTrue);
-    expect(isCompositeComponentWithTypeV2(results[1], sampleComponentV2), isTrue);
+    expect(isCompositeComponentWithTypeV2(results[0], sampleComponent), isTrue);
+    expect(isCompositeComponentWithTypeV2(results[1], sampleComponent), isTrue);
   });
 
   test('scryRenderedDOMComponentsWithClass', () {

--- a/test/test_components.dart
+++ b/test/test_components.dart
@@ -1,5 +1,4 @@
 import 'package:react/react.dart';
-import 'package:react/react_client.dart' show ReactComponentFactory, ReactComponentFactoryProxy; // ignore: deprecated_member_use
 
 /// Base component for event handling classes used in test cases.
 class EventComponent extends Component {
@@ -45,9 +44,6 @@ class EventComponent extends Component {
   );
 }
 
-// ignore: deprecated_member_use
-ReactComponentFactory eventComponent = registerComponent(() => new EventComponent()) as ReactComponentFactory;
-
 class SampleComponent extends Component {
   render() => div(props, [
       h1({}, 'A header'),
@@ -57,21 +53,12 @@ class SampleComponent extends Component {
   ]);
 }
 
-// ignore: deprecated_member_use
-ReactComponentFactory sampleComponent = registerComponent(() => new SampleComponent()) as ReactComponentFactory;
-
 class WrapperComponent extends Component {
   render() => div(props, props['children']);
 }
 
-// ignore: deprecated_member_use
-ReactComponentFactory wrapperComponent = registerComponent(() => new WrapperComponent()) as ReactComponentFactory;
+final eventComponent = registerComponent(() => new EventComponent());
 
-final eventComponentV2 = registerComponent(() =>
-    new EventComponent()) as ReactComponentFactoryProxy;
+final sampleComponent = registerComponent(() => new SampleComponent());
 
-final sampleComponentV2 = registerComponent(() =>
-    new SampleComponent()) as ReactComponentFactoryProxy;
-
-final wrapperComponentV2 = registerComponent(() =>
-    new WrapperComponent()) as ReactComponentFactoryProxy;
+final wrapperComponent = registerComponent(() => new WrapperComponent());


### PR DESCRIPTION
## React is now compatible with the Dart 2 SDK! 

### Consumer Consumption Tests

1. [x] __PASSED__ [over_react](https://github.com/Workiva/over_react/pull/191)
2. [x] __PASSED__ [wsd](https://github.com/Workiva/web_skin_dart/pull/1083)
    * _Had to remove usage of deprecated `isCompositeComponentWithType` test utility to get tests to pass using the `1.24.3` SDK + dartdevc compiler_