### PR TITLE
Fix DOM component callback ref regression

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -687,15 +687,14 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
 
     // We can't mutate the original since we can't be certain that the value of the
     // the converted event handler will be compatible with the Map's type parameters.
-    final convertibleProps = new JsBackedMap.from(props);
+    var convertibleProps = new Map.from(props);
     convertProps(convertibleProps);
 
-    return factory(convertibleProps.jsObject, children);
+    return factory(jsify(convertibleProps), children);
   }
 
   /// Prepares the bound values, event handlers, and style props for consumption by ReactJS DOM components.
   static void convertProps(Map props) {
-    _jsifyMapProps(props);
     _convertBoundValues(props);
     _convertEventHandlers(props);
   }
@@ -760,14 +759,6 @@ _convertBoundValues(Map args) {
       }
     };
   }
-}
-
-void _jsifyMapProps(Map map) {
-  map.forEach((key, value) {
-    if (value is Map) {
-      map[key] = jsify(value);
-    }
-  });
 }
 
 /// A mapping from converted/wrapped JS handler functions (the result of [_convertEventHandlers])

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -204,6 +204,24 @@ void domEventHandlerWrappingTests(ReactDomComponentFactoryProxy factory) {
   });
 }
 
+void refTests(ReactComponentFactoryProxy factory,
+    {void verifyCallbackRefValue(dynamic refValue)}) {
+  test('callback refs are called with the correct value', () {
+    var called = false;
+    var refValue;
+
+    rtu.renderIntoDocument(factory({
+      'ref': (ref) {
+        called = true;
+        refValue = ref;
+      }
+    }));
+
+    expect(called, isTrue, reason: 'should have called the callback ref');
+    verifyCallbackRefValue(refValue);
+  });
+}
+
 void _childKeyWarningTests(Function factory) {
   group('key/children validation', () {
     bool consoleErrorCalled;

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -17,11 +17,27 @@ main() {
 
     group('- common factory behavior -', () {
       group('Component -', () {
-        commonFactoryTests(Foo);
+        group('- common factory behavior -', () {
+          commonFactoryTests(Foo);
+        });
+
+        group('- refs -', () {
+          refTests(Foo, verifyCallbackRefValue: (ref) {
+            expect(ref, TypeMatcher<_Foo>());
+          });
+        });
       });
 
       group('Component2 -', () {
-        commonFactoryTests(Foo2);
+        group('- common factory behavior -', () {
+          commonFactoryTests(Foo2);
+        });
+
+        group('- refs -', () {
+          refTests(Foo2, verifyCallbackRefValue: (ref) {
+            expect(ref, TypeMatcher<_Foo2>());
+          });
+        });
       });
 
       group('utils', () {

--- a/test/factory/dom_factory_test.dart
+++ b/test/factory/dom_factory_test.dart
@@ -1,4 +1,6 @@
 @TestOn('browser')
+import 'dart:html';
+
 import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
@@ -16,6 +18,12 @@ main() {
 
     group('- dom event handler wrapping -', () {
       domEventHandlerWrappingTests(react.div);
+    });
+
+    group('- refs -', () {
+      refTests(react.span, verifyCallbackRefValue: (ref) {
+        expect(ref, TypeMatcher<SpanElement>());
+      });
     });
 
     test('has a type corresponding to the DOM tagName', () {


### PR DESCRIPTION
### Problem
DOM callback refs weren't working right in dart2js because they weren't being `allowInterop`'d

This bug was introduced as part of cleanup in the JS map PR.

### Solution
- Revert changes that broke behavior
- Add regression tests for callback refs

### Testing
- Passing CI