### PR TITLE
Idea: use a state setter instead of initializeState

### DIFF
--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -390,8 +390,10 @@ class _NewContextTypeConsumerComponent extends react.Component2 {
 }
 
 class _Component2TestComponent extends react.Component2 with react.TypedSnapshot<String> {
-  Map getInitialState() {
-    return {
+  get defaultProps => {'defaultProp': true};
+
+  init() {
+    state = {
       "items": new List.from([0, 1, 2, 3])
     };
   }

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -542,7 +542,7 @@ abstract class Component2 implements Component {
   Map props;
 
   @override
-  Map state;
+  Map get state => _state;
 
   @override
   dynamic _jsThis;
@@ -608,8 +608,10 @@ abstract class Component2 implements Component {
   ///     init() {
   ///       initializeState({'count': 0});
   ///     }
-  void initializeState(Map value) {
+  @override
+  set state(Map value) {
     _bridge.initializeState(this, value);
+    _state = value;
   }
 
   void forceUpdate([SetStateCallback callback]) {

--- a/lib/react_client/bridge.dart
+++ b/lib/react_client/bridge.dart
@@ -86,6 +86,7 @@ class Component2BridgeImpl extends Component2Bridge {
 
   @override
   void initializeState(Component2 component, Map state) {
+    if (component.jsThis.state != null) return;
     dynamic jsState = jsBackingMapOrJsCopy(state);
     component.jsThis.state = jsState;
   }

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -798,7 +798,7 @@ void sharedLifecycleTests<T extends react.Component>({
         };
 
         final Map initialProps =
-            unmodifiableMap({'init': (react.Component2 component) => component.initializeState(initialState)});
+            unmodifiableMap({'init': (react.Component2 component) => component.state = initialState});
         final Map expectedProps = unmodifiableMap(defaultProps, initialProps, emptyChildrenProps);
         LifecycleTestHelper component = getDartComponent(render(LifecycleTest(initialProps)));
 
@@ -822,7 +822,7 @@ void sharedLifecycleTests<T extends react.Component>({
         };
 
         final Map initialProps = unmodifiableMap({
-          'init': (react.Component2 component) => component.initializeState(initialState),
+          'init': (react.Component2 component) => component.state = initialState,
           'getInitialState': (_) => initialState
         });
         expect(() {

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -23,13 +23,13 @@ class _SetStateTest extends react.Component2 with LifecycleTestHelper {
   @override
   void init() {
     lifecycleCall('init');
-    initializeState({
+    state = {
       'counter': 1,
       'shouldThrow': true,
       'errorFromGetDerivedState': '',
       'error': '',
       'info': '',
-    });
+    };
   }
 
   @override


### PR DESCRIPTION
# Motivation
In ReactJS inside the constructor consumers set the initial state like this: `this.state = {whatever: true}`. We added the `init` method to emulate the `constructor` concept and due to typing issues we created `initializeState` but seriously, no. 

# Changes
- Eliminate `initializeState` from the face of the planet.
- Update state setter to utilize `_state`
- Update `bridge.initializeState` to return without doing anything if the state is already initialized.


