### PR TITLE
CPLAT-4335 Add deprecations in preparation for 5.0.0

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -119,6 +119,14 @@ abstract class Component {
   String get displayName => runtimeType.toString();
 
   /// Bind the value of input to [state[key]].
+  ///
+  /// __DEPRECATED.__
+  ///
+  /// This will be removed in the `6.0.0` release when `Component` is removed.
+  ///
+  /// There is currently no planned support for it within `Component2` which will be released in `5.0.0`
+  /// since there was never a ReactJS analogue for this API.
+  @Deprecated('6.0.0')
   bind(key) => [
         state[key],
         (value) => setState({key: value})

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -56,6 +56,7 @@ abstract class Component {
   /// > It is strongly recommended that you do not use this, and instead wait for `Component2.context`.
   @experimental
   dynamic get context => _context;
+
   /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
   /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
   /// > new version of `Component` called `Component2`.
@@ -84,6 +85,7 @@ abstract class Component {
   /// Until then, use a callback ref instead.
   @Deprecated('6.0.0')
   Ref get ref => _ref;
+
   /// __DEPRECATED.__
   ///
   /// Support for String `ref`s will be removed in the `6.0.0` release when `Component` is removed.

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -214,6 +214,13 @@ abstract class Component {
   Map nextProps;
 
   /// Transfers `Component` [_nextState] to [state], and [state] to [prevState].
+  ///
+  /// > __DEPRECATED.__
+  /// >
+  /// > This was never designed for public consumption, and there will be no replacement implementation in `Component2`.
+  /// >
+  /// > Will be removed in `6.0.0` along with `Component`.
+  @Deprecated('6.0.0')
   void transferComponentState() {
     prevState = state;
     if (_nextState != null) {

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -79,11 +79,21 @@ abstract class Component {
   Map get state => _state;
   set state(Map value) => _state = value;
 
-  /// A function that returns a component reference:
+  /// __DEPRECATED.__
   ///
-  /// * [Component] if it is a Dart component.
-  /// * `Element` _(DOM node)_ if it is a React DOM component.
+  /// Support for String `ref`s will be removed in the `6.0.0` release when `Component` is removed.
+  ///
+  /// There will be new and improved ways to use / set refs in the `5.0.0` release via APIs exposed in `Component2`.
+  /// Until then, use a callback ref instead.
+  @Deprecated('6.0.0')
   Ref get ref => _ref;
+  /// __DEPRECATED.__
+  ///
+  /// Support for String `ref`s will be removed in the `6.0.0` release when `Component` is removed.
+  ///
+  /// There will be new and improved ways to use / set refs in the `5.0.0` release via APIs exposed in `Component2`.
+  /// Until then, use a callback ref instead.
+  @Deprecated('6.0.0')
   set ref(Ref value) => _ref = value;
 
   dynamic _jsRedraw;

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -47,7 +47,24 @@ abstract class Component {
   /// The React context map of this component, passed down from its ancestors' [getChildContext] value.
   ///
   /// Only keys declared in this component's [contextKeys] will be present.
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Map get context => _context;
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   set context(Map value) => _context = value;
 
   /// ReactJS [Component] props.
@@ -126,6 +143,15 @@ abstract class Component {
   /// Private reference to the value of [context] for the upcoming render cycle.
   ///
   /// Useful for ReactJS lifecycle methods [shouldComponentUpdateWithContext] and [componentWillUpdateWithContext].
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Map nextContext;
 
   /// Private reference to the value of [state] for the upcoming render cycle.
@@ -137,6 +163,15 @@ abstract class Component {
   /// the ReactJS lifecycle method.
   ///
   /// __DO NOT set__ from anywhere outside react-dart lifecycle internals.
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Map prevContext;
 
   /// Reference to the value of [state] from the previous render cycle, used internally for proxying
@@ -241,25 +276,17 @@ abstract class Component {
   ///
   /// Calling [setState] within this function will not trigger an additional [render].
   ///
-  /// __Note__: Choose either this method or [componentWillReceivePropsWithContext]. They are both called at the same
-  /// time so using both provides no added benefit.
-  ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillreceiveprops>
   void componentWillReceiveProps(Map newProps) {}
 
-  /// ReactJS lifecycle method that is invoked when a `Component` is receiving [newProps].
-  ///
-  /// This method is not called for the initial [render].
-  ///
-  /// Use this as an opportunity to react to a prop or context transition before [render] is called by updating the
-  /// [state] using [setState]. The old props and context can be accessed via [props] and [context], respectively.
-  ///
-  /// Calling [setState] within this function will not trigger an additional [render].
-  ///
-  /// __Note__: Choose either this method or [componentWillReceiveProps]. They are both called at the same time so using
-  /// both provides no added benefit.
-  ///
-  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillreceiveprops>
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   void componentWillReceivePropsWithContext(Map newProps, nextContext) {}
 
   /// ReactJS lifecycle method that is invoked before rendering when [nextProps] or [nextState] are being received.
@@ -267,22 +294,17 @@ abstract class Component {
   /// Use this as an opportunity to return `false` when you're certain that the transition to the new props and state
   /// will not require a component update.
   ///
-  /// __Note__: This method is called after [shouldComponentUpdateWithContext]. When it returns `null`, the result of
-  /// this method is used, but this is not called if a valid `bool` is returned from [shouldComponentUpdateWithContext].
-  ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#updating-shouldcomponentupdate>
   bool shouldComponentUpdate(Map nextProps, Map nextState) => true;
 
-  /// ReactJS lifecycle method that is invoked before rendering when [nextProps], [nextState], or [nextContext] are
-  /// being received.
-  ///
-  /// Use this as an opportunity to return `false` when you're certain that the transition to the new props, state, and
-  /// context will not require a component update.
-  ///
-  /// __Note__: This method is called before [shouldComponentUpdate]. Returning `null` will defer the update to the
-  /// result of [shouldComponentUpdate], but [shouldComponentUpdate] is not called if a valid `bool` is returned.
-  ///
-  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-shouldcomponentupdate>
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   bool shouldComponentUpdateWithContext(
           Map nextProps, Map nextState, Map nextContext) =>
       null;
@@ -300,17 +322,14 @@ abstract class Component {
   /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillupdate>
   void componentWillUpdate(Map nextProps, Map nextState) {}
 
-  /// ReactJS lifecycle method that is invoked immediately before rendering when [nextProps], [nextState], or
-  /// [nextContext] are being received.
-  ///
-  /// This method is not called for the initial [render].
-  ///
-  /// Use this as an opportunity to perform preparation before an update occurs.
-  ///
-  /// __Note__: Choose either this method or [componentWillUpdate]. They are both called at the same time so using both
-  /// provides no added benefit.
-  ///
-  /// See: <https://facebook.github.io/react/docs/react-component.html#updating-componentwillupdate>
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   void componentWillUpdateWithContext(
       Map nextProps, Map nextState, Map nextContext) {}
 
@@ -335,16 +354,43 @@ abstract class Component {
   /// Returns a Map of context to be passed to descendant components.
   ///
   /// Only keys present in [childContextKeys] will be used; all others will be ignored.
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Map<String, dynamic> getChildContext() => const {};
 
   /// The keys this component uses in its child context map (returned by [getChildContext]).
   ///
   /// __This method is called only once, upon component registration.__
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Iterable<String> get childContextKeys => const [];
 
   /// The keys of context used by this component.
   ///
   /// __This method is called only once, upon component registration.__
+  ///
+  /// > __DEPRECATED - DO NOT USE__
+  /// >
+  /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+  /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+  /// > new version of `Component` called `Component2`.
+  /// >
+  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+  @Deprecated('6.0.0')
   Iterable<String> get contextKeys => const [];
 
   /// Invoked once before the `Component` is mounted. The return value will be used as the initial value of [state].

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -5,6 +5,7 @@
 /// A Dart library for building UI using ReactJS.
 library react;
 
+import 'package:meta/meta.dart';
 import 'package:react/src/typedefs.dart';
 
 typedef Component ComponentFactory();
@@ -48,23 +49,19 @@ abstract class Component {
   ///
   /// Only keys declared in this component's [contextKeys] will be present.
   ///
-  /// > __DEPRECATED - DO NOT USE__
-  /// >
   /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
   /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
   /// > new version of `Component` called `Component2`.
   /// >
-  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
-  @Deprecated('6.0.0')
-  Map get context => _context;
-  /// > __DEPRECATED - DO NOT USE__
-  /// >
+  /// > It is strongly recommended that you do not use this, and instead wait for `Component2.context`.
+  @experimental
+  dynamic get context => _context;
   /// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
   /// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
   /// > new version of `Component` called `Component2`.
   /// >
-  /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
-  @Deprecated('6.0.0')
+  /// > It is strongly recommended that you do not use this, and instead wait for `Component2.context`.
+  @experimental
   set context(Map value) => _context = value;
 
   /// ReactJS [Component] props.

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -234,6 +234,8 @@ abstract class Component {
   /// Optionally accepts a [callback] that gets called after the component updates.
   ///
   /// [A.k.a "forceUpdate"](https://facebook.github.io/react/docs/react-component.html#forceupdate)
+  ///
+  /// TODO: Deprecate in 5.0.0-wip (use `Component2.forceUpdate` instead)
   void redraw([callback()]) {
     setState({}, callback);
   }

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -250,6 +250,11 @@ abstract class Component {
   /// Optionally accepts a callback that gets called after the component updates.
   ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
+  ///
+  /// > __DEPRECATED.__
+  /// >
+  /// > Use [setState] instead.
+  @Deprecated('6.0.0')
   void replaceState(Map newState, [callback()]) {
     Map nextState = newState == null ? {} : new Map.from(newState);
     _nextState = nextState;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -487,6 +487,8 @@ _setValueToProps(Map props, val) {
 }
 
 /// Convert bound values to pure value and packed onChange function
+///
+/// TODO: Remove in 6.0.0 when [Component.bind] is removed.
 _convertBoundValues(Map args) {
   var boundValue = args['value'];
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -155,6 +155,31 @@ class ReactComponent {
   external void setState(state, [callback]);
   external void forceUpdate([callback]);
 
+  /// __DEPRECATED.__
+  ///
+  /// Will be completely removed in the `5.0.0` release.
+  ///
+  /// The analogous JS bits for this were removed in ReactJS 16,
+  /// which the `react` Dart package will be upgrading to in the `5.0.0` release.
+  ///
+  /// Instead, set your own flag within a `Component` instance like so:
+  ///
+  ///     class _SomeComponent extends react.Component {
+  ///       bool _isMounted;
+  ///
+  ///       @override
+  ///       void componentDidMount() {
+  ///         _isMounted = true;
+  ///       }
+  ///
+  ///       @override
+  ///       void componentWillUnmount() {
+  ///         _isMounted = false;
+  ///       }
+  ///     }
+  ///
+  /// And then reference the private flag instead of calling `isMounted()`.
+  @Deprecated('5.0.0')
   external bool isMounted();
 }
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -86,6 +86,7 @@ class ReactClassConfig {
       Function componentDidUpdate,
       Function componentWillUnmount,
       Function getChildContext,
+      @Deprecated('5.0.0')
       Map<String, dynamic> childContextTypes,
       Function getDefaultProps,
       Function getInitialState,
@@ -167,6 +168,15 @@ class ReactComponent {
 /// in a way that's opaque to the JS, and avoids the need to use dart2js interceptors.
 ///
 /// __For internal/advanced use only.__
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+/// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+/// > new version of `Component` called `Component2`.
+/// >
+/// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+@Deprecated('6.0.0')
 @JS()
 @anonymous
 class InteropContextValue {
@@ -210,6 +220,15 @@ class ReactDartComponentInternal {
 /// [Component] instances.
 ///
 /// __For internal/advanced use only.__
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+/// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+/// > new version of `Component` called `Component2`.
+/// >
+/// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+@Deprecated('6.0.0')
 class ReactDartContextInternal {
   final dynamic value;
 
@@ -238,6 +257,8 @@ void markChildrenValidated(List<dynamic> children) {
 /// Returns a new JS [ReactClassConfig] for a component that uses
 /// [dartInteropStatics] and [componentStatics] internally to proxy between
 /// the JS and Dart component instances.
+///
+/// TODO: Deprecate in 5.0.0-wip (use `createReactDartComponentClass` instead)
 @JS('_createReactDartComponentClassConfig')
 external ReactClassConfig createReactDartComponentClassConfig(
     ReactDartInteropStatics dartInteropStatics,
@@ -311,6 +332,15 @@ class ComponentStatics {
 
 /// Additional configuration passed to [createReactDartComponentClassConfig]
 /// that needs to be directly accessible by that JS code.
+///
+/// > __DEPRECATED - DO NOT USE__
+/// >
+/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
+/// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
+/// > new version of `Component` called `Component2`.
+/// >
+/// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+@Deprecated('6.0.0')
 @JS()
 @anonymous
 class JsComponentConfig {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -384,11 +384,13 @@ class ComponentStatics {
 ///
 /// > __DEPRECATED - DO NOT USE__
 /// >
-/// > This API was never stable in any version of ReactJS, and was replaced with a new, incompatible context API
-/// > in ReactJS 16 that will be exposed in version `5.0.0` of the `react` Dart package via a
-/// > new version of `Component` called `Component2`.
+/// > The `context` API that this supports was never stable in any version of ReactJS,
+/// > and was replaced with a new, incompatible context API in ReactJS 16 that will be
+/// > exposed in version `5.0.0` of the `react` Dart package via a new version of
+/// > `Component` called `Component2`.
 /// >
-/// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
+/// > This will be completely removed when the JS side of `context` it is slated for
+/// > removal (ReactJS 17 / react.dart 6.0.0)
 @Deprecated('6.0.0')
 @JS()
 @anonymous

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -36,6 +36,10 @@ abstract class ReactDom {
       ReactDOM.unmountComponentAtNode(element);
 }
 
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 @JS('ReactDOMServer')
 abstract class ReactDomServer {
   external static String renderToString(ReactElement component);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -18,6 +18,7 @@ typedef ReactElement ReactJsComponentFactory(props, children);
 
 @JS()
 abstract class React {
+  @Deprecated('6.0.0')
   external static ReactClass createClass(ReactClassConfig reactClassConfig);
   external static ReactJsComponentFactory createFactory(type);
 
@@ -72,6 +73,11 @@ class ReactClass {
 /// A JS interop class used as an argument to [React.createClass].
 ///
 /// See: <http://facebook.github.io/react/docs/top-level-api.html#react.createclass>.
+///
+/// > __DEPRECATED.__
+/// >
+/// > Will be removed alongside [React.createClass] in the `6.0.0` release.
+@Deprecated('6.0.0')
 @JS()
 @anonymous
 class ReactClassConfig {
@@ -85,9 +91,7 @@ class ReactClassConfig {
       Function componentWillUpdate,
       Function componentDidUpdate,
       Function componentWillUnmount,
-      @Deprecated('6.0.0')
       Function getChildContext,
-      @Deprecated('6.0.0')
       Map<String, dynamic> childContextTypes,
       Function getDefaultProps,
       Function getInitialState,
@@ -284,12 +288,26 @@ void markChildrenValidated(List<dynamic> children) {
 /// [dartInteropStatics] and [componentStatics] internally to proxy between
 /// the JS and Dart component instances.
 ///
-/// TODO: Deprecate in 5.0.0-wip (use `createReactDartComponentClass` instead)
+/// > __DEPRECATED.__
+/// >
+/// > Use [createReactDartComponentClass] instead.
+@Deprecated('5.0.0')
 @JS('_createReactDartComponentClassConfig')
 external ReactClassConfig createReactDartComponentClassConfig(
     ReactDartInteropStatics dartInteropStatics,
     ComponentStatics componentStatics,
     [JsComponentConfig jsConfig]);
+
+/// Returns a new JS [ReactClassConfig] for a component that uses
+/// [dartInteropStatics] and [componentStatics] internally to proxy between
+/// the JS and Dart component instances.
+ReactClass createReactDartComponentClass(
+    ReactDartInteropStatics dartInteropStatics,
+    ComponentStatics componentStatics,
+    [JsComponentConfig jsConfig]) {
+  // TODO: Change this impl to external in 5.0.0, and deprecate it as 6.0.0 removal
+  return React.createClass(createReactDartComponentClassConfig(dartInteropStatics, componentStatics, jsConfig));
+}
 
 typedef Component _InitComponent(
     ReactComponent jsThis,

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -85,8 +85,9 @@ class ReactClassConfig {
       Function componentWillUpdate,
       Function componentDidUpdate,
       Function componentWillUnmount,
+      @Deprecated('6.0.0')
       Function getChildContext,
-      @Deprecated('5.0.0')
+      @Deprecated('6.0.0')
       Map<String, dynamic> childContextTypes,
       Function getDefaultProps,
       Function getInitialState,

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -310,7 +310,8 @@ ReactClass createReactDartComponentClass(
     ComponentStatics componentStatics,
     [JsComponentConfig jsConfig]) {
   // TODO: Change this impl to external in 5.0.0, and deprecate it as 6.0.0 removal
-  return React.createClass(createReactDartComponentClassConfig(dartInteropStatics, componentStatics, jsConfig));
+  return React.createClass(createReactDartComponentClassConfig(
+      dartInteropStatics, componentStatics, jsConfig));
 }
 
 typedef Component _InitComponent(

--- a/lib/react_dom_server.dart
+++ b/lib/react_dom_server.dart
@@ -2,27 +2,28 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// __DEPRECATED.__
+///
+/// This library will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 library react_dom_server;
 
-/// Renders a ReactElement to its initial HTML. This should only be used on the server.
-/// React will return an HTML string. You can use this method to generate HTML on the
-/// server and send the markup down on the initial request for faster page loads and to
-/// allow search engines to crawl your pages for SEO purposes.
-
-/// If you call `ReactDOM.render()` on a node that already has this server-rendered markup,
-/// React will preserve it and only attach event handlers, allowing you to have a very
-/// performant first-load experience.
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 var renderToString;
 
-/// Similar to [renderToString], except this doesn't create extra DOM attributes such as
-/// data-react-id, that React uses internally. This is useful if you want to use React
-/// as a simple static page generator, as stripping away the extra attributes can save
-/// lots of bytes.
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 var renderToStaticMarkup;
 
-/// Sets configuration based on passed functions.
+/// __DEPRECATED.__
 ///
-/// Passes arguments to global variables.
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 setReactDOMServerConfiguration(
     customRenderToString, customRenderToStaticMarkup) {
   renderToString = customRenderToString;

--- a/lib/react_server.dart
+++ b/lib/react_server.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// __DEPRECATED.__
+///
+/// This library will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 library react_server;
 
 import 'dart:math';
@@ -17,8 +21,22 @@ String _CHECKSUM_ATTR_NAME = 'data-react-checksum';
 num _GLOBAL_MOUNT_POINT_MAX = 9999999;
 num _MOD = 65521;
 
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 typedef String OwnerFactory([String ownerId, num position, String key]);
+
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 typedef OwnerFactory ReactComponentFactory(Map props, [dynamic children]);
+
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 typedef Component ComponentFactory();
 
 /// Creates a method that creates a new [Component], runs lifecycle methods and returns the result of the
@@ -403,6 +421,10 @@ _adler32(String data) {
   return (A | B).x;
 }
 
+/// __DEPRECATED.__
+///
+/// Server-side rendering support via APIs in the `react` package will not be maintained beyond the `5.0.0` release.
+@Deprecated('5.0.0')
 void setServerConfiguration() {
   setReactConfiguration(_reactDom, _registerComponent);
   setReactDOMServerConfiguration(

--- a/lib/react_test_utils.dart
+++ b/lib/react_test_utils.dart
@@ -147,6 +147,14 @@ class Simulate {
 /// component.  All methods are used in the same way:
 ///
 ///   SimulateNative.{eventName}(/* [1] */ componentOrNode, [Map] eventData)
+///
+/// > __DEPRECATED.__
+/// >
+/// > Will be completely removed in the `5.0.0` release.
+/// >
+/// > The analogous JS bits for this were removed in ReactJS 16,
+///   which the `react` Dart package will be upgrading to in the `5.0.0` release.
+@Deprecated('5.0.0')
 class SimulateNative {
   static void blur(/* [1] */ componentOrNode, [Map eventData = const {}]) =>
       simulate_wrappers.SimulateNative.blur(componentOrNode, jsify(eventData));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   sdk: '>=1.24.3 <3.0.0'
 dependencies:
   js: ^0.6.0
+  meta: ^1.1.6
 dev_dependencies:
   build_runner: ">=0.6.0 <2.0.0"
   build_test: ">=0.9.0 <2.0.0"


### PR DESCRIPTION
As part of preparations for ReactJS 16 support coming in version 5.0.0, we need to alert consumers to some important deprecations by annotating those deprecated members, and providing comments about what to use instead _(if applicable)_.

### Deprecations:

1. [Legacy `context` APIs](https://github.com/cleandart/react-dart/pull/162/commits/f8cd44a63bba1ba8339f0a6a740411e0accc9189)
1. [`isMounted`](https://github.com/cleandart/react-dart/pull/162/commits/33f4f7508801b1549f8a83a7a0a2b40458256451)
1. [`react_test_utils.SimulateNative`](https://github.com/cleandart/react-dart/pull/162/commits/e5398815df1c0567e18db16caae74341df265758)
1. [String `Component.ref`s](https://github.com/cleandart/react-dart/pull/162/commits/911df628b492e61ebb30b6cda94ab351fb791728)
1. [`Component.replaceState`s](https://github.com/cleandart/react-dart/pull/162/commits/9486382c2744ed9ac2bef6fefe580c985d5e3837)
1. [All aspects of server-side rendering](https://github.com/cleandart/react-dart/pull/162/commits/e259daddc769979226041acfb904af42000cf7ee)
1. [`Component.bind`](https://github.com/cleandart/react-dart/pull/162/commits/e849f4b1e9550e96ea89183c9e3bf49911cce97b)
1. [`Component.transferComponentState`](https://github.com/cleandart/react-dart/pull/162/commits/dd5db69f231df54d1d5b2d3616d2c4caab94c63e)

---

@kealjones-wk @joebingham-wk @greglittlefield-wf 