### PR TITLE
Zone improvements (for testing)

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -529,15 +529,14 @@ Function unconvertJsEventHandler(Function jsConvertedEventHandler) {
 /// Convert packed event handler into wrapper and pass it only the Dart [SyntheticEvent] object converted from the
 /// [events.SyntheticEvent] event.
 _convertEventHandlers(Map args) {
-  final zone = dart2_async.Zone.root;
   args.forEach((propKey, value) {
     var eventFactory = eventPropKeyToEventFactory[propKey];
     if (eventFactory != null && value != null) {
       // Apply allowInterop here so that the function we store in [_originalEventHandlers]
       // is the same one we'll retrieve from the JS props.
-      var reactDartConvertedEventHandler = allowInterop((events.SyntheticEvent e, [_, __]) => zone.run(() {
-            value(eventFactory(e));
-          }));
+      var reactDartConvertedEventHandler = allowInterop((events.SyntheticEvent e, [_, __]) {
+        value(eventFactory(e));
+      });
 
       args[propKey] = reactDartConvertedEventHandler;
       _originalEventHandlers[reactDartConvertedEventHandler] = value;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -10,6 +10,7 @@ import "dart:collection";
 import "dart:html";
 import 'dart:js';
 
+import "package:dart2_constant/async.dart" as dart2_async;
 import "package:js/js.dart";
 import "package:react/react.dart";
 import "package:react/react_client/js_interop_helpers.dart";
@@ -178,7 +179,7 @@ Map<String, dynamic> _unjsifyContext(InteropContextValue interopContext) {
 
 /// The static methods that proxy JS component lifecycle methods to Dart components.
 final ReactDartInteropStatics _dartInteropStatics = (() {
-  var zone = Zone.current;
+  final zone = dart2_async.Zone.root;
 
   /// Wrapper for [Component.getInitialState].
   Component initComponent(ReactComponent jsThis, ReactDartComponentInternal internal, InteropContextValue context,
@@ -528,7 +529,7 @@ Function unconvertJsEventHandler(Function jsConvertedEventHandler) {
 /// Convert packed event handler into wrapper and pass it only the Dart [SyntheticEvent] object converted from the
 /// [events.SyntheticEvent] event.
 _convertEventHandlers(Map args) {
-  var zone = Zone.current;
+  final zone = dart2_async.Zone.root;
   args.forEach((propKey, value) {
     var eventFactory = eventPropKeyToEventFactory[propKey];
     if (eventFactory != null && value != null) {


### PR DESCRIPTION
### Problem
- The way the zone used for component lifecycle methods is determined is unpredictable: whatever zone the first `registerComponent` is called in is used, and all subsequent components will also use that zone as well.

    This means that if the first component is rendered in a `test` block, all other lifecycle methods will be run in that test's zone, resulting in output that:
    - makes errors in lifecycle methods look like they were caused by the first test
    - makes print statements in lifecycle methods look like they were caused by the first test

    Also, as a result, any event handlers added to a ReactElement within a component also had the same output issues.
- The way the zone used for event handlers is determined gets in the way of testing: the zone in which the ReactElement with the event handler is used. 

    This results in errors such as the following when wrapping `expectAsync` in event handlers or using `expect` in them, since they're executed in the root zone as opposed to the current test's zone.
    > Bad state: Can't add or remove outstanding callbacks outside of a test body.
    
    This happens quite commonly when testing w_flux actions, or custom event-based prop callbacks.

### Solution
- Always use the root zone to run component lifecycle methods, since that's what it should be most of the time.
- Run event handlers in the zone they're dispatched in. This should always be the root zone outside of tests, and lets the test zone be used when simulating events.

- Add tests

### Testing
- Verify unit tests pass
- Pull into a large UI repo (e.g., WSD) and verify that there are no regressions