### PR TITLE
CPLAT-4447: Type style map as Map<String, dynamic>

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -531,7 +531,7 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-    props['style'] = _dartifyJsMap(style);
+    props['style'] = _dartifyJsMap<String, dynamic>(style);
   }
 
   return props;
@@ -572,8 +572,8 @@ _convertEventHandlers(Map args) {
 }
 
 /// Returns a Dart Map copy of the JS property key-value pairs in [jsMap].
-Map _dartifyJsMap(jsMap) {
-  return new Map.fromIterable(_objectKeys(jsMap),
+Map<K, V> _dartifyJsMap<K, V>(jsMap) {
+  return new Map<K, V>.fromIterable(_objectKeys(jsMap),
       value: (key) => getProperty(jsMap, key));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,9 +12,9 @@ environment:
 dependencies:
   js: ^0.6.0
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <2.0.0"
   dart2_constant: ^1.0.0
   dependency_validator: ^1.2.0
   test: ">=0.12.30 <2.0.0"

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -35,6 +35,8 @@ main() {
           'children': testChildren,
         }),
       );
+      expect(unconvertJsProps(instance)['style'],
+          TypeMatcher<Map<String, dynamic>>());
     });
 
     test('returns props for a composite JS ReactComponent', () {

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -36,7 +36,7 @@ main() {
         }),
       );
       expect(unconvertJsProps(instance)['style'],
-          TypeMatcher<Map<String, dynamic>>());
+          new isInstanceOf<Map<String, dynamic>>());
     });
 
     test('returns props for a composite JS ReactComponent', () {


### PR DESCRIPTION
The typing for the unconverted js map for `style` should be `Map<String, dynamic>`. 