### PR TITLE
CPLAT-7369 Add Check for Dart Map

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -855,8 +855,12 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-    props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
-  }
+      if (style is! Map) {
+        props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
+      } else {
+        props['style'] = Map<String, dynamic>.from(JsBackedMap.from(style));
+      }
+    }
 
   return props;
 }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -848,8 +848,8 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = Map.from(JsBackedMap.backedBy(instance.props));
 
   // Catch if a Dart component has been passed in.
-  if (props['internal'] != null || (props['style'] != null && props['style'] is Map)) {
-    throw new Exception('A Dart Component cannot be passed into unconvertJsProps.');
+  if (props['internal'] is ReactDartComponentInternal || (props['style'] != null && props['style'] is Map)) {
+    throw new ArgumentError('A Dart Component cannot be passed into unconvertJsProps.');
   }
 
   eventPropKeyToEventFactory.keys.forEach((key) {

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -847,7 +847,10 @@ final Expando<Function> _originalEventHandlers = new Expando();
 Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = Map.from(JsBackedMap.backedBy(instance.props));
 
-  // Catch if a Dart component has been passed in.
+  // Catch if a Dart component has been passed in. Component (version 1) can be identified by having the "internal"
+  // prop value. Component2, however, does not have that but can be detected by checking whether or not the style
+  // prop is a Map. Because both a ReactElement and a ReactComponent will have a JS Object, it can be assumed that if
+  // the style prop is a Map then it is a Component.
   if (props['internal'] is ReactDartComponentInternal || (props['style'] != null && props['style'] is Map)) {
     throw new ArgumentError('A Dart Component cannot be passed into unconvertJsProps.');
   }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -846,10 +846,10 @@ final Expando<Function> _originalEventHandlers = new Expando();
 /// Dart synthetic counterparts.
 Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = Map.from(JsBackedMap.backedBy(instance.props));
-  
+
   // Catch if a Dart component has been passed in.
   if (props['internal'] != null || (props['style'] != null && props['style'] is Map)) {
-    throw new Exception('A Dart Component cannot be passed into unconvertJsProps');
+    throw new Exception('A Dart Component cannot be passed into unconvertJsProps.');
   }
 
   eventPropKeyToEventFactory.keys.forEach((key) {
@@ -861,7 +861,7 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-      props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
+    props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
   }
 
   return props;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -849,8 +849,8 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
 
   // Catch if a Dart component has been passed in. Component (version 1) can be identified by having the "internal"
   // prop value. Component2, however, does not have that but can be detected by checking whether or not the style
-  // prop is a Map. Because both a ReactElement and a ReactComponent will have a JS Object, it can be assumed that if
-  // the style prop is a Map then it is a Component.
+  // prop is a Map. Because non-Dart components will have a JS Object, it can be assumed that if the style prop is a
+  // Map then it is a Dart Component.
   if (props['internal'] is ReactDartComponentInternal || (props['style'] != null && props['style'] is Map)) {
     throw new ArgumentError('A Dart Component cannot be passed into unconvertJsProps.');
   }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -846,6 +846,12 @@ final Expando<Function> _originalEventHandlers = new Expando();
 /// Dart synthetic counterparts.
 Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = Map.from(JsBackedMap.backedBy(instance.props));
+  
+  // Catch if a Dart component has been passed in.
+  if (props['internal'] != null || (props['style'] != null && props['style'] is Map)) {
+    throw new Exception('A Dart Component cannot be passed into unconvertJsProps');
+  }
+
   eventPropKeyToEventFactory.keys.forEach((key) {
     if (props.containsKey(key)) {
       props[key] = unconvertJsEventHandler(props[key]) ?? props[key];
@@ -855,11 +861,7 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-    if (style is! Map) {
       props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
-    } else {
-      props['style'] = Map<String, dynamic>.from(JsBackedMap.from(style));
-    }
   }
 
   return props;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -848,9 +848,9 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = Map.from(JsBackedMap.backedBy(instance.props));
 
   // Catch if a Dart component has been passed in. Component (version 1) can be identified by having the "internal"
-  // prop value. Component2, however, does not have that but can be detected by checking whether or not the style
-  // prop is a Map. Because non-Dart components will have a JS Object, it can be assumed that if the style prop is a
-  // Map then it is a Dart Component.
+  // prop. Component2, however, does not have that but can be detected by checking whether or not the style prop is a
+  // Map. Because non-Dart components will have a JS Object, it can be assumed that if the style prop is a Map then
+  // it is a Dart Component.
   if (props['internal'] is ReactDartComponentInternal || (props['style'] != null && props['style'] is Map)) {
     throw new ArgumentError('A Dart Component cannot be passed into unconvertJsProps.');
   }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -855,12 +855,12 @@ Map unconvertJsProps(/* ReactElement|ReactComponent */ instance) {
   // Convert the nested style map so it can be read by Dart code.
   var style = props['style'];
   if (style != null) {
-      if (style is! Map) {
-        props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
-      } else {
-        props['style'] = Map<String, dynamic>.from(JsBackedMap.from(style));
-      }
+    if (style is! Map) {
+      props['style'] = Map<String, dynamic>.from(JsBackedMap.backedBy(style));
+    } else {
+      props['style'] = Map<String, dynamic>.from(JsBackedMap.from(style));
     }
+  }
 
   return props;
 }

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -6,6 +6,8 @@ library react_test_utils_test;
 import 'dart:html' show DivElement;
 
 import 'package:js/js.dart';
+import 'package:react/react.dart';
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
@@ -14,6 +16,8 @@ import 'package:react/react_client/react_interop.dart' show React, ReactComponen
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/src/react_client/event_prop_key_to_event_factory.dart';
+
+import 'test_components.dart';
 
 main() {
   setClientConfiguration();
@@ -37,6 +41,28 @@ main() {
         }),
       );
       expect(unconvertJsProps(instance)['style'], isA<Map<String, dynamic>>());
+    });
+
+    test('returns props for a Dart component (Component2)', () {
+      final instance = DartComponent2({
+        'jsProp': 'js',
+        'style': testStyle,
+      }, testChildren);
+
+      expect(() => unconvertJsProps(instance),
+        throwsException
+      );
+    });
+
+    test('returns props for a Dart component', () {
+      final instance = DartComponent({
+        'jsProp': 'js',
+        'style': testStyle,
+      }, testChildren);
+
+      expect(() => unconvertJsProps(instance),
+          throwsException
+      );
     });
 
     test('returns props for a composite JS ReactComponent', () {
@@ -167,3 +193,23 @@ final Function testJsComponentFactory = (() {
     return reactFactory(jsifyAndAllowInterop(props), listifyChildren(children));
   };
 })();
+
+class DartComponent2Component extends Component2 {
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+ReactDartComponentFactoryProxy2 DartComponent2 = react.registerComponent(() => new DartComponent2Component());
+
+class DartComponentComponent extends Component {
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+ReactDartComponentFactoryProxy DartComponent = react.registerComponent(() => new DartComponentComponent());

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -43,26 +43,22 @@ main() {
       expect(unconvertJsProps(instance)['style'], isA<Map<String, dynamic>>());
     });
 
-    test('returns props for a Dart component (Component2)', () {
+    test('throws when a Dart component (Component2) is passed in', () {
       final instance = DartComponent2({
         'jsProp': 'js',
         'style': testStyle,
       }, testChildren);
 
-      expect(() => unconvertJsProps(instance),
-        throwsException
-      );
+      expect(() => unconvertJsProps(instance), throwsException);
     });
 
-    test('returns props for a Dart component', () {
+    test('throws when a Dart component is passed in', () {
       final instance = DartComponent({
         'jsProp': 'js',
         'style': testStyle,
       }, testChildren);
 
-      expect(() => unconvertJsProps(instance),
-          throwsException
-      );
+      expect(() => unconvertJsProps(instance), throwsException);
     });
 
     test('returns props for a composite JS ReactComponent', () {
@@ -195,7 +191,6 @@ final Function testJsComponentFactory = (() {
 })();
 
 class DartComponent2Component extends Component2 {
-
   @override
   render() {
     return null;
@@ -205,7 +200,6 @@ class DartComponent2Component extends Component2 {
 ReactDartComponentFactoryProxy2 DartComponent2 = react.registerComponent(() => new DartComponent2Component());
 
 class DartComponentComponent extends Component {
-
   @override
   render() {
     return null;

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -7,7 +7,6 @@ import 'dart:html' show DivElement;
 
 import 'package:js/js.dart';
 import 'package:react/react.dart';
-import 'package:react/react_client/js_backed_map.dart';
 import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
@@ -16,8 +15,6 @@ import 'package:react/react_client/react_interop.dart' show React, ReactComponen
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/src/react_client/event_prop_key_to_event_factory.dart';
-
-import 'test_components.dart';
 
 main() {
   setClientConfiguration();
@@ -49,7 +46,7 @@ main() {
         'style': testStyle,
       }, testChildren);
 
-      expect(() => unconvertJsProps(instance), throwsException);
+      expect(() => unconvertJsProps(instance), throwsArgumentError);
     });
 
     test('throws when a Dart component is passed in', () {
@@ -58,7 +55,7 @@ main() {
         'style': testStyle,
       }, testChildren);
 
-      expect(() => unconvertJsProps(instance), throwsException);
+      expect(() => unconvertJsProps(instance), throwsArgumentError);
     });
 
     test('returns props for a composite JS ReactComponent', () {


### PR DESCRIPTION
## Why?
`unconvertJsProps` will take in a Dart `Component`, when it shouldn't. This PR adds a check and throws if that happens.

## Changes
- Add an if statement checking for `Component` only props, and throw if they're found.