### PR TITLE
Fill in coverage gaps for Component2

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -864,9 +864,7 @@ abstract class Component2 implements Component {
   /// > Use the [initialState] getter instead.
   @mustCallSuper
   @Deprecated('6.0.0')
-  Map getInitialState() {
-    _unsupportedLifecycleError('getInitialState');
-  }
+  Map getInitialState() => throw _unsupportedLifecycleError('getInitialState');
 
   /// Invoked once and cached when [reactComponentClass] is called. Values in the mapping will be set on [props]
   /// if that prop is not specified by the parent component.
@@ -881,9 +879,7 @@ abstract class Component2 implements Component {
   /// > Use the [defaultProps] getter instead.
   @mustCallSuper
   @Deprecated('6.0.0')
-  Map getDefaultProps() {
-    _unsupportedLifecycleError('getDefaultProps');
-  }
+  Map getDefaultProps() => throw _unsupportedLifecycleError('getDefaultProps');
 
   /// ReactJS lifecycle method that is invoked once, both on the client and server, immediately before the initial
   /// rendering occurs.
@@ -898,7 +894,7 @@ abstract class Component2 implements Component {
   /// > Use [componentDidMount] instead
   @mustCallSuper
   @Deprecated('6.0.0')
-  void componentWillMount() => _unsupportedLifecycleError('componentWillMount');
+  void componentWillMount() => throw _unsupportedLifecycleError('componentWillMount');
 
   /// ReactJS lifecycle method that is invoked when a `Component` is receiving [newProps].
   ///
@@ -920,7 +916,7 @@ abstract class Component2 implements Component {
   /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
   @mustCallSuper
   @Deprecated('6.0.0')
-  void componentWillReceiveProps(Map newProps) => _unsupportedLifecycleError('componentWillReceiveProps');
+  void componentWillReceiveProps(Map newProps) => throw _unsupportedLifecycleError('componentWillReceiveProps');
 
   /// ReactJS lifecycle method that is invoked immediately before rendering when [nextProps] or [nextState] are being
   /// received.
@@ -945,7 +941,7 @@ abstract class Component2 implements Component {
   /// > This will be completely removed when the JS side of it is slated for removal (ReactJS 17 / react.dart 6.0.0)
   @mustCallSuper
   @Deprecated('6.0.0')
-  void componentWillUpdate(Map nextProps, Map nextState) => _unsupportedLifecycleError('componentWillUpdate');
+  void componentWillUpdate(Map nextProps, Map nextState) => throw _unsupportedLifecycleError('componentWillUpdate');
 
   /// Do not use; this is part of the legacy context API.
   ///

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -486,6 +486,7 @@ abstract class _ReactDartInteropStatics2 {
 
         component.state = new JsBackedMap.backedBy(jsThis.state);
 
+        // ignore: invalid_use_of_protected_member
         Component2Bridge.bridgeForComponent[component] = componentStatics.bridgeFactory(component);
         return component;
       });

--- a/lib/react_client/bridge.dart
+++ b/lib/react_client/bridge.dart
@@ -1,4 +1,5 @@
 import 'package:js/js.dart';
+import 'package:meta/meta.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart';
@@ -27,6 +28,10 @@ typedef Component2BridgeFactory = Component2Bridge Function(Component2 component
 ///
 /// __For internal/advanced use only.__
 abstract class Component2Bridge {
+  /// Associates a bridge with a component instance.
+  ///
+  /// Protected; use [forComponent] instead.
+  @protected
   static final Expando<Component2Bridge> bridgeForComponent = new Expando();
 
   const Component2Bridge();

--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -107,9 +107,16 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
   @override
   bool operator ==(other) => other is JsBackedMap && other.jsObject == jsObject;
 
-  // FIXME 3.1.0-wip add workaround for DDC hashcode bug
   @override
-  int get hashCode => jsObject.hashCode;
+  int get hashCode {
+    // Work around DDC throwing when accessing hashCode on frozen JS objects:
+    // https://github.com/dart-lang/sdk/issues/36354
+    try {
+      return jsObject.hashCode;
+    } catch (_) {}
+
+    return 0;
+  }
 }
 
 /// A utility interop class for a plain JS "object"/"map"/"dictionary".

--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -24,8 +24,10 @@ import 'package:js/js.dart';
 class JsBackedMap extends MapBase<dynamic, dynamic> {
   final JsMap jsObject;
 
+  /// Creates a JsBackedMap instance backed by a new [jsObject].
   JsBackedMap() : jsObject = new JsMap();
 
+  /// Creates a JsBackedMap instance backed by [jsObject].
   JsBackedMap.backedBy(this.jsObject);
 
   /// Creates a JsBackedMap instance that contains all key/value pairs of [other].

--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -117,6 +117,9 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
       return jsObject.hashCode;
     } catch (_) {}
 
+    // While constant hashCode like this one are not high-quality and may cause
+    // hashCode collisions more often, they are completely valid.
+    // For more information, see the `Object.hashCode` doc comment.
     return 0;
   }
 }

--- a/test/react_client/bridge_test.dart
+++ b/test/react_client/bridge_test.dart
@@ -13,11 +13,28 @@ main() {
 
   // Test behavior that isn't functionally tested via component lifecycle tests.
   group('Component2Bridge', () {
-    test(
-        '.forComponent returns the bridge used by that mounted component,'
-        ' which by default is a const instance of Component2BridgeImpl', () {
-      final instance = getDartComponent<_Foo>(render(Foo({})));
-      expect(Component2Bridge.forComponent(instance), same(const Component2BridgeImpl()));
+    group('.forComponent returns the bridge used by that mounted component, which', () {
+      test('by default is a const instance of Component2BridgeImpl', () {
+        final instance = getDartComponent<_Foo>(render(Foo({})));
+        expect(Component2Bridge.forComponent(instance), same(const Component2BridgeImpl()));
+      });
+
+      test('can be a custom bridge specified via registerComponent2', () {
+        customBridgeCalls.clear();
+        final instance = getDartComponent<_BridgeTest>(render(BridgeTest({})));
+        final bridge = Component2Bridge.forComponent(instance);
+        expect(bridge, isNotNull);
+        expect(
+          customBridgeCalls,
+          // Use `contains` since the static component instance and its bridge also get instantiated,
+          // adding entries to customBridgeCalls.
+          // `equals` is needed otherwise deep matching with matchers won't work
+          contains(equals({
+            'component': same(instance),
+            'returnedBridge': same(bridge),
+          })),
+        );
+      });
     });
 
     group('- Component2BridgeImpl', () {
@@ -34,3 +51,21 @@ class _Foo extends react.Component2 {
   @override
   render() => react.div({});
 }
+
+final customBridgeCalls = [];
+
+final BridgeTest = react.registerComponent2(() => new _BridgeTest(), bridgeFactory: (component) {
+  final returnedBridge = new CustomComponent2Bridge();
+  customBridgeCalls.add({
+    'component': component,
+    'returnedBridge': returnedBridge,
+  });
+  return returnedBridge;
+});
+
+class _BridgeTest extends react.Component2 {
+  @override
+  render() => react.div({});
+}
+
+class CustomComponent2Bridge extends Component2BridgeImpl {}

--- a/test/react_client/bridge_test.dart
+++ b/test/react_client/bridge_test.dart
@@ -1,0 +1,36 @@
+@TestOn('browser')
+library react.bridge_test;
+
+import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+import 'package:react/react_client/bridge.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  setClientConfiguration();
+
+  // Test behavior that isn't functionally tested via component lifecycle tests.
+  group('Component2Bridge', () {
+    test(
+        '.forComponent returns the bridge used by that mounted component,'
+        ' which by default is a const instance of Component2BridgeImpl', () {
+      final instance = getDartComponent<_Foo>(render(Foo({})));
+      expect(Component2Bridge.forComponent(instance), same(const Component2BridgeImpl()));
+    });
+
+    group('- Component2BridgeImpl', () {
+      test('.bridgeFactory returns a const instance of Component2BridgeImpl', () {
+        expect(Component2BridgeImpl.bridgeFactory(new _Foo()), same(const Component2BridgeImpl()));
+      });
+    });
+  });
+}
+
+final Foo = react.registerComponent2(() => new _Foo());
+
+class _Foo extends react.Component2 {
+  @override
+  render() => react.div({});
+}

--- a/test/react_client/bridge_test.dart
+++ b/test/react_client/bridge_test.dart
@@ -20,7 +20,9 @@ main() {
       });
 
       test('can be a custom bridge specified via registerComponent2', () {
-        customBridgeCalls.clear();
+        customBridgeCalls = [];
+        addTearDown(() => customBridgeCalls = null);
+
         final instance = getDartComponent<_BridgeTest>(render(BridgeTest({})));
         final bridge = Component2Bridge.forComponent(instance);
         expect(bridge, isNotNull);
@@ -52,11 +54,11 @@ class _Foo extends react.Component2 {
   render() => react.div({});
 }
 
-final customBridgeCalls = [];
+List<Map> customBridgeCalls;
 
 final BridgeTest = react.registerComponent2(() => new _BridgeTest(), bridgeFactory: (component) {
   final returnedBridge = new CustomComponent2Bridge();
-  customBridgeCalls.add({
+  customBridgeCalls?.add({
     'component': component,
     'returnedBridge': returnedBridge,
   });

--- a/test/react_client/bridge_test.html
+++ b/test/react_client/bridge_test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title></title>
+    <script src="packages/react/react_with_addons.js"></script>
+    <script src="packages/react/react_dom.js"></script>
+    <script src="../ReactCompositeTestComponent.js"></script>
+    <link rel="x-dart-test" href="bridge_test.dart">
+    <script src="packages/test/dart.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/react_client/js_backed_map_test.dart
+++ b/test/react_client/js_backed_map_test.dart
@@ -3,6 +3,7 @@
 library react.js_backed_map_test.dart;
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:test/test.dart';
 
@@ -19,5 +20,164 @@ main() {
 
       sharedTypeTests(testTypeValue);
     });
+
+    group('constructor', () {
+      test('(default) creates an instance backed by a new JS object', () {
+        final jsBackedMap = JsBackedMap();
+        expect(jsBackedMap.jsObject, isNotNull);
+        expect(jsBackedMap.jsObject, isNot(JsBackedMap().jsObject));
+      });
+
+      test('.backedBy creates a new instance backed by a given JS map', () {
+        final jsMap = jsify({'foo': 1});
+        final jsBackedMap = JsBackedMap.backedBy(jsMap);
+        expect(jsBackedMap, containsPair('foo', 1));
+
+        setProperty(jsMap, 'baz', 2);
+        expect(jsBackedMap, containsPair('baz', 2), reason: 'should be backed by the given JS map');
+      });
+
+      test('.from creates a new instance with all key-value pairs from another map', () {
+        final otherMap = {'foo': 1};
+        final jsBackedMap = JsBackedMap.from(otherMap);
+        expect(jsBackedMap, otherMap);
+
+        otherMap['bar'] = 2;
+        expect(jsBackedMap, hasLength(1), reason: 'should not be backed by the other map');
+      });
+
+      test('.fromJs creates a new instance with all key-value pairs from another JS map', () {
+        final otherJsMap = jsify({'foo': 1});
+        final jsBackedMap = JsBackedMap.fromJs(otherJsMap);
+        expect(jsBackedMap, containsPair('foo', 1));
+        expect(jsBackedMap.jsObject, isNot(otherJsMap));
+
+        setProperty(otherJsMap, 'baz', 2);
+        expect(jsBackedMap, hasLength(1), reason: 'should not be backed by the other map');
+      });
+    });
+
+    test('addAllFromJs adds all properties from another JS object', () {
+      final jsMap = new JsBackedMap.from({
+        'foo': 1,
+        'bar': 2,
+      });
+      jsMap.addAllFromJs(jsify({
+        'foo': 'overwritten',
+        'baz': 3,
+      }));
+      expect(jsMap, {
+        'foo': 'overwritten',
+        'bar': 2,
+        'baz': 3,
+      });
+    });
+    test('is equal to other instances backed by the same JS object', () {
+      final jsObjectA = JsMap();
+      final jsObjectB = JsMap();
+
+      final backedByA1 = JsBackedMap.backedBy(jsObjectA);
+      final backedByA2 = JsBackedMap.backedBy(jsObjectA);
+      final backedByB = JsBackedMap.backedBy(jsObjectB);
+
+      // Don't use equals/isNot matchers since they perform deep map equality,
+      // which we don't want here.
+      expect(backedByA1 == backedByA2, isTrue);
+      expect(backedByA1 == backedByB, isFalse);
+    });
+
+    group('has a valid hashCode that does not throw, when backed by', () {
+      test('normal JS objects', () {
+        final jsBackedMap = JsBackedMap();
+        expect(() => jsBackedMap.hashCode, returnsNormally);
+      });
+
+      test('frozen JS objects', () {
+        final jsBackedMap = JsBackedMap();
+        _objectFreeze(jsBackedMap.jsObject);
+        try {
+          // This throws only in strict-mode JS, meaning it throws in DDC and not in dart2js.
+          jsBackedMap['foo'] = 'bar';
+        } catch (_) {}
+        expect(jsBackedMap, isEmpty, reason: 'test setup check; object should be frozen');
+
+        // DDC throws when attempting to access `.hashCode` on frozen objects:
+        // https://github.com/dart-lang/sdk/issues/36354
+        expect(() => jsBackedMap.hashCode, returnsNormally);
+      });
+    });
+
+    group('other map methods overridden or needed by MapBase', () {
+      JsBackedMap testMap;
+
+      setUp(() {
+        testMap = new JsBackedMap.from({
+          'foo': 1,
+          'bar': 2,
+        });
+      });
+
+      test('keys', () {
+        expect(testMap.keys, unorderedEquals(['foo', 'bar']));
+      });
+
+      test('values', () {
+        expect(testMap.values, unorderedEquals([1, 2]));
+      });
+
+      group('addAll', () {
+        test('', () {
+          testMap.addAll({
+            'foo': 'overwritten',
+            'baz': 3,
+          });
+          expect(testMap, {
+            'foo': 'overwritten',
+            'bar': 2,
+            'baz': 3,
+          });
+        });
+
+        test('with a JSBackedMap (special case)', () {
+          testMap.addAll(new JsBackedMap.from({
+            'foo': 'overwritten',
+            'baz': 3,
+          }));
+          expect(testMap, {'foo': 'overwritten', 'bar': 2, 'baz': 3});
+        });
+      });
+
+      test('clear', () {
+        testMap.clear();
+        expect(testMap, isEmpty);
+      });
+
+      group('containsKey:', () {
+        test('for key in map', () {
+          expect(testMap.containsKey('bar'), isTrue);
+        });
+
+        test('for key not in map', () {
+          expect(testMap.containsKey('not in the map'), isFalse);
+        });
+      });
+
+      group('remove:', () {
+        test('for key in map', () {
+          final value = testMap.remove('bar');
+          expect(testMap, {'foo': 1});
+          expect(value, 2);
+        });
+
+        test('for key not in map', () {
+          final value = testMap.remove('not in the map');
+          expect(testMap, {'foo': 1, 'bar': 2});
+          expect(value, isNull);
+        });
+      });
+    });
   });
 }
+
+@JS('Object.freeze')
+external void _objectFreeze(JsMap object);

--- a/test/react_client/js_backed_map_test.dart
+++ b/test/react_client/js_backed_map_test.dart
@@ -72,6 +72,7 @@ main() {
         'baz': 3,
       });
     });
+
     test('is equal to other instances backed by the same JS object', () {
       final jsObjectA = JsMap();
       final jsObjectB = JsMap();

--- a/test/react_component_test.dart
+++ b/test/react_component_test.dart
@@ -1,0 +1,101 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+@TestOn('browser')
+
+import 'package:react/react.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('Component2', () {
+    Component2 component;
+
+    setUpAll(() {
+      component = new MyComponent();
+    });
+
+    group('throws when unsupported lifecycle methods are called (e.g., via super-calls)', () {
+      test('getInitialState', () {
+        expect(() => component.getInitialState(), throwsUnsupportedError);
+      });
+      test('getDefaultProps', () {
+        expect(() => component.getDefaultProps(), throwsUnsupportedError);
+      });
+      test('componentWillMount', () {
+        expect(() => component.componentWillMount(), throwsUnsupportedError);
+      });
+      test('componentWillReceiveProps', () {
+        expect(() => component.componentWillReceiveProps(null), throwsUnsupportedError);
+      });
+      test('componentWillUpdate', () {
+        expect(() => component.componentWillUpdate(null, null), throwsUnsupportedError);
+      });
+      test('getChildContext', () {
+        expect(() => component.getChildContext(), throwsUnsupportedError);
+      });
+      test('shouldComponentUpdateWithContext', () {
+        expect(() => component.shouldComponentUpdateWithContext(null, null, null), throwsUnsupportedError);
+      });
+      test('componentWillUpdateWithContext', () {
+        expect(() => component.componentWillUpdateWithContext(null, null, null), throwsUnsupportedError);
+      });
+      test('componentWillReceivePropsWithContext', () {
+        expect(() => component.componentWillReceivePropsWithContext(null, null), throwsUnsupportedError);
+      });
+    });
+
+    group('throws when unsupported members inherited from Component are used', () {
+      test('replaceState', () {
+        expect(() => component.replaceState(null), throwsUnsupportedError);
+      });
+      test('childContextKeys getter', () {
+        expect(() => component.childContextKeys, throwsUnsupportedError);
+      });
+      test('contextKeys getter', () {
+        expect(() => component.contextKeys, throwsUnsupportedError);
+      });
+      test('initComponentInternal', () {
+        expect(() => component.initComponentInternal(null, null), throwsUnsupportedError);
+      });
+      test('initStateInternal', () {
+        expect(() => component.initStateInternal(), throwsUnsupportedError);
+      });
+      test('nextContext getter', () {
+        expect(() => component.nextContext, throwsUnsupportedError);
+      });
+      test('nextContext setter', () {
+        expect(() => component.nextContext = null, throwsUnsupportedError);
+      });
+      test('prevContext getter', () {
+        expect(() => component.prevContext, throwsUnsupportedError);
+      });
+      test('prevContext setter', () {
+        expect(() => component.prevContext = null, throwsUnsupportedError);
+      });
+      test('prevState getter', () {
+        expect(() => component.prevState, throwsUnsupportedError);
+      });
+      test('nextState getter', () {
+        expect(() => component.nextState, throwsUnsupportedError);
+      });
+      test('nextProps getter', () {
+        expect(() => component.nextProps, throwsUnsupportedError);
+      });
+      test('transferComponentState', () {
+        expect(() => component.transferComponentState(), throwsUnsupportedError);
+      });
+      test('ref getter', () {
+        expect(() => component.ref, throwsUnsupportedError);
+      });
+      test('setStateCallbacks getter', () {
+        expect(() => component.setStateCallbacks, throwsUnsupportedError);
+      });
+      test('transactionalSetStateCallbacks getter', () {
+        expect(() => component.transactionalSetStateCallbacks, throwsUnsupportedError);
+      });
+    });
+  });
+}
+
+class MyComponent extends Component2 {
+  @override
+  render() => null;
+}

--- a/test/util.dart
+++ b/test/util.dart
@@ -32,8 +32,8 @@ bool isDartComponent(ReactElement element) {
   return element.type is! String && (element.type as ReactClass).dartComponentVersion != null;
 }
 
-react.Component getDartComponent(ReactComponent dartComponent) {
-  return dartComponent.dartComponent;
+T getDartComponent<T extends react.Component>(ReactComponent dartComponent) {
+  return dartComponent.dartComponent as T;
 }
 
 Map getDartComponentProps(ReactComponent dartComponent) {


### PR DESCRIPTION
### Motivation
There were missing tests for some of the new Component2 code.

### Changes
- Add full test coverage for `JsBackedMap` methods
    - Fix hashCode in DDC
- Add missing test coverage for `setStateWithUpdater` arguments
- Add tests for Component2Bridge
- Add tests for throwing `UnsupportedError`, fix missing `throws` keywords

Boyscouting:
- Make `bridgeForComponent` protected.

### Testing Instrructions
- Ensure CI passes