### PR TITLE
Revert "Remove binding for nonexistent SyntheticDataTransfer class"

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -712,7 +712,7 @@ SyntheticFormEvent syntheticFormEventFactory(events.SyntheticFormEvent e) {
 }
 
 /// Wrapper for [SyntheticDataTransfer].
-SyntheticDataTransfer syntheticDataTransferFactory(DataTransfer dt) {
+SyntheticDataTransfer syntheticDataTransferFactory(events.SyntheticDataTransfer dt) {
   if (dt == null) return null;
   List<File> files = [];
   if (dt.files != null) {

--- a/lib/src/react_client/synthetic_event_wrappers.dart
+++ b/lib/src/react_client/synthetic_event_wrappers.dart
@@ -61,6 +61,15 @@ class SyntheticFormEvent extends SyntheticEvent {}
 
 @JS()
 @anonymous
+class SyntheticDataTransfer {
+  external String get dropEffect;
+  external String get effectAllowed;
+  external List<File> get files;
+  external List<String> get types;
+}
+
+@JS()
+@anonymous
 class SyntheticMouseEvent extends SyntheticEvent {
   external bool get altKey;
   external num get button;
@@ -68,7 +77,7 @@ class SyntheticMouseEvent extends SyntheticEvent {
   external num get clientX;
   external num get clientY;
   external bool get ctrlKey;
-  external DataTransfer get dataTransfer;
+  external SyntheticDataTransfer get dataTransfer;
   external bool get metaKey;
   external num get pageX;
   external num get pageY;


### PR DESCRIPTION
Reverts cleandart/react-dart#151 - it results in some typing errors like so:

```
Unhandled exception:
type 'JSObjectImpl' is not a subtype of type 'DataTransfer' of 'dt' where
JSObjectImpl is from dart:js
DataTransfer is from dart:html
#0      syntheticDataTransferFactory (package:react/react_client.dart:746:65)
#1      syntheticMouseEventFactory (package:react/react_client.dart:784:30)
#2      _convertEventHandlers.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:react/react_client.dart:561:35)
```

This commit had not yet been released, so for the time being (in order to get #153 through) we are going to revert. We can circle back to fix this by finding a way to construct a real DataTransfer object using JS.

@greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf