### PR TITLE
Deprecate emptyJsMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ jobs:
         - pub run build_runner test -- -p chrome
     - stage: Dart 1
       dart: 1.24.3
+      before_install:
+        - sed -i '/Remove if solving times out in Dart 1/d'  pubspec.yaml
       script:
         - dartanalyzer .
         - pub run test -p chrome

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -24,6 +24,10 @@ import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_f
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 
+/// __Deprecated. Will be removed in the `5.0.0` release.__
+///
+/// Use `newObject()` from the `dart:js_util` library instead.
+@Deprecated('5.0.0')
 final EmptyObject emptyJsMap = new EmptyObject();
 
 /// __Deprecated. Will be removed in the `5.0.0` release.__ Use [ReactComponentFactoryProxy] instead.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   js: ^0.6.0
   meta: ^1.1.6
 dev_dependencies:
-  build_runner: ">=0.6.0 <2.0.0"
-  build_test: ">=0.9.0 <2.0.0"
-  build_web_compilers: ">=0.2.0 <2.0.0"
+  build_runner: ">=0.6.0 <2.0.0"         # Remove if solving times out in Dart 1
+  build_test: ">=0.9.0 <2.0.0"           # Remove if solving times out in Dart 1
+  build_web_compilers: ">=0.2.0 <2.0.0"  # Remove if solving times out in Dart 1
   dart2_constant: ^1.0.0
   dependency_validator: ^1.2.0
   test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
When deprecating a bunch of JS Object stuff in `4.7.0` we missed `emptyJsMap`.

@greglittlefield-wf 