### PR TITLE
Remove Component.bind

### DIFF
--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -24,6 +24,7 @@ class _HelloGreeter extends react.Component {
   onInputChange(e) {
     var input = react_dom.findDOMNode(myInput);
     print(input.borderEdge);
+    setState({'name': e.target.value});
   }
 
   render() {
@@ -32,7 +33,7 @@ class _HelloGreeter extends react.Component {
         'key': 'input',
         'className': 'form-control',
         'ref': (ref) => myInput = ref,
-        'value': bind('name'),
+        'value': state['name'],
         'onChange': onInputChange,
       }),
       helloComponent({'key': 'hello', 'name': state['name']})
@@ -45,7 +46,7 @@ var helloGreeter = react.registerComponent(() => new _HelloGreeter());
 class _CheckBoxComponent extends react.Component {
   getInitialState() => {"checked": false};
 
-  change(e) {
+  _handleChange(e) {
     this.setState({'checked': e.target.checked});
   }
 
@@ -58,7 +59,8 @@ class _CheckBoxComponent extends react.Component {
         'key': 'input',
         'className': 'form-check-input',
         'type': 'checkbox',
-        'value': bind('checked'),
+        'checked': state['checked'],
+        'onChange': _handleChange,
       }),
       react.label({
         'htmlFor': 'doTheDishes',

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -116,20 +116,6 @@ abstract class Component {
   /// to be set for debugging purposes.
   String get displayName => runtimeType.toString();
 
-  /// > Bind the value of input to [state[key]].
-  ///
-  /// __DEPRECATED.__
-  ///
-  /// This will be removed in the `6.0.0` release when `Component` is removed.
-  ///
-  /// There is currently no planned support for it within `Component2` which will be released in `5.1.0`
-  /// since there was never a ReactJS analogue for this API.
-  @Deprecated('6.0.0')
-  bind(key) => [
-        state[key],
-        (value) => setState({key: value})
-      ];
-
   initComponentInternal(props, _jsRedraw, [Ref ref, _jsThis, context]) {
     this._jsRedraw = _jsRedraw;
     this.ref = ref;

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -407,7 +407,6 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
 
   /// Prepares the bound values, event handlers, and style props for consumption by ReactJS DOM components.
   static void convertProps(Map props) {
-    _convertBoundValues(props);
     _convertEventHandlers(props);
   }
 }
@@ -449,29 +448,6 @@ _setValueToProps(Map props, val) {
     }
   } else {
     props['value'] = val;
-  }
-}
-
-/// Convert bound values to pure value and packed onChange function
-///
-/// TODO: Remove in 6.0.0 when [Component.bind] is removed.
-_convertBoundValues(Map args) {
-  var boundValue = args['value'];
-
-  if (boundValue is List) {
-    _setValueToProps(args, boundValue[0]);
-    args['value'] = boundValue[0];
-    var onChange = args['onChange'];
-
-    // Put new function into onChange event handler.
-    // If there was something listening for that event, trigger it and return its return value.
-    args['onChange'] = (event) {
-      boundValue[1](_getValueFromDom(event.target));
-
-      if (onChange != null) {
-        return onChange(event);
-      }
-    };
   }
 }
 


### PR DESCRIPTION
`Component.bind` was slated for removal in 5.0.0, and got removed in 5.1.0-wip, but not 5.0.0-wip. We need to remove it.

Note that  the deprecation in master is "5.0.0", while 5.0.0-wip has the out-of-date "6.0.0":
https://github.com/cleandart/react-dart/blob/master/lib/react.dart#L125-L126