### PR TITLE
Upgrade to build_web_compilers 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,18 @@ cache:
 
 jobs:
   include:
-    - stage: Dart 2
+    - stage: Dart 2 stable
       dart: stable
       script:
         - dartanalyzer .
         - dartfmt --line-length=120 --dry-run --set-exit-if-changed .
         - pub run dependency_validator -i build_runner,build_test,build_web_compilers
+        - pub run test -p chrome
+        - pub run build_runner test -- -p chrome
+    - stage: Dart 2 dev
+      dart: dev
+      script:
+        - dartanalyzer .
         - pub run test -p chrome
         - pub run build_runner test -- -p chrome
     - stage: Dart 1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   meta: ^1.1.6
 dev_dependencies:
   build_runner: ">=0.6.0 <2.0.0"         # Remove if solving times out in Dart 1
-  build_test: ">=0.9.0 <2.0.0"           # Remove if solving times out in Dart 1
-  build_web_compilers: ">=0.2.0 <2.0.0"  # Remove if solving times out in Dart 1
+  build_test: ">=0.9.0 <1.0.0"           # Remove if solving times out in Dart 1
+  build_web_compilers: ">=0.2.0 <3.0.0"  # Remove if solving times out in Dart 1
   dart2_constant: ^1.0.0
   dependency_validator: ^1.2.0
   test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
## Changes
- Upgrade to build_web_compilers 2.x - no source/test changes were needed, it works as-is.
- Update Travis CI config to also run on dart2 dev channel

