### PR TITLE
CPLAT-5908 Add initializeState to Component2

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -481,6 +481,7 @@ abstract class Component2Adapter {
   void setState(Map newState, SetStateCallback callback);
   void setStateWithUpdater(StateUpdaterCallback stateUpdater, SetStateCallback callback);
   void forceUpdate(SetStateCallback callback);
+  void initializeState(Map state);
 }
 
 /// Top-level ReactJS [Component class](https://facebook.github.io/react/docs/react-component.html)
@@ -588,6 +589,14 @@ abstract class Component2 implements Component {
   /// See: <https://reactjs.org/docs/react-component.html#setstate>
   void setStateWithUpdater(StateUpdaterCallback updater, [SetStateCallback callback]) {
     adapter.setStateWithUpdater(updater, callback);
+  }
+
+  /// Method used to initialize the [state] of a component.
+  ///
+  /// To avoid unnecessary Map copies and setter calls, the [init] method should use [initializeState] (instead of
+  /// this.state) to directly set the state on the JavaScript side.
+  void initializeState(Map value) {
+    adapter.initializeState(value);
   }
 
   void forceUpdate([SetStateCallback callback]) {

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -597,14 +597,12 @@ abstract class Component2 implements Component {
   /// supporting that is difficult in the Dart implementation, so this method must be used instead.
   ///
   /// __Example__:
-  ///     ```js
+  ///
   ///     // JavaScript
   ///     constructor() {
   ///       this.state = {count: 0};
   ///     }
-  ///     ```
   ///
-  ///     ```dart
   ///     // Dart
   ///     init() {
   ///       initializeState({'count': 0});

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -591,11 +591,26 @@ abstract class Component2 implements Component {
     adapter.setStateWithUpdater(updater, callback);
   }
 
-  /// Method used to initialize the [state] of a component.
+  /// Initializes this component's [state] to [value].
   ///
-  /// To avoid unnecessary Map copies and setter calls, the [init] method should use [initializeState] (instead of
-  /// this.state) to directly set the state on the JavaScript side.
+  /// Whereas `this.state` can be set directly in JavaScript components during initialization, 
+  /// supporting that is difficult in the Dart implementation, so this method must be used instead.
+  ///
+  /// __Example__:
+  ///     ```js
+  ///     // JavaScript
+  ///     constructor() {
+  ///       this.state = {count: 0};
+  ///     }
+  ///     ```
+  ///
+  ///     ```dart
+  ///     // Dart
+  ///     init() {
+  ///       initializeState({'count': 0});
+  ///     }
   void initializeState(Map value) {
+    print('setting state');
     adapter.initializeState(value);
   }
 

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -824,12 +824,15 @@ abstract class Component2 implements Component {
   /// This is equivalent to `Constructor` in React 16, this is called before mounting
   /// See: <https://reactjs.org/docs/react-component.html#constructor>
   ///
+  /// __NOTE__: In contrast to `Constructor`, state should be initialized via [initializeState]
+  /// rather than `this.state = {}`.
+  ///
   /// __Example__:
   ///
   ///    class MyClass extends react.Component2 {
   ///      @override
   ///      void init() {
-  ///        this.state = {'foo': 0, 'bar': 1};
+  ///        initializeState({'foo': 0, 'bar': 1});
   ///      }
   ///    }
   void init() {}

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -593,7 +593,7 @@ abstract class Component2 implements Component {
 
   /// Initializes this component's [state] to [value].
   ///
-  /// Whereas `this.state` can be set directly in JavaScript components during initialization, 
+  /// Whereas `this.state` can be set directly in JavaScript components during initialization,
   /// supporting that is difficult in the Dart implementation, so this method must be used instead.
   ///
   /// __Example__:
@@ -610,7 +610,6 @@ abstract class Component2 implements Component {
   ///       initializeState({'count': 0});
   ///     }
   void initializeState(Map value) {
-    print('setting state');
     adapter.initializeState(value);
   }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -503,6 +503,12 @@ class JsComponent2Adapter extends Component2Adapter {
   }
 
   @override
+  void initializeState(Map state) {
+    dynamic jsState = jsBackingMapOrJsCopy(state);
+    jsThis.state = jsState;
+  }
+
+  @override
   void setStateWithUpdater(StateUpdaterCallback stateUpdater, SetStateCallback callback) {
     final firstArg = allowInterop((jsPrevState, jsProps, [_]) {
       return jsBackingMapOrJsCopy(stateUpdater(

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -134,15 +134,6 @@ main() {
         isComponent2: true,
       );
 
-      test('initializes correctly using initializeState', () {
-        var mountNode = new DivElement();
-        var renderedInstance = react_dom.render(components2.SetStateTest({}), mountNode);
-        LifecycleTestHelper component = getDartComponent(renderedInstance);
-
-        expect(component.state["initializedCorrectly"], isTrue);
-        expect(component.state, isA<JsBackedMap>());
-      });
-
       test('updates with correct lifecycle calls when `forceUpdate` is called', () {
         const Map initialState = const {
           'initialState': 'initial',
@@ -812,7 +803,7 @@ void sharedLifecycleTests<T extends react.Component>({
         };
 
         final Map initialProps =
-            unmodifiableMap({'init': (react.Component2 component) => component.state = initialState});
+            unmodifiableMap({'init': (react.Component2 component) => component.initializeState(initialState)});
         final Map expectedProps = unmodifiableMap(defaultProps, initialProps, emptyChildrenProps);
         LifecycleTestHelper component = getDartComponent(render(LifecycleTest(initialProps)));
 
@@ -820,11 +811,12 @@ void sharedLifecycleTests<T extends react.Component>({
             component.lifecycleCalls,
             equals([
               matchCall('init', props: expectedProps, state: null),
-              matchCall('getInitialState', props: expectedProps, state: initialState),
+              matchCall('getInitialState', props: expectedProps),
               matchCall('getDerivedStateFromProps', args: {expectedProps, initialState}),
               matchCall('render', props: expectedProps, state: initialState),
               matchCall('componentDidMount', props: expectedProps, state: initialState)
             ].where((matcher) => matcher != null)));
+        expect(component.state, isA<JsBackedMap>());
       });
     }
 
@@ -835,7 +827,7 @@ void sharedLifecycleTests<T extends react.Component>({
         };
 
         final Map initialProps = unmodifiableMap({
-          'init': (react.Component2 component) => component.state = initialState,
+          'init': (react.Component2 component) => component.initializeState(initialState),
           'getInitialState': (_) => initialState
         });
         expect(() {

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -134,6 +134,15 @@ main() {
         isComponent2: true,
       );
 
+      test('initializes correctly using initializeState', () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(components2.SetStateTest({}), mountNode);
+        LifecycleTestHelper component = getDartComponent(renderedInstance);
+
+        expect(component.state["initializedCorrectly"], isTrue);
+        expect(component.state, isA<JsBackedMap>());
+      });
+
       test('updates with correct lifecycle calls when `forceUpdate` is called', () {
         const Map initialState = const {
           'initialState': 'initial',

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -22,8 +22,7 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
   @override
   void init() {
     lifecycleCall('init');
-    this.initializeState({
-      'initializedCorrectly': true,
+    initializeState({
       'counter': 1,
       'shouldThrow': true,
       'errorFromGetDerivedState': '',

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -20,16 +20,17 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
       };
 
   @override
-  void init() => lifecycleCall('init');
-
-  @override
-  getInitialState() => {
-        'counter': 1,
-        'shouldThrow': true,
-        'errorFromGetDerivedState': '',
-        'error': '',
-        'info': '',
-      };
+  void init() {
+    lifecycleCall('init');
+    this.initializeState({
+      'initializedCorrectly': true,
+      'counter': 1,
+      'shouldThrow': true,
+      'errorFromGetDerivedState': '',
+      'error': '',
+      'info': '',
+    });
+  }
 
   @override
   Map getDerivedStateFromProps(_, __) {

--- a/test/lifecycle_test/util.dart
+++ b/test/lifecycle_test/util.dart
@@ -35,8 +35,6 @@ mixin LifecycleTestHelper on Component {
       }).toList();
 
   dynamic lifecycleCall(String memberName, {List arguments: const [], defaultReturnValue(), Map staticProps}) {
-    print('lifecycle $memberName');
-    print('State ${state.toString()}');
     lifecycleCalls.add({
       'memberName': memberName,
       'arguments': arguments,
@@ -53,9 +51,6 @@ mixin LifecycleTestHelper on Component {
             ..add(this)
             ..addAll(arguments));
     }
-
-    print('lifecycle $memberName');
-    print('State ${state.toString()}');
 
     if (defaultReturnValue != null) {
       return defaultReturnValue();

--- a/test/lifecycle_test/util.dart
+++ b/test/lifecycle_test/util.dart
@@ -35,6 +35,8 @@ mixin LifecycleTestHelper on Component {
       }).toList();
 
   dynamic lifecycleCall(String memberName, {List arguments: const [], defaultReturnValue(), Map staticProps}) {
+    print('lifecycle $memberName');
+    print('State ${state.toString()}');
     lifecycleCalls.add({
       'memberName': memberName,
       'arguments': arguments,
@@ -51,6 +53,9 @@ mixin LifecycleTestHelper on Component {
             ..add(this)
             ..addAll(arguments));
     }
+
+    print('lifecycle $memberName');
+    print('State ${state.toString()}');
 
     if (defaultReturnValue != null) {
       return defaultReturnValue();


### PR DESCRIPTION
 ## Issue

over_react did not have an ideal API to initialize component state within the `init` lifecycle method. A pure over_react solution would have been detrimental to performance. The better solution was to create a direct method in react-dart that can convert a `Map` to a `JsBackedMap` and update the JS layer directly.

## Changes
- Add the `initializeState` method to `Component2`
- Add an `initializeState` method in `Component2Adapter` and override it in `JsCompoent2Adapter`
- Add Tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @kealjones-wk 

## QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]