### PR TITLE
Revert typing change of componentWillReceivePropsWithContext

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -329,7 +329,7 @@ abstract class Component {
   /// > in ReactJS 16 that is exposed via the [Component2] class.
   /// >
   /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
-  void componentWillReceivePropsWithContext(Map newProps, Map nextContext) {}
+  void componentWillReceivePropsWithContext(Map newProps, dynamic nextContext) {}
 
   /// ReactJS lifecycle method that is invoked before rendering when [nextProps] or [nextState] are being received.
   ///


### PR DESCRIPTION
It's dynamic in master/5.0.0-wip, and should remain that way to avoid issues in subclasses that implicitly inherit argument types
https://github.com/cleandart/react-dart/blob/master@{29-07-2019}/lib/react.dart#L320
https://github.com/cleandart/react-dart/blob/5.0.0-wip@{29-07-2019}/lib/react.dart#L317