### PR TITLE
Deprecate react_test.dart

### DIFF
--- a/lib/react_test.dart
+++ b/lib/react_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Deprecated('5.0.0')
 library react_test;
 
 import 'package:react/react.dart';


### PR DESCRIPTION
react_test.dart hasn't been maintained for a while, and isn't tested. 

We don't plan on supporting it in the future, so it's being deprecated.
