### PR TITLE
CPLAT-6232 normalize set state call

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -278,9 +278,6 @@ abstract class Component {
     } else if (newState != null) {
       throw new ArgumentError(
           'setState expects its first parameter to either be a Map or a `TransactionalSetStateCallback`.');
-    } else {
-      // newState is null, so short-circuit to match the ReactJS 16 behavior of not re-rendering the component if newState is null.
-      return;
     }
 
     if (callback != null) _setStateCallbacks.add(callback);

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1244,30 +1244,36 @@ void sharedLifecycleTests<T extends react.Component>({
       });
     }
 
-    if (isComponent2) {
-      test('calling setState does not update the component when the value passed is null', () {
+    group('calling setState', () {
+      LifecycleTestHelper component;
+
+      setUp(() {
         var mountNode = new DivElement();
         var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
-        LifecycleTestHelper component = getDartComponent(renderedInstance);
+        component = getDartComponent(renderedInstance);
         component.lifecycleCalls.clear();
-
-        component.callSetStateWithNullValue();
-
-        expect(component.lifecycleCalls, isEmpty);
       });
-    } else {
-      test('calling setState does update the component when the value passed is null', () {
-        var mountNode = new DivElement();
-        var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
-        LifecycleTestHelper component = getDartComponent(renderedInstance);
-        component.lifecycleCalls.clear();
 
-        component.callSetStateWithNullValue();
-
-        expect(
-            component.lifecycleCalls, ['shouldComponentUpdate', 'componentWillUpdate', 'render', 'componentDidUpdate']);
+      tearDown(() {
+        component?.lifecycleCalls?.clear();
+        component = null;
       });
-    }
+
+      if (isComponent2) {
+        test('does not update the component when the value passed is null', () {
+          component.callSetStateWithNullValue();
+
+          expect(component.lifecycleCalls, isEmpty);
+        });
+      } else {
+        test('does update the component when the value passed is null', () {
+          component.callSetStateWithNullValue();
+
+          expect(component.lifecycleCalls,
+              ['shouldComponentUpdate', 'componentWillUpdate', 'render', 'componentDidUpdate']);
+        });
+      }
+    });
 
     group('calls the setState callback, and transactional setState callback in the correct order', () {
       test('when shouldComponentUpdate returns false', () {

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1264,11 +1264,10 @@ void sharedLifecycleTests<T extends react.Component>({
 
         component.callSetStateWithNullValue();
 
-        expect(component.lifecycleCalls, ['shouldComponentUpdate', 'componentWillUpdate', 'render', 'componentDidUpdate']);
+        expect(
+            component.lifecycleCalls, ['shouldComponentUpdate', 'componentWillUpdate', 'render', 'componentDidUpdate']);
       });
     }
-
-
 
     group('calls the setState callback, and transactional setState callback in the correct order', () {
       test('when shouldComponentUpdate returns false', () {

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1256,7 +1256,7 @@ void sharedLifecycleTests<T extends react.Component>({
         expect(component.lifecycleCalls, isEmpty);
       });
     } else {
-      test('calling setState does not update the component when the value passed is null', () {
+      test('calling setState does update the component when the value passed is null', () {
         var mountNode = new DivElement();
         var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
         LifecycleTestHelper component = getDartComponent(renderedInstance);

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -1244,16 +1244,31 @@ void sharedLifecycleTests<T extends react.Component>({
       });
     }
 
-    test('calling setState does not update the component when the value passed is null', () {
-      var mountNode = new DivElement();
-      var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
-      LifecycleTestHelper component = getDartComponent(renderedInstance);
-      component.lifecycleCalls.clear();
+    if (isComponent2) {
+      test('calling setState does not update the component when the value passed is null', () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
+        LifecycleTestHelper component = getDartComponent(renderedInstance);
+        component.lifecycleCalls.clear();
 
-      component.callSetStateWithNullValue();
+        component.callSetStateWithNullValue();
 
-      expect(component.lifecycleCalls, isEmpty);
-    });
+        expect(component.lifecycleCalls, isEmpty);
+      });
+    } else {
+      test('calling setState does not update the component when the value passed is null', () {
+        var mountNode = new DivElement();
+        var renderedInstance = react_dom.render(SetStateTest({}), mountNode);
+        LifecycleTestHelper component = getDartComponent(renderedInstance);
+        component.lifecycleCalls.clear();
+
+        component.callSetStateWithNullValue();
+
+        expect(component.lifecycleCalls, ['shouldComponentUpdate', 'componentWillUpdate', 'render', 'componentDidUpdate']);
+      });
+    }
+
+
 
     group('calls the setState callback, and transactional setState callback in the correct order', () {
       test('when shouldComponentUpdate returns false', () {


### PR DESCRIPTION
# Motivation 
Calling `setState` in React 15 essentially always causes an update (regardless of whether or not a new state is passed in). This behavior changes in React 16. We want to ensure that `Component` does not break expectations while changing behavior in `Component2`.

# Changes
- Remove null check that stops the update if `null` is passed in
- Add tests to show that `Component` will update if `null` is passed but `Component2` will not

@aaronlademann-wf @kealjones-wk @greglittlefield-wf @sydneyjodon-wk 