### PR TITLE
Fix context setter typing to match getter and not fail implicit_casts

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -62,7 +62,7 @@ abstract class Component {
   /// >
   /// > It is strongly recommended that you do not use this, and instead wait for `Component2.context`.
   @experimental
-  set context(Map value) => _context = value;
+  set context(dynamic value) => _context = value;
 
   /// ReactJS [Component] props.
   ///

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -682,11 +682,7 @@ external List getUpdatingSetStateLifeCycleCalls();
 external List getNonUpdatingSetStateLifeCycleCalls();
 
 /// A test helper to record lifecycle calls
-abstract class LifecycleTestHelper {
-  Map context;
-  Map props;
-  Map state;
-
+abstract class LifecycleTestHelper implements react.Component {
   List lifecycleCalls = [];
 
   dynamic lifecycleCall(String memberName, {List arguments: const [], defaultReturnValue()}) {


### PR DESCRIPTION
## Motivation 
With `implicit_casts: false` in consumer repos, all components exhibit the following error:
> error: The return type of getter 'Component.context' is 'dynamic' which isn't assignable to the type 'Map<dynamic, dynamic>' of its setter 'Component.context'.

## Changes
Update setter to be dynamic.

## Testing
- CI passes
- Verify that the issue does not reproduce when pulled into a consumer repo with `implicit_casts: false`
    ```
    dependency_overrides:
      react:
        git:
          url: git@github.com:cleandart/react-dart.git
          ref: greglittlefield-wf-patch-1
    ```