### PR TITLE
Expose JsBackedMap from react_client

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -24,7 +24,7 @@ import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_f
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
-export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap;
+export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;
 
 final EmptyObject emptyJsMap = new EmptyObject();
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -24,6 +24,7 @@ import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_f
 
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
+export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap;
 
 final EmptyObject emptyJsMap = new EmptyObject();
 


### PR DESCRIPTION
## Description:
JsBackedMap needed to be exposed and accessible via `react_client.dart`.

## Changes:
Add `export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;` to `react_client.dart`.

## Testing suggestions:
 - CI Passes

## Potential areas of regression:
None.