### PR TITLE
CPLAT-4764 React16 setState updates

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -106,7 +106,7 @@ abstract class Component {
 
   List<SetStateCallback> _setStateCallbacks = [];
 
-  List<TransactionalSetStateCallback> _transactionalSetStateCallbacks = [];
+  List<StateUpdaterCallback> _transactionalSetStateCallbacks = [];
 
   /// The List of callbacks to be called after the component has been updated from a call to [setState].
   List get setStateCallbacks => _setStateCallbacks;
@@ -254,12 +254,12 @@ abstract class Component {
   /// > __DEPRECATED.__
   /// >
   /// > Note that when migrating to [Component2], [Component2.setState] will only accept a `Map` for [newState].
-  /// > Transactional `setState` calls will have to be changed to utilize [Component2.setStateTransaction].
+  /// > Transactional `setState` calls will have to be changed to utilize [Component2.setStateWithUpdater].
   @Deprecated('6.0.0')
   void setState(covariant dynamic newState, [callback()]) {
     if (newState is Map) {
       _nextState.addAll(newState);
-    } else if (newState is TransactionalSetStateCallback) {
+    } else if (newState is StateUpdaterCallback) {
       _transactionalSetStateCallbacks.add(newState);
     } else if (newState != null) {
       throw new ArgumentError(
@@ -457,8 +457,8 @@ abstract class Component {
 
 abstract class Component2Adapter {
   void setState(Map newState, SetStateCallback callback);
-  void setStateTransaction(
-      TransactionalSetStateCallback stateUpdater, SetStateCallback callback);
+  void setStateWithUpdater(
+      StateUpdaterCallback stateUpdater, SetStateCallback callback);
   void forceUpdate(SetStateCallback callback);
 }
 
@@ -502,7 +502,7 @@ abstract class Component2 implements Component {
   ///
   /// Optionally accepts a [callback] that gets called after the component updates.
   ///
-  /// To use a transactional `setState` callback, check out [setStateTransaction].
+  /// To use a transactional `setState` callback, check out [setStateWithUpdater].
   ///
   /// See: <https://reactjs.org/docs/react-component.html#setstate>
   void setState(Map newState, [SetStateCallback callback]) {
@@ -510,14 +510,14 @@ abstract class Component2 implements Component {
   }
 
   /// Triggers a rerender with new state obtained by shallow-merging
-  /// the return value of [stateUpdater] into the current [state].
+  /// the return value of [updater] into the current [state].
   ///
   /// Optionally accepts a [callback] that gets called after the component updates.
   ///
   /// See: <https://reactjs.org/docs/react-component.html#setstate>
-  void setStateTransaction(TransactionalSetStateCallback stateUpdater,
+  void setStateWithUpdater(StateUpdaterCallback updater,
       [SetStateCallback callback]) {
-    adapter.setStateTransaction(stateUpdater, callback);
+    adapter.setStateWithUpdater(updater, callback);
   }
 
   void forceUpdate([SetStateCallback callback]) {
@@ -760,7 +760,7 @@ abstract class Component2 implements Component {
   Map _state;
 
   @override
-  List<TransactionalSetStateCallback> _transactionalSetStateCallbacks;
+  List<StateUpdaterCallback> _transactionalSetStateCallbacks;
 
   @override
   Map context;
@@ -783,7 +783,7 @@ abstract class Component2 implements Component {
       throw new UnimplementedError();
 
   @override
-  List<TransactionalSetStateCallback> get transactionalSetStateCallbacks =>
+  List<StateUpdaterCallback> get transactionalSetStateCallbacks =>
       throw new UnimplementedError();
 }
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -250,7 +250,13 @@ abstract class Component {
   /// Also allows [newState] to be used as a transactional `setState` callback.
   ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
-  void setState(dynamic newState, [callback()]) {
+  ///
+  /// > __DEPRECATED.__
+  /// >
+  /// > Note that when migrating to [Component2], [Component2.setState] will only accept a `Map` for [newState].
+  /// > Transactional `setState` calls will have to be changed to utilize [Component2.setStateTransaction].
+  @Deprecated('6.0.0')
+  void setState(covariant dynamic newState, [callback()]) {
     if (newState is Map) {
       _nextState.addAll(newState);
     } else if (newState is TransactionalSetStateCallback) {
@@ -450,7 +456,8 @@ abstract class Component {
 }
 
 abstract class Component2Adapter {
-  void setState(dynamic newState, SetStateCallback callback);
+  void setState(Map newState, SetStateCallback callback);
+  void setStateTransaction(TransactionalSetStateCallback stateUpdater, SetStateCallback callback);
   void forceUpdate(SetStateCallback callback);
 }
 
@@ -494,11 +501,21 @@ abstract class Component2 implements Component {
   ///
   /// Optionally accepts a [callback] that gets called after the component updates.
   ///
-  /// Also allows [newState] to be used as a transactional `setState` callback.
+  /// To use a transactional `setState` callback, check out [setStateTransaction].
   ///
-  /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
-  void setState(dynamic newState, [SetStateCallback callback]) {
+  /// See: <https://reactjs.org/docs/react-component.html#setstate>
+  void setState(Map newState, [SetStateCallback callback]) {
     adapter.setState(newState, callback);
+  }
+
+  /// Triggers a rerender with new state obtained by shallow-merging
+  /// the return value of [stateUpdater] into the current [state].
+  ///
+  /// Optionally accepts a [callback] that gets called after the component updates.
+  ///
+  /// See: <https://reactjs.org/docs/react-component.html#setstate>
+  void setStateTransaction(TransactionalSetStateCallback stateUpdater, [SetStateCallback callback]) {
+    adapter.setStateTransaction(stateUpdater, callback);
   }
 
   void forceUpdate([SetStateCallback callback]) {

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -457,7 +457,8 @@ abstract class Component {
 
 abstract class Component2Adapter {
   void setState(Map newState, SetStateCallback callback);
-  void setStateTransaction(TransactionalSetStateCallback stateUpdater, SetStateCallback callback);
+  void setStateTransaction(
+      TransactionalSetStateCallback stateUpdater, SetStateCallback callback);
   void forceUpdate(SetStateCallback callback);
 }
 
@@ -514,7 +515,8 @@ abstract class Component2 implements Component {
   /// Optionally accepts a [callback] that gets called after the component updates.
   ///
   /// See: <https://reactjs.org/docs/react-component.html#setstate>
-  void setStateTransaction(TransactionalSetStateCallback stateUpdater, [SetStateCallback callback]) {
+  void setStateTransaction(TransactionalSetStateCallback stateUpdater,
+      [SetStateCallback callback]) {
     adapter.setStateTransaction(stateUpdater, callback);
   }
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -258,6 +258,9 @@ abstract class Component {
     } else if (newState != null) {
       throw new ArgumentError(
           'setState expects its first parameter to either be a Map or a `TransactionalSetStateCallback`.');
+    } else {
+      // newState is null, so short-circuit to match the ReactJS 16 behavior of not re-rendering the component if newState is null.
+      return;
     }
 
     if (callback != null) _setStateCallbacks.add(callback);

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -467,7 +467,8 @@ class JsComponent2Adapter extends Component2Adapter {
   }
 
   @override
-  void setStateTransaction(TransactionalSetStateCallback stateUpdater, SetStateCallback callback) {
+  void setStateTransaction(
+      TransactionalSetStateCallback stateUpdater, SetStateCallback callback) {
     final firstArg = allowInterop((jsPrevState, jsProps, [_]) {
       return jsBackingMapOrJsCopy(stateUpdater(
         new JsBackedMap.backedBy(jsPrevState),

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -452,6 +452,9 @@ class JsComponent2Adapter extends Component2Adapter {
 
   @override
   void setState(newState, SetStateCallback callback) {
+    // Short-circuit to match the ReactJS 16 behavior of not re-rendering the component if newState is null.
+    if (newState == null) return;
+
     dynamic firstArg;
 
     if (newState is Map) {

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -467,8 +467,8 @@ class JsComponent2Adapter extends Component2Adapter {
   }
 
   @override
-  void setStateTransaction(
-      TransactionalSetStateCallback stateUpdater, SetStateCallback callback) {
+  void setStateWithUpdater(
+      StateUpdaterCallback stateUpdater, SetStateCallback callback) {
     final firstArg = allowInterop((jsPrevState, jsProps, [_]) {
       return jsBackingMapOrJsCopy(stateUpdater(
         new JsBackedMap.backedBy(jsPrevState),

--- a/lib/src/react_client/js_backed_map.dart
+++ b/lib/src/react_client/js_backed_map.dart
@@ -130,8 +130,6 @@ abstract class _Reflect {
 }
 
 JsMap jsBackingMapOrJsCopy(Map other) {
-  other ??= const {};
-
   // todo is it faster to just always do .from?
   if (other is JsBackedMap) {
     return other.jsObject;

--- a/lib/src/react_client/js_backed_map.dart
+++ b/lib/src/react_client/js_backed_map.dart
@@ -130,6 +130,8 @@ abstract class _Reflect {
 }
 
 JsMap jsBackingMapOrJsCopy(Map other) {
+  other ??= const {};
+
   // todo is it faster to just always do .from?
   if (other is JsBackedMap) {
     return other.jsObject;

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -8,10 +8,10 @@ import 'package:react/react.dart';
 /// * `Element` _(DOM node)_ if it is a React DOM component.
 typedef dynamic Ref(String ref);
 
-/// Typedef of a transactional [Component2.setStateTransaction] callback.
+/// Typedef for the `updater` argument of [Component2.setStateWithUpdater].
 ///
 /// See: <https://reactjs.org/docs/react-component.html#setstate>
-typedef Map TransactionalSetStateCallback(Map prevState, Map props);
+typedef Map StateUpdaterCallback(Map prevState, Map props);
 
 /// Typedef of a non-transactional [Component2.setState] callback.
 ///

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -8,12 +8,12 @@ import 'package:react/react.dart';
 /// * `Element` _(DOM node)_ if it is a React DOM component.
 typedef dynamic Ref(String ref);
 
-/// Typedef of a transactional [Component.setState] callback.
+/// Typedef of a transactional [Component2.setStateTransaction] callback.
 ///
-/// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
+/// See: <https://reactjs.org/docs/react-component.html#setstate>
 typedef Map TransactionalSetStateCallback(Map prevState, Map props);
 
-/// Typedef of a non-transactional [Component.setState] callback.
+/// Typedef of a non-transactional [Component2.setState] callback.
 ///
-/// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
+/// See: <https://reactjs.org/docs/react-component.html#setstate>
 typedef SetStateCallback();

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -858,6 +858,17 @@ void sharedLifecycleTests<T extends react.Component>({
       });
     }
 
+    test('calling setState does not update the component when the value passed is null', () {
+      var mountNode = new DivElement();
+      var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
+      LifecycleTestHelper component = getDartComponent(renderedInstance);
+      component.lifecycleCalls.clear();
+
+      component.callSetStateWithNullValue();
+
+      expect(component.lifecycleCalls, isEmpty);
+    });
+
     group(
         'calls the setState callback, and transactional setState callback in the correct order',
         () {

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -39,7 +39,8 @@ main() {
           'throws when setState is called with something other than a Map or Function that accepts two parameters',
           () {
         var mountNode = new DivElement();
-        var renderedInstance = react_dom.render(components.SetStateTest({}), mountNode);
+        var renderedInstance =
+            react_dom.render(components.SetStateTest({}), mountNode);
         LifecycleTestHelper component = getDartComponent(renderedInstance);
 
         expect(() => component.setState(new Map()), returnsNormally);
@@ -78,7 +79,8 @@ main() {
           expectedState1 = {}..addAll(initialState)..addAll(newState1);
           expectedState2 = {}..addAll(expectedState1)..addAll(newState2);
 
-          component = getDartComponent(render(components.LifecycleTest(initialProps)));
+          component =
+              getDartComponent(render(components.LifecycleTest(initialProps)));
           component.lifecycleCalls.clear();
         });
 
@@ -916,7 +918,9 @@ void sharedLifecycleTests<T extends react.Component>({
       });
     }
 
-    test('calling setState does not update the component when the value passed is null', () {
+    test(
+        'calling setState does not update the component when the value passed is null',
+        () {
       var mountNode = new DivElement();
       var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
       LifecycleTestHelper component = getDartComponent(renderedInstance);

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -34,6 +34,93 @@ main() {
         LifecycleTestWithContext: components.LifecycleTestWithContext,
         LifecycleTest: components.LifecycleTest,
       );
+
+      test(
+          'throws when setState is called with something other than a Map or Function that accepts two parameters',
+          () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(components.SetStateTest({}), mountNode);
+        LifecycleTestHelper component = getDartComponent(renderedInstance);
+
+        expect(() => component.setState(new Map()), returnsNormally);
+        expect(
+            () => component.setState((_, __) {
+                  return {};
+                }),
+            returnsNormally);
+        expect(() => component.setState(null), returnsNormally);
+
+        expect(() => component.setState('Not A Valid Parameter'),
+            throwsArgumentError);
+        expect(() => component.setState(5), throwsArgumentError);
+      });
+
+      group('prevents concurrent modification of `_setStateCallbacks`', () {
+        LifecycleTestHelper component;
+        const Map initialState = const {
+          'initialState': 'initial',
+        };
+        int firstStateUpdateCalls;
+        int secondStateUpdateCalls;
+        Map initialProps;
+        Map newState1;
+        Map expectedState1;
+        Map newState2;
+        Map expectedState2;
+
+        setUp(() {
+          firstStateUpdateCalls = 0;
+          secondStateUpdateCalls = 0;
+          initialProps =
+              unmodifiableMap({'getInitialState': (_) => initialState});
+          newState1 = {'foo': 'bar'};
+          newState2 = {'baz': 'foobar'};
+          expectedState1 = {}..addAll(initialState)..addAll(newState1);
+          expectedState2 = {}..addAll(expectedState1)..addAll(newState2);
+
+          component = getDartComponent(render(components.LifecycleTest(initialProps)));
+          component.lifecycleCalls.clear();
+        });
+
+        tearDown(() {
+          component?.lifecycleCalls?.clear();
+          component = null;
+          initialProps = null;
+          newState1 = null;
+          expectedState1 = null;
+          newState2 = null;
+          expectedState2 = null;
+        });
+
+        test(
+            'when `replaceState` is called from within another `replaceState` callback',
+            () {
+          void handleSecondStateUpdate() {
+            secondStateUpdateCalls++;
+            expect(component.state, newState2);
+          }
+
+          void handleFirstStateUpdate() {
+            firstStateUpdateCalls++;
+            expect(component.state, newState1);
+            component.replaceState(
+                newState2, Zone.current.bindCallback(handleSecondStateUpdate));
+          }
+
+          component.replaceState(
+              newState1, Zone.current.bindCallback(handleFirstStateUpdate));
+
+          expect(firstStateUpdateCalls, 1);
+          expect(secondStateUpdateCalls, 1);
+
+          expect(
+              component.lifecycleCalls,
+              containsAllInOrder([
+                matchCall('componentWillUpdate', args: [anything, newState1]),
+                matchCall('componentWillUpdate', args: [anything, newState2]),
+              ]));
+        });
+      });
     });
 
     group('Component2', () {
@@ -553,35 +640,6 @@ void sharedLifecycleTests<T extends react.Component>({
                   args: [anything, expectedState2]),
             ]));
       });
-
-      test(
-          'when `replaceState` is called from within another `replaceState` callback',
-          () {
-        void handleSecondStateUpdate() {
-          secondStateUpdateCalls++;
-          expect(component.state, newState2);
-        }
-
-        void handleFirstStateUpdate() {
-          firstStateUpdateCalls++;
-          expect(component.state, newState1);
-          component.replaceState(
-              newState2, Zone.current.bindCallback(handleSecondStateUpdate));
-        }
-
-        component.replaceState(
-            newState1, Zone.current.bindCallback(handleFirstStateUpdate));
-
-        expect(firstStateUpdateCalls, 1);
-        expect(secondStateUpdateCalls, 1);
-
-        expect(
-            component.lifecycleCalls,
-            containsAllInOrder([
-              matchCall('componentWillUpdate', args: [anything, newState1]),
-              matchCall('componentWillUpdate', args: [anything, newState2]),
-            ]));
-      }, skip: 'replaceState is deprecated');
     });
 
     test('properly handles a call to setState within componentWillReceiveProps',
@@ -909,26 +967,6 @@ void sharedLifecycleTests<T extends react.Component>({
         expect(renderedNode.children.first.text, '3');
         expect(renderedNode.children.first.text, getUpdatingRenderedCounter());
       });
-    });
-
-    test(
-        'throws when setState is called with something other than a Map or Function that accepts two parameters',
-        () {
-      var mountNode = new DivElement();
-      var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
-      LifecycleTestHelper component = getDartComponent(renderedInstance);
-
-      expect(() => component.setState(new Map()), returnsNormally);
-      expect(
-          () => component.setState((_, __) {
-                return {};
-              }),
-          returnsNormally);
-      expect(() => component.setState(null), returnsNormally);
-
-      expect(() => component.setState('Not A Valid Parameter'),
-          throwsArgumentError);
-      expect(() => component.setState(5), throwsArgumentError);
     });
   });
 }

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -7,7 +7,7 @@ import 'package:react/react_client.dart';
 
 import 'util.dart';
 
-ReactDartComponentFactoryProxy SetStateTest =
+ReactDartComponentFactoryProxy2 SetStateTest =
     react.registerComponent(() => new _SetStateTest());
 
 class _SetStateTest extends react.Component2 with LifecycleTestHelper {
@@ -43,12 +43,12 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
     return props['shouldUpdate'] as bool;
   }
 
-  Map outerTransactionalSetStateCallback(previousState, __) {
+  Map outerTransactionalSetStateCallback(Map previousState, __) {
     recordLifecyleCall('outerTransactionalSetStateCallback');
     return {'counter': previousState['counter'] + 1};
   }
 
-  Map innerTransactionalSetStateCallback(previousState, __) {
+  Map innerTransactionalSetStateCallback(Map previousState, __) {
     recordLifecyleCall('innerTransactionalSetStateCallback');
     return {'counter': previousState['counter'] + 1};
   }
@@ -64,14 +64,14 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
     return react.div(
         {
           'onClick': (_) {
-            setState(outerTransactionalSetStateCallback, () {
+            setStateTransaction(outerTransactionalSetStateCallback, () {
               recordLifecyleCall('outerSetStateCallback');
             });
           }
         },
         react.div({
           'onClick': (_) {
-            setState(innerTransactionalSetStateCallback, () {
+            setStateTransaction(innerTransactionalSetStateCallback, () {
               recordLifecyleCall('innerSetStateCallback');
             });
           }
@@ -100,7 +100,7 @@ class _DefaultPropsCachingTest extends react.Component2
   render() => false;
 }
 
-ReactDartComponentFactoryProxy DefaultPropsTest =
+ReactDartComponentFactoryProxy2 DefaultPropsTest =
     react.registerComponent(() => new _DefaultPropsTest());
 
 class _DefaultPropsTest extends react.Component2 {
@@ -111,7 +111,7 @@ class _DefaultPropsTest extends react.Component2 {
   render() => false;
 }
 
-ReactDartComponentFactoryProxy ContextWrapperWithoutKeys =
+ReactDartComponentFactoryProxy2 ContextWrapperWithoutKeys =
     react.registerComponent(() => new _ContextWrapperWithoutKeys());
 
 class _ContextWrapperWithoutKeys extends react.Component2
@@ -131,7 +131,7 @@ class _ContextWrapperWithoutKeys extends react.Component2
   dynamic render() => react.div({}, props['children']);
 }
 
-ReactDartComponentFactoryProxy ContextWrapper =
+ReactDartComponentFactoryProxy2 ContextWrapper =
     react.registerComponent(() => new _ContextWrapper());
 
 class _ContextWrapper extends react.Component2 with LifecycleTestHelper {
@@ -150,7 +150,7 @@ class _ContextWrapper extends react.Component2 with LifecycleTestHelper {
   dynamic render() => react.div({}, props['children']);
 }
 
-ReactDartComponentFactoryProxy LifecycleTestWithContext =
+ReactDartComponentFactoryProxy2 LifecycleTestWithContext =
     react.registerComponent(() => new _LifecycleTestWithContext());
 
 class _LifecycleTestWithContext extends _LifecycleTest {
@@ -159,7 +159,7 @@ class _LifecycleTestWithContext extends _LifecycleTest {
       const ['foo']; // only listening to one context key
 }
 
-ReactDartComponentFactoryProxy LifecycleTest =
+ReactDartComponentFactoryProxy2 LifecycleTest =
     react.registerComponent(() => new _LifecycleTest());
 
 class _LifecycleTest extends react.Component2 with LifecycleTestHelper {

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -64,14 +64,14 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
     return react.div(
         {
           'onClick': (_) {
-            setStateTransaction(outerTransactionalSetStateCallback, () {
+            setStateWithUpdater(outerTransactionalSetStateCallback, () {
               recordLifecyleCall('outerSetStateCallback');
             });
           }
         },
         react.div({
           'onClick': (_) {
-            setStateTransaction(innerTransactionalSetStateCallback, () {
+            setStateWithUpdater(innerTransactionalSetStateCallback, () {
               recordLifecyleCall('innerSetStateCallback');
             });
           }

--- a/test/lifecycle_test/util.dart
+++ b/test/lifecycle_test/util.dart
@@ -48,6 +48,10 @@ mixin LifecycleTestHelper on Component {
 
     return null;
   }
+
+  void callSetStateWithNullValue() {
+    setState(null);
+  }
 }
 
 abstract class DefaultPropsCachingTestHelper implements Component {


### PR DESCRIPTION
> ~~__NOT A CLEAN DIFF.__  Will not be a clean diff until #162 / #164 are merged.~~

### Problem 1
In ReactJS 16, calling `setState` with a null value no longer triggers an update. However, our interop layer results in an update happening regardless because we always pass an empty `Map` into the JS layer.

### Solution 1
https://github.com/cleandart/react-dart/commit/d382d716c2ab3c50a6b558e8887b2301076e72b4
* Update logic within `Component`, and within `JsComponent2Adapter` so that a `null` value passed as the first argument of `setState` does not result in a component update.
* Add tests

---

### Problem 2
In `Component`, the first argument of `setState` is `dynamic` so that either a `Map`, or a `TransactionalSetStateCallback` can be provided. Dynamic is gross.

### Solution 2
https://github.com/cleandart/react-dart/commit/cbee295abd35357e6539cef7c40ca2449fb06d29
* Tighten the type on the first argument of `Component2.setState` to be a `Map`
* Add a new `setStateTransaction` method that has a first argument value type of `TransactionalSetStateCallback`.
* Add tests


@greglittlefield-wf @kealjones-wk