### PR TITLE
Fix callback refs with non-dynamic args failing in Dart 2

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -134,7 +134,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
       //
       // Use _CallbackRef<Null> to check arity, since parameters could be non-dynamic, and thus
       // would fail the `is _CallbackRef<dynamic>` check.
-      // See https://github.com/dart-lang/sdk/issues/34593 for moe information on arity checks.
+      // See https://github.com/dart-lang/sdk/issues/34593 for more information on arity checks.
       if (ref is _CallbackRef<Null>) {
         interopProps.ref = allowInterop((ReactComponent instance) {
           // Call as dynamic to perform dynamic dispatch, since we can't cast to _CallbackRef<dynamic>,

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -47,7 +47,7 @@ typedef ReactElement ReactComponentFactory(Map props, [dynamic children]);
 /// The type of [Component.ref] specified as a callback.
 ///
 /// See: <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>
-typedef _CallbackRef(componentOrDomNode);
+typedef _CallbackRef<T>(T componentOrDomNode);
 
 /// Prepares [children] to be passed to the ReactJS [React.createElement] and
 /// the Dart [react.Component].
@@ -131,8 +131,16 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
 
       // If the ref is a callback, pass ReactJS a function that will call it
       // with the Dart Component instance, not the ReactComponent instance.
-      if (ref is _CallbackRef) {
-        interopProps.ref = allowInterop((ReactComponent instance) => ref(instance?.dartComponent));
+      //
+      // Use _CallbackRef<Null> to check arity, since parameters could be non-dynamic, and thus
+      // would fail the `is _CallbackRef<dynamic>` check.
+      // See https://github.com/dart-lang/sdk/issues/34593 for moe information on arity checks.
+      if (ref is _CallbackRef<Null>) {
+        interopProps.ref = allowInterop((ReactComponent instance) {
+          // Call as dynamic to perform dynamic dispatch, since we can't cast to _CallbackRef<dynamic>,
+          // and since calling with non-null values will fail at runtime due to the _CallbackRef<Null> typing.
+          return (ref as dynamic)(instance?.dartComponent);
+        });
       } else {
         interopProps.ref = ref;
       }

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -27,22 +27,17 @@ main() {
           fooRef = ref;
         }
 
-        expect(callbackRef, const isInstanceOf<dynamic Function(dynamic)>(), reason: 'test setup check');
-
         expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
             reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');
         expect(fooRef, const isInstanceOf<_Foo>(),
             reason: 'should be the correct type, not be a NativeJavaScrriptObject/etc.');
       });
 
-      test('`dynamic Function(dynamic)`', () {
+      test('`dynamic Function(ComponentClass)`', () {
         _Foo fooRef;
         callbackRef(_Foo ref) {
           fooRef = ref;
         }
-
-        expect(callbackRef, const isInstanceOf<dynamic Function(_Foo)>(), reason: 'test setup check');
-        expect(callbackRef, isNot(const isInstanceOf<dynamic Function(dynamic)>()), reason: 'test setup check');
 
         expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
             reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_test_utils.dart' as rtu;
 
 import 'common_factory_tests.dart';
 
@@ -16,6 +17,38 @@ main() {
 
     group('- common factory behavior -', () {
       commonFactoryTests(Foo);
+    });
+
+    // TODO remove and transfer over to ref tests once 5.1.0-wip releases
+    group('has functional callback refs when they are typed as', () {
+      test('`dynamic Function(dynamic)`', () {
+        _Foo fooRef;
+        callbackRef(ref) {
+          fooRef = ref;
+        }
+
+        expect(callbackRef, const isInstanceOf<dynamic Function(dynamic)>(), reason: 'test setup check');
+
+        expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
+            reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');
+        expect(fooRef, const isInstanceOf<_Foo>(),
+            reason: 'should be the correct type, not be a NativeJavaScrriptObject/etc.');
+      });
+
+      test('`dynamic Function(dynamic)`', () {
+        _Foo fooRef;
+        callbackRef(_Foo ref) {
+          fooRef = ref;
+        }
+
+        expect(callbackRef, const isInstanceOf<dynamic Function(_Foo)>(), reason: 'test setup check');
+        expect(callbackRef, isNot(const isInstanceOf<dynamic Function(dynamic)>()), reason: 'test setup check');
+
+        expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
+            reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');
+        expect(fooRef, const isInstanceOf<_Foo>(),
+            reason: 'should be the correct type, not be a NativeJavaScrriptObject/etc.');
+      });
     });
   });
 }

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -30,7 +30,7 @@ main() {
         expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
             reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');
         expect(fooRef, const isInstanceOf<_Foo>(),
-            reason: 'should be the correct type, not be a NativeJavaScrriptObject/etc.');
+            reason: 'should be the correct type, not be a NativeJavaScriptObject/etc.');
       });
 
       test('`dynamic Function(ComponentClass)`', () {
@@ -42,7 +42,7 @@ main() {
         expect(() => rtu.renderIntoDocument(Foo({'ref': callbackRef})), returnsNormally,
             reason: 'React should not have a problem with the ref we pass it, and calling it should not throw');
         expect(fooRef, const isInstanceOf<_Foo>(),
-            reason: 'should be the correct type, not be a NativeJavaScrriptObject/etc.');
+            reason: 'should be the correct type, not be a NativeJavaScriptObject/etc.');
       });
     });
   });


### PR DESCRIPTION
## Motivation
Callback refs with non-dynamic arguments weren't being handled properly, and would result in obtuse error messages.

Example: 
- dynamic ref argument (works):
    ```dart
    Foo({'ref': (ref) => _fooRef = ref})
    ```
- non-dynamic ref argument (does not work):
    ```dart
    Foo({'ref': (FooComponent ref) => _fooRef = ref})
    ```


In DDC, the ref function would be called correctly, but the ref argument would be of type `NativeJavaScriptObject` instead of the expected component class.
This is because the JS component was being passed instead of the Dart one.

In dart2js, React would throw upon creation of the ReactElement, with the following error.
> Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).

This is because allowInterop was not called on the provided function.

## Solution
- Fix type checking using `Null` arity hack shown here: https://github.com/dart-lang/sdk/issues/34593
- Add tests

## Testing
- Verify tests pass in both DDC and dart2js
- Verify tests fail in both DDC and dart2js if either of the following changes are made in react_client.dart:
    - changing the `is _CallbackRef<Null>` check to `is _CallbackRef<dynamic>`
    - removing the `as dynamic` cast in the ref invocation