### PR TITLE
CPLAT-6459 4.x updates in preparation for 5.0.0 release

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -116,15 +116,13 @@ abstract class Component {
   /// to be set for debugging purposes.
   String get displayName => runtimeType.toString();
 
-  /// Bind the value of input to [state[key]].
+  /// > Bind the value of input to [state[key]].
   ///
   /// __DEPRECATED.__
   ///
-  /// This will be removed in the `6.0.0` release when `Component` is removed.
-  ///
-  /// There is currently no planned support for it within `Component2` which will be released in `5.0.0`
-  /// since there was never a ReactJS analogue for this API.
-  @Deprecated('6.0.0')
+  /// This is being removed since it was a non-standard component API that
+  /// only exists in react-dart, and not React JS in the Dart implementation.
+  @Deprecated('5.0.0')
   bind(key) => [
         state[key],
         (value) => setState({key: value})

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -18,6 +18,7 @@ typedef ReactElement ReactJsComponentFactory(props, children);
 
 @JS()
 abstract class React {
+  external static String get version;
   @Deprecated('6.0.0')
   external static ReactClass createClass(ReactClassConfig reactClassConfig);
   external static ReactJsComponentFactory createFactory(type);


### PR DESCRIPTION
## Motivation
- `React.version` was added in 5.0.0, and we want to avoid adding APIs to make it easier to maintain compatibility with both 4.x/5.x
- `Component.bind` was listed as being deprecated in 6.0.0, but we actually want to remove it in 5.0.0 to realize the perf gains of eliminating `_convertBoundValues` from ReactElement creation

## Solution / Release Notes
- Backport `React.version` from 5.0.0-wip
- Move up removal version for `Component.bind` from 6.0.0 to 5.0.0

## Testing
n/a