### PR TITLE
CPLAT 4337 Expose React 16 createRef / forwardRef

### DIFF
--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -16,6 +16,55 @@ class _ChildComponent extends react.Component {
   render() => react.span({}, "Child element with value ${somevalue}");
 }
 
+var InputComponentForm = forwardRef((props, ref) {
+  return react.form({
+    'key': 'inputForm',
+    'className': 'form-inline'
+  }, [
+    react.input({
+      'key': 'create-input',
+      'className': 'form-control',
+      'ref': ref,
+    }),
+    '\u00a0',
+    react.button({
+      'type': 'button',
+      'key': 'create-show-input',
+      'className': 'btn btn-primary',
+      'onClick': props['showInputForwardRefValue'],
+    }, 'Print input element value'),
+  ]);
+});
+
+var ChildComponentForm = forwardRef((props, ref) {
+  return react.div({}, [
+    react.h4({'key': 'create-child-h4'}, "ChildComponent"),
+    react.form({
+      'key': 'childComponentForm',
+      'className': 'form-inline'
+    }, [
+      ChildComponent({
+        'key': 'create-child',
+        "ref": ref,
+      }),
+      '\u00a0',
+      react.button({
+        'type': 'button',
+        'key': 'create-show-button',
+        'className': 'btn btn-primary',
+        'onClick': props['showChildForwardRefValue'],
+      }, 'Print child value'),
+      '\u00a0',
+      react.button({
+        'type': 'button',
+        'key': 'create-increment-button',
+        'className': 'btn btn-primary',
+        'onClick': props['incrementChildForwardRefValue'],
+      }, 'Increment child value'),
+    ])
+  ]);
+});
+
 var ParentComponent = react.registerComponent(() => new _ParentComponent());
 
 class _ParentComponent extends react.Component {
@@ -163,59 +212,29 @@ class _ParentComponent extends react.Component {
       ]),
     ]);
 
-    var createRefs = react.div({
-      'key': 'create-refs'
+    var forwardRefs = react.div({
+      'key': 'forward-refs'
     }, [
-      react.h2({'key': 'h2-create'}, "Create refs"),
-      react.h4({'key': 'h4-create-input'}, "<input>"),
-      react.form({
-        'key': 'inputForm',
-        'className': 'form-inline'
-      }, [
-        react.input({
-          'key': 'create-input',
-          'className': 'form-control',
-          'ref': _inputCreateRef,
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'create-show-input',
-          'className': 'btn btn-primary',
-          'onClick': showInputCreateRefValue,
-        }, 'Print input element value'),
-      ]),
-      react.h4({'key': 'create-child-h4'}, "ChildComponent"),
-      react.form({
-        'key': 'childComponentForm',
-        'className': 'form-inline'
-      }, [
-        ChildComponent({
-          'key': 'create-child',
-          "ref": _childCreateRef,
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'create-show-button',
-          'className': 'btn btn-primary',
-          'onClick': showChildCreateRefValue,
-        }, 'Print child value'),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'create-increment-button',
-          'className': 'btn btn-primary',
-          'onClick': incrementChildCreateRefValue,
-        }, 'Increment child value'),
-      ]),
+      react.h2({'key': 'h2-forward'}, "Create / Forward refs"),
+      react.h4({'key': 'h4-forward-input'}, "<input>"),
+      InputComponentForm({
+        'ref': _inputCreateRef,
+        'showInputForwardRefValue': showInputCreateRefValue,
+        'key': 'input-component-form',
+      }),
+      ChildComponentForm({
+        'ref': _childCreateRef,
+        'showChildForwardRefValue': showChildCreateRefValue,
+        'incrementChildForwardRefValue': incrementChildCreateRefValue,
+        'key': 'child-component-form',
+      }),
     ]);
 
     return react.div({}, [
       react.h1({'key': 'h1'}, 'Refs'),
       stringRefs,
       callbackRefs,
-      createRefs,
+      forwardRefs,
     ]);
   }
 }

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -1,6 +1,7 @@
 import "dart:html";
 
 import "package:react/react.dart" as react;
+import 'package:react/react.dart';
 import "package:react/react_dom.dart" as react_dom;
 import "package:react/react_client.dart";
 
