### PR TITLE
testEvent logic could create false positives

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -530,7 +530,7 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-    props['style'] = _dartifyJsMap(style);
+    props['style'] = _dartifyJsMap<String, dynamic>(style);
   }
 
   return props;
@@ -571,8 +571,8 @@ _convertEventHandlers(Map args) {
 }
 
 /// Returns a Dart Map copy of the JS property key-value pairs in [jsMap].
-Map _dartifyJsMap(jsMap) {
-  return new Map.fromIterable(_objectKeys(jsMap),
+Map<K, V> _dartifyJsMap<K, V>(jsMap) {
+  return new Map<K, V>.fromIterable(_objectKeys(jsMap),
       value: (key) => getProperty(jsMap, key));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 4.6.0
+version: 4.6.1
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>
@@ -12,9 +12,9 @@ environment:
 dependencies:
   js: ^0.6.0
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <2.0.0"
   dart2_constant: ^1.0.0
   dependency_validator: ^1.2.0
   test: ">=0.12.30 <2.0.0"

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -36,6 +36,8 @@ main() {
           'children': testChildren,
         }),
       );
+      expect(unconvertJsProps(instance)['style'],
+          new isInstanceOf<Map<String, dynamic>>());
     });
 
     test('returns props for a composite JS ReactComponent', () {

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -74,12 +74,12 @@ void main() {
 
       test('with React instance as arg', () {
         event(findRenderedDOMComponentWithTag(component, 'div'), eventData);
-        expect(domNode.text, contains('$eventName $fakeTimeStamp'));
+        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
       });
 
       test('with DOM Element as arg', () {
         event(domNode, eventData);
-        expect(domNode.text, contains('$eventName $fakeTimeStamp'));
+        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
       });
     }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -59,17 +59,27 @@ void main() {
       expect(domNode.text, equals(''));
     });
 
-    void testEvent(void event(dynamic instanceOrNode), String eventName) {
+    void testEvent(
+        void event(dynamic instanceOrNode, Map eventData), String eventName) {
       eventName = eventName.toLowerCase();
+      Map eventData;
+      int fakeTimeStamp;
+
+      setUp(() {
+        fakeTimeStamp = eventName.hashCode;
+        eventData = {
+          'timeStamp': fakeTimeStamp,
+        };
+      });
 
       test('with React instance as arg', () {
-        event(findRenderedDOMComponentWithTag(component, 'div'));
-        expect(domNode.text, contains('$eventName'));
+        event(findRenderedDOMComponentWithTag(component, 'div'), eventData);
+        expect(domNode.text, contains('$eventName $fakeTimeStamp'));
       });
 
       test('with DOM Element as arg', () {
-        event(domNode);
-        expect(domNode.text, contains('$eventName'));
+        event(domNode, eventData);
+        expect(domNode.text, contains('$eventName $fakeTimeStamp'));
       });
     }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -60,26 +60,17 @@ void main() {
     });
 
     void testEvent(
-        void event(dynamic instanceOrNode, Map eventData), String eventName) {
-      Map eventData;
-      int fakeTimeStamp;
-
-      setUp(() {
-        fakeTimeStamp = eventName.hashCode;
-        eventData = {
-          'type': eventName,
-          'timeStamp': fakeTimeStamp,
-        };
-      });
+        void event(dynamic instanceOrNode), String eventName) {
+      eventName = eventName.toLowerCase();
 
       test('with React instance as arg', () {
-        event(findRenderedDOMComponentWithTag(component, 'div'), eventData);
-        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
+        event(findRenderedDOMComponentWithTag(component, 'div'));
+        expect(domNode.text, contains('$eventName'));
       });
 
       test('with DOM Element as arg', () {
-        event(domNode, eventData);
-        expect(domNode.text, equals('$eventName $fakeTimeStamp'));
+        event(domNode);
+        expect(domNode.text, contains('$eventName'));
       });
     }
 

--- a/test/react_test_utils_test.dart
+++ b/test/react_test_utils_test.dart
@@ -59,8 +59,7 @@ void main() {
       expect(domNode.text, equals(''));
     });
 
-    void testEvent(
-        void event(dynamic instanceOrNode), String eventName) {
+    void testEvent(void event(dynamic instanceOrNode), String eventName) {
       eventName = eventName.toLowerCase();
 
       test('with React instance as arg', () {


### PR DESCRIPTION
This fixes faulty logic in `testEvent` Tests. Previously the `eventName` supplied to the test was used in `eventData` and would create a false positive because the event name supplied was, in essence, compared to itself, not the actual `eventData`. If the event that was supplied was previously setup to call `onEvent`, would show whatever `eventName` that was provided to the test as `eventData`. Meaning, that the `eventName` comparison would match even if the actual even that fired it was not that event name. This fixes that, using the actual `event.type` as the comparison to the supplied `eventName`.

### Testing
- [ ] CI Passes