### PR TITLE
Remove binding for nonexistent SyntheticDataTransfer class

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -621,7 +621,7 @@ SyntheticFormEvent syntheticFormEventFactory(events.SyntheticFormEvent e) {
 }
 
 /// Wrapper for [SyntheticDataTransfer].
-SyntheticDataTransfer syntheticDataTransferFactory(events.SyntheticDataTransfer dt) {
+SyntheticDataTransfer syntheticDataTransferFactory(DataTransfer dt) {
   if (dt == null) return null;
   List<File> files = [];
   if (dt.files != null) {

--- a/lib/src/react_client/synthetic_event_wrappers.dart
+++ b/lib/src/react_client/synthetic_event_wrappers.dart
@@ -61,15 +61,6 @@ class SyntheticFormEvent extends SyntheticEvent {}
 
 @JS()
 @anonymous
-class SyntheticDataTransfer {
-  external String get dropEffect;
-  external String get effectAllowed;
-  external List<File> get files;
-  external List<String> get types;
-}
-
-@JS()
-@anonymous
 class SyntheticMouseEvent extends SyntheticEvent {
   external bool get altKey;
   external num get button;
@@ -77,7 +68,7 @@ class SyntheticMouseEvent extends SyntheticEvent {
   external num get clientX;
   external num get clientY;
   external bool get ctrlKey;
-  external SyntheticDataTransfer get dataTransfer;
+  external DataTransfer get dataTransfer;
   external bool get metaKey;
   external num get pageX;
   external num get pageY;


### PR DESCRIPTION
## Problem
There's no `SyntheticDataTransfer` object in React JS; synthetic JS mouse events get passed the actual `DataTransfer` object.

Having this JS binding and typing the real `DataTransfer` object as it was causing dart2js errors that looked like:

    Warning: 'gJ2' is used reflectively but not in MirrorsUsed. This will break minified code.
    14:38:58.512 react_with_react_dom_prod.js:100 Uncaught Error: NoSuchMethodError: method not found: 'gJ2'

## Solution
Remove the private JS binding, and use the native `DataTransfer` instead.

## Testing
Trigger a react-dart `onClick` handler and verify it doesn't throw in checked mode.

- `pub serve example/test/`
- In both Dartium (checked mode) and Chrome (dart2js)
    - Go to <http://localhost:8080/ref_test.html>
    - Click a button
    - Verify that the button did something and that there are no errors in the console