@@ -37,7 +38,7 @@ var InputComponentForm = forwardRef((props, ref) {
 });
 
 var ChildComponentForm = forwardRef((props, ref) {
-  return react.div({}, [
+  return Fragment({}, [
     react.h4({'key': 'create-child-h4'}, "ChildComponent"),
     react.form({
       'key': 'childComponentForm',
@@ -230,7 +231,7 @@ class _ParentComponent extends react.Component {
       }),
     ]);
 
-    return react.div({}, [
+    return Fragment({}, [
       react.h1({'key': 'h1'}, 'Refs'),
       stringRefs,
       callbackRefs,

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -49,92 +49,175 @@ class _ParentComponent extends react.Component {
     _childCallbackRef.incrementValue();
   }
 
-  render() => react.div({}, [
-        react.h1({'key': 'h1'}, 'Refs'),
-        react.h2({'key': 'string-h2'}, "String refs"),
-        react.h4({'key': 'string-h4'}, "<input>"),
-        react.form({
-          'key': 'stringRefInputForm',
-          'className': 'form-inline'
-        }, [
-          react.input({
-            'key': 'string-input',
-            'className': 'form-control',
-            'ref': 'inputRef',
-          }),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'string-show-input',
-            'className': 'btn btn-primary',
-            'onClick': showInputValue,
-          }, 'Print input element value'),
-        ]),
-        react.h4({'key': 'string-h4-child'}, "ChildComponent"),
-        react.form({
-          'key': 'stringRefChildComponentForm',
-          'className': 'form-inline'
-        }, [
-          ChildComponent({'key': 'string-child', "ref": "childRef"}),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'string-show-button',
-            'className': 'btn btn-primary',
-            'onClick': showChildValue,
-          }, 'Print child value'),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'string-increment-button',
-            'className': 'btn btn-primary',
-            'onClick': incrementChildValue,
-          }, 'Increment child value'),
-        ]),
-        react.h2({'key': 'h2-callback'}, "Callback refs"),
-        react.h4({'key': 'h4-callback-input'}, "<input>"),
-        react.form({
-          'key': 'inputForm',
-          'className': 'form-inline'
-        }, [
-          react.input({
-            'key': 'callback-input',
-            'className': 'form-control',
-            'ref': (instance) => _inputCallbackRef = instance,
-          }),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'callback-show-input',
-            'className': 'btn btn-primary',
-            'onClick': showInputCallbackRefValue,
-          }, 'Print input element value'),
-        ]),
-        react.h4({'key': 'callback-child-h4'}, "ChildComponent"),
-        react.form({
-          'key': 'childComponentForm',
-          'className': 'form-inline'
-        }, [
-          ChildComponent({
-            'key': 'callback-child',
-            "ref": (instance) => _childCallbackRef = instance,
-          }),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'callback-show-button',
-            'className': 'btn btn-primary',
-            'onClick': showChildCallbackRefValue,
-          }, 'Print child value'),
-          '\u00a0',
-          react.button({
-            'type': 'button',
-            'key': 'callback-increment-button',
-            'className': 'btn btn-primary',
-            'onClick': incrementChildCallbackRefValue,
-          }, 'Increment child value'),
-        ]),
-      ]);
+  // Create refs
+  var _inputCreateRef = createRef<InputElement>();
+  var _childCreateRef = createRef<_ChildComponent>();
+
+  showInputCreateRefValue(_) {
+    var input = react_dom.findDOMNode(_inputCreateRef.current);
+    print(input.value);
+  }
+
+  showChildCreateRefValue(_) {
+    print(_childCreateRef.current.somevalue);
+  }
+
+  incrementChildCreateRefValue(_) {
+    _childCreateRef.current.incrementValue();
+  }
+
+  render() {
+    var stringRefs = react.div({
+      'key': 'string-refs'
+    }, [
+      react.h2({'key': 'string-h2'}, "String refs"),
+      react.h4({'key': 'string-h4'}, "<input>"),
+      react.form({
+        'key': 'stringRefInputForm',
+        'className': 'form-inline',
+      }, [
+        react.input({
+          'key': 'string-input',
+          'className': 'form-control',
+          'ref': 'inputRef',
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'string-show-input',
+          'className': 'btn btn-primary',
+          'onClick': showInputValue,
+        }, 'Print input element value'),
+      ]),
+      react.h4({'key': 'string-h4-child'}, "ChildComponent"),
+      react.form({
+        'key': 'stringRefChildComponentForm',
+        'className': 'form-inline',
+      }, [
+        ChildComponent({
+          'key': 'string-child',
+          "ref": "childRef",
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'string-show-button',
+          'className': 'btn btn-primary',
+          'onClick': showChildValue,
+        }, 'Print child value'),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'string-increment-button',
+          'className': 'btn btn-primary',
+          'onClick': incrementChildValue,
+        }, 'Increment child value'),
+      ]),
+    ]);
+
+    var callbackRefs = react.div({
+      'key': 'callback-refs'
+    }, [
+      react.h2({'key': 'h2-callback'}, "Callback refs"),
+      react.h4({'key': 'h4-callback-input'}, "<input>"),
+      react.form({
+        'key': 'inputForm',
+        'className': 'form-inline'
+      }, [
+        react.input({
+          'key': 'callback-input',
+          'className': 'form-control',
+          'ref': (instance) => _inputCallbackRef = instance,
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'callback-show-input',
+          'className': 'btn btn-primary',
+          'onClick': showInputCallbackRefValue,
+        }, 'Print input element value'),
+      ]),
+      react.h4({'key': 'callback-child-h4'}, "ChildComponent"),
+      react.form({
+        'key': 'childComponentForm',
+        'className': 'form-inline'
+      }, [
+        ChildComponent({
+          'key': 'callback-child',
+          "ref": (instance) => _childCallbackRef = instance,
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'callback-show-button',
+          'className': 'btn btn-primary',
+          'onClick': showChildCallbackRefValue,
+        }, 'Print child value'),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'callback-increment-button',
+          'className': 'btn btn-primary',
+          'onClick': incrementChildCallbackRefValue,
+        }, 'Increment child value'),
+      ]),
+    ]);
+
+    var createRefs = react.div({
+      'key': 'create-refs'
+    }, [
+      react.h2({'key': 'h2-create'}, "Create refs"),
+      react.h4({'key': 'h4-create-input'}, "<input>"),
+      react.form({
+        'key': 'inputForm',
+        'className': 'form-inline'
+      }, [
+        react.input({
+          'key': 'create-input',
+          'className': 'form-control',
+          'ref': _inputCreateRef,
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'create-show-input',
+          'className': 'btn btn-primary',
+          'onClick': showInputCreateRefValue,
+        }, 'Print input element value'),
+      ]),
+      react.h4({'key': 'create-child-h4'}, "ChildComponent"),
+      react.form({
+        'key': 'childComponentForm',
+        'className': 'form-inline'
+      }, [
+        ChildComponent({
+          'key': 'create-child',
+          "ref": _childCreateRef,
+        }),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'create-show-button',
+          'className': 'btn btn-primary',
+          'onClick': showChildCreateRefValue,
+        }, 'Print child value'),
+        '\u00a0',
+        react.button({
+          'type': 'button',
+          'key': 'create-increment-button',
+          'className': 'btn btn-primary',
+          'onClick': incrementChildCreateRefValue,
+        }, 'Increment child value'),
+      ]),
+    ]);
+
+    return react.div({}, [
+      react.h1({'key': 'h1'}, 'Refs'),
+      stringRefs,
+      callbackRefs,
+      createRefs,
+    ]);
+  }
 }
 
 var mountedNode = querySelector('#content');

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -1,7 +1,6 @@
 import "dart:html";
 
 import "package:react/react.dart" as react;
-import 'package:react/react.dart';
 import "package:react/react_dom.dart" as react_dom;
 import "package:react/react_client.dart";
 
@@ -38,7 +37,7 @@ var InputComponentForm = forwardRef((props, ref) {
 });
 
 var ChildComponentForm = forwardRef((props, ref) {
-  return Fragment({}, [
+  return react.Fragment({}, [
     react.h4({'key': 'create-child-h4'}, "ChildComponent"),
     react.form({
       'key': 'childComponentForm',
@@ -231,7 +230,7 @@ class _ParentComponent extends react.Component {
       }),
     ]);
 
-    return Fragment({}, [
+    return react.Fragment({}, [
       react.h1({'key': 'h1'}, 'Refs'),
       stringRefs,
       callbackRefs,

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -99,8 +99,8 @@ class _ParentComponent extends react.Component {
   }
 
   // Create refs
-  var _inputCreateRef = createRef<InputElement>();
-  var _childCreateRef = createRef<_ChildComponent>();
+  final Ref<InputElement> _inputCreateRef = createRef();
+  final Ref<_ChildComponent> _childCreateRef = createRef();
 
   showInputCreateRefValue(_) {
     var input = react_dom.findDOMNode(_inputCreateRef.current);

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -116,14 +116,13 @@ class _ParentComponent extends react.Component {
   }
 
   render() => react.div({}, [
-        react.div({
-          'key': 'string-refs'
-        }, [
+        react.h1({'key': 'h1'}, 'Refs'),
+        react.div({'key': 'string-refs'}, [
           react.h2({'key': 'string-h2'}, "String refs"),
           react.h4({'key': 'string-h4'}, "<input>"),
           react.form({
             'key': 'stringRefInputForm',
-            'className': 'form-inline',
+            'className': 'form-inline'
           }, [
             react.input({
               'key': 'string-input',
@@ -141,12 +140,9 @@ class _ParentComponent extends react.Component {
           react.h4({'key': 'string-h4-child'}, "ChildComponent"),
           react.form({
             'key': 'stringRefChildComponentForm',
-            'className': 'form-inline',
+            'className': 'form-inline'
           }, [
-            ChildComponent({
-              'key': 'string-child',
-              "ref": "childRef",
-            }),
+            ChildComponent({'key': 'string-child', "ref": "childRef"}),
             '\u00a0',
             react.button({
               'type': 'button',
@@ -163,9 +159,7 @@ class _ParentComponent extends react.Component {
             }, 'Increment child value'),
           ]),
         ]),
-        react.div({
-          'key': 'callback-refs'
-        }, [
+        react.div({'key': 'callback-refs'}, [
           react.h2({'key': 'h2-callback'}, "Callback refs"),
           react.h4({'key': 'h4-callback-input'}, "<input>"),
           react.form({
@@ -210,9 +204,7 @@ class _ParentComponent extends react.Component {
             }, 'Increment child value'),
           ]),
         ]),
-        react.div({
-          'key': 'forward-refs'
-        }, [
+        react.div({'key': 'forward-refs'}, [
           react.h2({'key': 'h2-forward'}, "Create / Forward refs"),
           react.h4({'key': 'h4-forward-input'}, "<input>"),
           InputComponentForm({

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -117,7 +117,9 @@ class _ParentComponent extends react.Component {
 
   render() => react.div({}, [
         react.h1({'key': 'h1'}, 'Refs'),
-        react.div({'key': 'string-refs'}, [
+        react.div({
+          'key': 'string-refs'
+        }, [
           react.h2({'key': 'string-h2'}, "String refs"),
           react.h4({'key': 'string-h4'}, "<input>"),
           react.form({
@@ -159,7 +161,9 @@ class _ParentComponent extends react.Component {
             }, 'Increment child value'),
           ]),
         ]),
-        react.div({'key': 'callback-refs'}, [
+        react.div({
+          'key': 'callback-refs'
+        }, [
           react.h2({'key': 'h2-callback'}, "Callback refs"),
           react.h4({'key': 'h4-callback-input'}, "<input>"),
           react.form({
@@ -204,7 +208,9 @@ class _ParentComponent extends react.Component {
             }, 'Increment child value'),
           ]),
         ]),
-        react.div({'key': 'forward-refs'}, [
+        react.div({
+          'key': 'forward-refs'
+        }, [
           react.h2({'key': 'h2-forward'}, "Create / Forward refs"),
           react.h4({'key': 'h4-forward-input'}, "<input>"),
           InputComponentForm({

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -115,128 +115,119 @@ class _ParentComponent extends react.Component {
     _childCreateRef.current.incrementValue();
   }
 
-  render() {
-    var stringRefs = react.div({
-      'key': 'string-refs'
-    }, [
-      react.h2({'key': 'string-h2'}, "String refs"),
-      react.h4({'key': 'string-h4'}, "<input>"),
-      react.form({
-        'key': 'stringRefInputForm',
-        'className': 'form-inline',
-      }, [
-        react.input({
-          'key': 'string-input',
-          'className': 'form-control',
-          'ref': 'inputRef',
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'string-show-input',
-          'className': 'btn btn-primary',
-          'onClick': showInputValue,
-        }, 'Print input element value'),
-      ]),
-      react.h4({'key': 'string-h4-child'}, "ChildComponent"),
-      react.form({
-        'key': 'stringRefChildComponentForm',
-        'className': 'form-inline',
-      }, [
-        ChildComponent({
-          'key': 'string-child',
-          "ref": "childRef",
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'string-show-button',
-          'className': 'btn btn-primary',
-          'onClick': showChildValue,
-        }, 'Print child value'),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'string-increment-button',
-          'className': 'btn btn-primary',
-          'onClick': incrementChildValue,
-        }, 'Increment child value'),
-      ]),
-    ]);
-
-    var callbackRefs = react.div({
-      'key': 'callback-refs'
-    }, [
-      react.h2({'key': 'h2-callback'}, "Callback refs"),
-      react.h4({'key': 'h4-callback-input'}, "<input>"),
-      react.form({
-        'key': 'inputForm',
-        'className': 'form-inline'
-      }, [
-        react.input({
-          'key': 'callback-input',
-          'className': 'form-control',
-          'ref': (instance) => _inputCallbackRef = instance,
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'callback-show-input',
-          'className': 'btn btn-primary',
-          'onClick': showInputCallbackRefValue,
-        }, 'Print input element value'),
-      ]),
-      react.h4({'key': 'callback-child-h4'}, "ChildComponent"),
-      react.form({
-        'key': 'childComponentForm',
-        'className': 'form-inline'
-      }, [
-        ChildComponent({
-          'key': 'callback-child',
-          "ref": (instance) => _childCallbackRef = instance,
-        }),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'callback-show-button',
-          'className': 'btn btn-primary',
-          'onClick': showChildCallbackRefValue,
-        }, 'Print child value'),
-        '\u00a0',
-        react.button({
-          'type': 'button',
-          'key': 'callback-increment-button',
-          'className': 'btn btn-primary',
-          'onClick': incrementChildCallbackRefValue,
-        }, 'Increment child value'),
-      ]),
-    ]);
-
-    var forwardRefs = react.div({
-      'key': 'forward-refs'
-    }, [
-      react.h2({'key': 'h2-forward'}, "Create / Forward refs"),
-      react.h4({'key': 'h4-forward-input'}, "<input>"),
-      InputComponentForm({
-        'ref': _inputCreateRef,
-        'showInputForwardRefValue': showInputCreateRefValue,
-        'key': 'input-component-form',
-      }),
-      ChildComponentForm({
-        'ref': _childCreateRef,
-        'showChildForwardRefValue': showChildCreateRefValue,
-        'incrementChildForwardRefValue': incrementChildCreateRefValue,
-        'key': 'child-component-form',
-      }),
-    ]);
-
-    return react.Fragment({}, [
-      react.h1({'key': 'h1'}, 'Refs'),
-      stringRefs,
-      callbackRefs,
-      forwardRefs,
-    ]);
-  }
+  render() => react.div({}, [
+        react.div({
+          'key': 'string-refs'
+        }, [
+          react.h2({'key': 'string-h2'}, "String refs"),
+          react.h4({'key': 'string-h4'}, "<input>"),
+          react.form({
+            'key': 'stringRefInputForm',
+            'className': 'form-inline',
+          }, [
+            react.input({
+              'key': 'string-input',
+              'className': 'form-control',
+              'ref': 'inputRef',
+            }),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'string-show-input',
+              'className': 'btn btn-primary',
+              'onClick': showInputValue,
+            }, 'Print input element value'),
+          ]),
+          react.h4({'key': 'string-h4-child'}, "ChildComponent"),
+          react.form({
+            'key': 'stringRefChildComponentForm',
+            'className': 'form-inline',
+          }, [
+            ChildComponent({
+              'key': 'string-child',
+              "ref": "childRef",
+            }),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'string-show-button',
+              'className': 'btn btn-primary',
+              'onClick': showChildValue,
+            }, 'Print child value'),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'string-increment-button',
+              'className': 'btn btn-primary',
+              'onClick': incrementChildValue,
+            }, 'Increment child value'),
+          ]),
+        ]),
+        react.div({
+          'key': 'callback-refs'
+        }, [
+          react.h2({'key': 'h2-callback'}, "Callback refs"),
+          react.h4({'key': 'h4-callback-input'}, "<input>"),
+          react.form({
+            'key': 'inputForm',
+            'className': 'form-inline'
+          }, [
+            react.input({
+              'key': 'callback-input',
+              'className': 'form-control',
+              'ref': (instance) => _inputCallbackRef = instance,
+            }),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'callback-show-input',
+              'className': 'btn btn-primary',
+              'onClick': showInputCallbackRefValue,
+            }, 'Print input element value'),
+          ]),
+          react.h4({'key': 'callback-child-h4'}, "ChildComponent"),
+          react.form({
+            'key': 'childComponentForm',
+            'className': 'form-inline'
+          }, [
+            ChildComponent({
+              'key': 'callback-child',
+              "ref": (instance) => _childCallbackRef = instance,
+            }),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'callback-show-button',
+              'className': 'btn btn-primary',
+              'onClick': showChildCallbackRefValue,
+            }, 'Print child value'),
+            '\u00a0',
+            react.button({
+              'type': 'button',
+              'key': 'callback-increment-button',
+              'className': 'btn btn-primary',
+              'onClick': incrementChildCallbackRefValue,
+            }, 'Increment child value'),
+          ]),
+        ]),
+        react.div({
+          'key': 'forward-refs'
+        }, [
+          react.h2({'key': 'h2-forward'}, "Create / Forward refs"),
+          react.h4({'key': 'h4-forward-input'}, "<input>"),
+          InputComponentForm({
+            'ref': _inputCreateRef,
+            'showInputForwardRefValue': showInputCreateRefValue,
+            'key': 'input-component-form',
+          }),
+          ChildComponentForm({
+            'ref': _childCreateRef,
+            'showChildForwardRefValue': showChildCreateRefValue,
+            'incrementChildForwardRefValue': incrementChildCreateRefValue,
+            'key': 'child-component-form',
+          }),
+        ]),
+      ]);
 }
 
 var mountedNode = querySelector('#content');

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -7,7 +7,7 @@ library react;
 
 import 'package:meta/meta.dart';
 import 'package:react/src/typedefs.dart';
-import 'package:react/react_client.dart';
+import 'package:react/react_client.dart' hide Ref;
 import 'package:react/react_client/react_interop.dart' show ReactErrorInfo, React;
 
 typedef T ComponentFactory<T extends Component>();

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -23,7 +23,7 @@ import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
 import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
-export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef;
+export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef, forwardRef;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -930,10 +930,8 @@ _convertBoundValues(Map args) {
 
 void _convertRefValue(Map args) {
   var ref = args['ref'];
-  if (ref != null) {
-    if (ref is react_interop.Ref) {
-      args['ref'] = ref.jsRef;
-    }
+  if (ref is react_interop.Ref) {
+    args['ref'] = ref.jsRef;
   }
 }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -120,7 +120,11 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       // with the Dart Component instance, not the ReactComponent instance.
       if (ref is _CallbackRef) {
         interopProps.ref = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
-      } else {
+      }
+      else if (ref is createRef) {
+        interopProps.ref = ref.jsCreateRef;
+      }
+      else {
         interopProps.ref = ref;
       }
     }
@@ -185,6 +189,10 @@ class ReactDartComponentFactoryProxy2<TComponent extends Component2> extends Rea
       // with the Dart Component instance, not the ReactComponent instance.
       if (ref is _CallbackRef) {
         propsForJs['ref'] = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
+      }
+
+      if (ref is createRef) {
+        propsForJs['ref'] = ref.jsCreateRef;
       }
     }
 
@@ -855,6 +863,7 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   static void convertProps(Map props) {
     _convertBoundValues(props);
     _convertEventHandlers(props);
+    _convertRefValue(props);
   }
 }
 
@@ -917,6 +926,16 @@ _convertBoundValues(Map args) {
         return onChange(event);
       }
     };
+  }
+}
+
+_convertRefValue(Map args) {
+  if (args.containsKey('ref')) {
+    var ref = args['ref'];
+
+    if (ref is createRef) {
+      args['ref'] = ref.jsCreateRef;
+    }
   }
 }
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -23,7 +23,8 @@ import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
 import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
-export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef, forwardRef;
+export 'package:react/react_client/react_interop.dart'
+    show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef, forwardRef;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -14,7 +14,8 @@ import 'dart:js_util';
 import "package:js/js.dart";
 import "package:react/react.dart";
 import 'package:react/react_client/js_interop_helpers.dart';
-import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_client/react_interop.dart' hide Ref;
+import 'package:react/react_client/react_interop.dart' as react_interop show Ref;
 import "package:react/react_dom.dart";
 import 'package:react/react_dom_server.dart';
 import "package:react/src/react_client/event_prop_key_to_event_factory.dart";
@@ -24,7 +25,7 @@ import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
 export 'package:react/react_client/react_interop.dart'
-    show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef, forwardRef;
+    show ReactElement, ReactJsComponentFactory, inReactDevMode, Ref, forwardRef, createRef;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;
 
@@ -120,8 +121,8 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       // with the Dart Component instance, not the ReactComponent instance.
       if (ref is _CallbackRef) {
         interopProps.ref = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
-      } else if (ref is createRef) {
-        interopProps.ref = ref.jsCreateRef;
+      } else if (ref is react_interop.Ref) {
+        interopProps.ref = ref.jsRef;
       } else {
         interopProps.ref = ref;
       }
@@ -189,8 +190,8 @@ class ReactDartComponentFactoryProxy2<TComponent extends Component2> extends Rea
         propsForJs['ref'] = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
       }
 
-      if (ref is createRef) {
-        propsForJs['ref'] = ref.jsCreateRef;
+      if (ref is react_interop.Ref) {
+        propsForJs['ref'] = ref.jsRef;
       }
     }
 
@@ -927,12 +928,11 @@ _convertBoundValues(Map args) {
   }
 }
 
-_convertRefValue(Map args) {
-  if (args.containsKey('ref')) {
-    var ref = args['ref'];
-
-    if (ref is createRef) {
-      args['ref'] = ref.jsCreateRef;
+void _convertRefValue(Map args) {
+  var ref = args['ref'];
+  if (ref != null) {
+    if (ref is react_interop.Ref) {
+      args['ref'] = ref.jsRef;
     }
   }
 }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -23,7 +23,7 @@ import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
 import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
-export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
+export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode, createRef;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap, JsMap, jsBackingMapOrJsCopy;
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -120,11 +120,9 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       // with the Dart Component instance, not the ReactComponent instance.
       if (ref is _CallbackRef) {
         interopProps.ref = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
-      }
-      else if (ref is createRef) {
+      } else if (ref is createRef) {
         interopProps.ref = ref.jsCreateRef;
-      }
-      else {
+      } else {
         interopProps.ref = ref;
       }
     }

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -5,13 +5,11 @@
 library react_client.react_interop;
 
 import 'dart:html';
-import 'dart:js_util';
 
 import 'package:meta/meta.dart';
 import 'package:js/js.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client.dart' show ComponentFactory, ReactJsComponentFactoryProxy;
-import 'package:react/react_client.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
 
@@ -40,7 +38,7 @@ abstract class React {
   external static JsRef createRef();
 }
 
-/// Creates a [Ref] object that can be attached to an element via the ref attribute.
+/// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.
 ///
 /// __Example__:
 ///
@@ -59,32 +57,29 @@ Ref<CurrentType> createRef<CurrentType>() {
   return new Ref<CurrentType>();
 }
 
-/// The return type of [createRef], the constructor wraps [React.createRef] for use in
-/// Dart.
-///
-/// A [Ref] can be attached to an element via the ref attribute. When the element renders,
-/// a reference to that node becomes accessible at the [current] attribute of the [Ref].
+/// When this is provided as the ref prop, a reference to the rendered component
+/// will be available via [current].
 ///
 /// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
 class Ref<CurrentType> {
+  /// A JavaScript ref object returned by [React.createRef].
   JsRef jsRef;
 
   Ref() {
     jsRef = React.createRef();
   }
 
-  /// When the element renders, a reference to that node becomes accessible at the
-  /// [current] attribute of the [Ref].
+  /// A reference to the latest instance of the rendered component.
   ///
   /// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
   CurrentType get current {
     final jsCurrent = jsRef.current;
 
     if (jsCurrent is! Element) {
-      final dartCurrent = jsCurrent?.dartComponent;
+      final dartCurrent = (jsCurrent as ReactComponent)?.dartComponent;
 
       if (dartCurrent != null) {
-        return dartCurrent;
+        return dartCurrent as CurrentType;
       }
     }
     return jsCurrent;
@@ -97,7 +92,7 @@ class JsRef {
   external dynamic get current;
 }
 
-/// A technique for automatically passing a ref through a component to one of its children.
+/// Automatically passes a [Ref] through a component to one of its children.
 ///
 /// See: <https://reactjs.org/docs/forwarding-refs.html>.
 ReactJsComponentFactoryProxy forwardRef(Function(Map props, Ref ref) wrapperFunction) {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -54,16 +54,17 @@ class createRef<CurrentType> {
   }
 
   CurrentType get current {
-    if (jsCreateRef.current != null) {
-      if (hasProperty(jsCreateRef.current, 'dartComponent')) {
-        return jsCreateRef.current.dartComponent;
+    var jsCurrent = getProperty(jsCreateRef, 'current');
+    if (jsCurrent != null) {
+      if (hasProperty(jsCurrent, 'dartComponent')) {
+        return getProperty(jsCurrent, 'dartComponent');
       }
     }
-    return jsCreateRef.current;
+    return jsCurrent;
   }
 
   set current(CurrentType v) {
-    jsCreateRef.current = v;
+    setProperty(jsCreateRef, 'current', v);
   }
 }
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -5,6 +5,7 @@
 library react_client.react_interop;
 
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:meta/meta.dart';
 import 'package:js/js.dart';
@@ -36,17 +37,28 @@ abstract class React {
   external static bool isValidElement(dynamic object);
   external static ReactClass get Fragment;
 
-  external static RefObject createRef();
+  external static createRef();
 }
 
-createRef() {
-  return React.createRef();
-}
+class createRef {
+  var jsCreateRef;
 
-@JS()
-@anonymous
-class RefObject<CurrentType> {
-  external CurrentType get current;
+  createRef() {
+    jsCreateRef = React.createRef();
+  }
+
+  get current {
+    if (jsCreateRef.current != null) {
+      if (hasProperty(jsCreateRef.current, 'dartComponent')) {
+        return jsCreateRef.current.dartComponent;
+      }
+    }
+    return jsCreateRef.current;
+  }
+
+  set current(v) {
+    jsCreateRef.current = v;
+  }
 }
 
 forwardRef(Function(Map props, Ref ref) wrapperFunction) {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -9,9 +9,10 @@ import 'dart:html';
 import 'package:meta/meta.dart';
 import 'package:js/js.dart';
 import 'package:react/react.dart';
-import 'package:react/react_client.dart' show ComponentFactory;
+import 'package:react/react_client.dart' show ComponentFactory, ReactJsComponentFactoryProxy;
 import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
+import 'package:react/src/typedefs.dart';
 
 typedef ReactElement ReactJsComponentFactory(props, children);
 
@@ -33,6 +34,19 @@ abstract class React {
   external static ReactElement createElement(dynamic type, props, [dynamic children]);
 
   external static bool isValidElement(dynamic object);
+  external static ReactClass get Fragment;
+
+  external static RefObject createRef();
+}
+
+createRef() {
+  return React.createRef();
+}
+
+@JS()
+@anonymous
+class RefObject<CurrentType> {
+  external CurrentType get current;
 }
 
 abstract class ReactDom {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -40,14 +40,14 @@ abstract class React {
   external static createRef();
 }
 
-class createRef {
+class createRef<CurrentType> {
   var jsCreateRef;
 
   createRef() {
     jsCreateRef = React.createRef();
   }
 
-  get current {
+  CurrentType get current {
     if (jsCreateRef.current != null) {
       if (hasProperty(jsCreateRef.current, 'dartComponent')) {
         return jsCreateRef.current.dartComponent;
@@ -56,7 +56,7 @@ class createRef {
     return jsCreateRef.current;
   }
 
-  set current(v) {
+  set current(CurrentType v) {
     jsCreateRef.current = v;
   }
 }

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -11,9 +11,9 @@ import 'package:meta/meta.dart';
 import 'package:js/js.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client.dart' show ComponentFactory, ReactJsComponentFactoryProxy;
+import 'package:react/react_client.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
-import 'package:react/src/typedefs.dart';
 
 typedef ReactElement ReactJsComponentFactory(props, children);
 
@@ -71,8 +71,8 @@ class createRef<CurrentType> {
 /// A technique for automatically passing a ref through a component to one of its children.
 ///
 /// See: <https://reactjs.org/docs/forwarding-refs.html>.
-forwardRef(Function(Map props, Ref ref) wrapperFunction) {
-  var hoc = _jsForwardRef(allowInterop((JsMap props, Ref ref) {
+forwardRef(Function(Map props, dynamic ref) wrapperFunction) {
+  var hoc = _jsForwardRef(allowInterop((JsMap props, dynamic ref) {
     var dartProps = new JsBackedMap.backedBy(props);
 
     return wrapperFunction(dartProps, ref);
@@ -82,7 +82,7 @@ forwardRef(Function(Map props, Ref ref) wrapperFunction) {
 }
 
 @JS('React.forwardRef')
-external ReactClass _jsForwardRef(JsMap Function(JsMap props, Ref ref) wrapperFunction);
+external ReactClass _jsForwardRef(Function(JsMap props, dynamic ref) wrapperFunction);
 
 abstract class ReactDom {
   static Element findDOMNode(object) => ReactDOM.findDOMNode(object);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -65,19 +65,7 @@ Ref<CurrentType> createRef<CurrentType>() {
 /// A [Ref] can be attached to an element via the ref attribute. When the element renders,
 /// a reference to that node becomes accessible at the [current] attribute of the [Ref].
 ///
-/// __Example__:
-///
-///     class FooComponent extends react.Component2 {
-///       final Ref<BarComponent> barRef = createRef();
-///       final Ref<InputElement> inputRef = createRef();
-///
-///       render() => react.div({}, [
-///         Bar({'ref': barRef}),
-///         react.input({'ref': inputRef}),
-///       ]);
-///     }
-///
-/// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
+/// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
 class Ref<CurrentType> {
   JsRef jsRef;
 
@@ -85,6 +73,10 @@ class Ref<CurrentType> {
     jsRef = React.createRef();
   }
 
+  /// When the element renders, a reference to that node becomes accessible at the
+  /// [current] attribute of the [Ref].
+  ///
+  /// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
   CurrentType get current {
     final jsCurrent = jsRef.current;
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -40,16 +40,44 @@ abstract class React {
   external static JsRef createRef();
 }
 
-/// Returns a Ref that can be attached to an element via the ref attribute.
+/// Creates a [Ref] object that can be attached to an element via the ref attribute.
 ///
-/// When a ref is passed to an element in render, a reference to the node becomes
-/// accessible at the 'current' attribute of the ref.
+/// __Example__:
 ///
-/// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
+///     class FooComponent extends react.Component2 {
+///       final Ref<BarComponent> barRef = createRef();
+///       final Ref<InputElement> inputRef = createRef();
+///
+///       render() => react.div({}, [
+///         Bar({'ref': barRef}),
+///         react.input({'ref': inputRef}),
+///       ]);
+///     }
+///
+/// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
 Ref<CurrentType> createRef<CurrentType>() {
   return new Ref<CurrentType>();
 }
 
+/// The return type of [createRef], the constructor wraps [React.createRef] for use in
+/// Dart.
+///
+/// A [Ref] can be attached to an element via the ref attribute. When the element renders,
+/// a reference to that node becomes accessible at the [current] attribute of the [Ref].
+///
+/// __Example__:
+///
+///     class FooComponent extends react.Component2 {
+///       final Ref<BarComponent> barRef = createRef();
+///       final Ref<InputElement> inputRef = createRef();
+///
+///       render() => react.div({}, [
+///         Bar({'ref': barRef}),
+///         react.input({'ref': inputRef}),
+///       ]);
+///     }
+///
+/// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
 class Ref<CurrentType> {
   JsRef jsRef;
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -37,6 +37,12 @@ abstract class React {
   external static bool isValidElement(dynamic object);
   external static ReactClass get Fragment;
 
+  /// Returns a ref that can be attached to an element via the ref attribute.
+  ///
+  /// When a ref is passed to an element in render, a reference to the node becomes
+  /// accessible at the 'current' attribute of the ref.
+  ///
+  /// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
   external static createRef();
 }
 
@@ -61,6 +67,9 @@ class createRef<CurrentType> {
   }
 }
 
+/// A technique for automatically passing a ref through a component to one of its children.
+///
+/// See: <https://reactjs.org/docs/forwarding-refs.html>.
 forwardRef(Function(Map props, Ref ref) wrapperFunction) {
   var hoc = _jsForwardRef(allowInterop((JsMap props, Ref ref) {
     var dartProps = new JsBackedMap.backedBy(props);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -49,6 +49,24 @@ class RefObject<CurrentType> {
   external CurrentType get current;
 }
 
+forwardRef(Function(Map props, Ref ref) wrapperFunction){
+  var hoc = _jsForwardRef(
+      allowInterop(
+              (JsMap props, Ref ref) {
+            var dartProps = new JsBackedMap.backedBy(props);
+            return wrapperFunction(dartProps, ref);
+          }
+      )
+  );
+
+  return new ReactJsComponentFactoryProxy(hoc, shouldConvertDomProps: false);
+}
+
+@JS('React.forwardRef')
+external ReactClass _jsForwardRef(
+    JsMap Function(JsMap props, Ref ref) wrapperFunction
+);
+
 abstract class ReactDom {
   static Element findDOMNode(object) => ReactDOM.findDOMNode(object);
   static ReactComponent render(ReactElement component, Element element) => ReactDOM.render(component, element);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -49,23 +49,18 @@ class RefObject<CurrentType> {
   external CurrentType get current;
 }
 
-forwardRef(Function(Map props, Ref ref) wrapperFunction){
-  var hoc = _jsForwardRef(
-      allowInterop(
-              (JsMap props, Ref ref) {
-            var dartProps = new JsBackedMap.backedBy(props);
-            return wrapperFunction(dartProps, ref);
-          }
-      )
-  );
+forwardRef(Function(Map props, Ref ref) wrapperFunction) {
+  var hoc = _jsForwardRef(allowInterop((JsMap props, Ref ref) {
+    var dartProps = new JsBackedMap.backedBy(props);
+
+    return wrapperFunction(dartProps, ref);
+  }));
 
   return new ReactJsComponentFactoryProxy(hoc, shouldConvertDomProps: false);
 }
 
 @JS('React.forwardRef')
-external ReactClass _jsForwardRef(
-    JsMap Function(JsMap props, Ref ref) wrapperFunction
-);
+external ReactClass _jsForwardRef(JsMap Function(JsMap props, Ref ref) wrapperFunction);
 
 abstract class ReactDom {
   static Element findDOMNode(object) => ReactDOM.findDOMNode(object);

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -242,7 +242,7 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
 
     var idValue;
     if (hasProperty(refValue.current, 'id')) {
-      idValue = getProperty(refValue.current, 'id');
+      idValue = refValue.current.id;
     } else {
       idValue = refValue.current.props['id'];
     }

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -224,6 +224,32 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
 
     verifyRefValue(refValue.current);
   });
+
+  test('forwardRef function passes a ref through a component to one of its children', () {
+    var ForwardRefTestComponent = forwardRef((props, ref) {
+      return factory({
+        'ref': ref,
+        'id': props['childId'],
+      });
+    });
+
+    var refValue = createRef();
+
+    rtu.renderIntoDocument(ForwardRefTestComponent({
+      'ref': refValue,
+      'childId': 'test',
+    }));
+
+    var idValue;
+    if (hasProperty(refValue.current, 'id')) {
+      idValue = getProperty(refValue.current, 'id');
+    } else {
+      idValue = refValue.current.props['id'];
+    }
+
+    expect(idValue, equals('test'), reason: 'child component should have access to parent props');
+    verifyRefValue(refValue.current);
+  });
 }
 
 void _childKeyWarningTests(Function factory) {

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -216,13 +216,13 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
   });
 
   test('createRef function creates ref with correct value', () {
-    var refValue = createRef();
+    final Ref ref = createRef();
 
     rtu.renderIntoDocument(factory({
-      'ref': refValue,
+      'ref': ref,
     }));
 
-    verifyRefValue(refValue.current);
+    verifyRefValue(ref.current);
   });
 
   test('forwardRef function passes a ref through a component to one of its children', () {
@@ -233,22 +233,22 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
       });
     });
 
-    var refValue = createRef();
+    final Ref refObject = createRef();
 
     rtu.renderIntoDocument(ForwardRefTestComponent({
-      'ref': refValue,
+      'ref': refObject,
       'childId': 'test',
     }));
 
     var idValue;
-    if (hasProperty(refValue.current, 'id')) {
-      idValue = refValue.current.id;
+    if (hasProperty(refObject.current, 'id')) {
+      idValue = refObject.current.id;
     } else {
-      idValue = refValue.current.props['id'];
+      idValue = refObject.current.props['id'];
     }
 
     expect(idValue, equals('test'), reason: 'child component should have access to parent props');
-    verifyRefValue(refValue.current);
+    verifyRefValue(refObject.current);
   });
 }
 

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -215,7 +215,7 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
     verifyRefValue(renderedInstance.dartComponent.ref('test'));
   });
 
-  test('createRef function creates refs with correct value', () {
+  test('createRef function creates ref with correct value', () {
     var refValue = createRef();
 
     rtu.renderIntoDocument(factory({

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -214,6 +214,16 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
 
     verifyRefValue(renderedInstance.dartComponent.ref('test'));
   });
+
+  test('createRef function creates refs with correct value', () {
+    var refValue = createRef();
+
+    rtu.renderIntoDocument(factory({
+      'ref': refValue,
+    }));
+
+    verifyRefValue(refValue.current);
+  });
 }
 
 void _childKeyWarningTests(Function factory) {

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -240,8 +240,10 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
       'childId': 'test',
     }));
 
+    // component props are accessed differently depending on if it is a dom component
+    // or a dart component
     var idValue;
-    if (hasProperty(refObject.current, 'id')) {
+    if (refObject.current is Element) {
       idValue = refObject.current.id;
     } else {
       idValue = refObject.current.props['id'];

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -240,8 +240,8 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
       'childId': 'test',
     }));
 
-    // component props are accessed differently depending on if it is a dom component
-    // or a dart component
+    // Component props are accessed differently depending on if it is a dom component
+    // or a dart component.
     var idValue;
     if (refObject.current is Element) {
       idValue = refObject.current.id;


### PR DESCRIPTION
# Motivation 
Expose React 16 `createRef` and `forwardRef`.

# Changes
- Expose React `createRef` function in react_interop.dart and wrap it in a class to handle typing.
- Wrap React `forwardRef` with `ReactJsComponentFactoryProxy`.
## Testing
- [ ] CI Passes
- [ ] Manual Testing

Please review:
@kealjones-wk @aaronlademann-wf @greglittlefield-wf @joebingham-wk 