### PR TITLE
CPLAT-7459 Test coverage improvements and miscellaneous fixes

### DIFF
--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -17,7 +17,7 @@ class _ChildComponent extends react.Component {
   render() => react.span({}, "Child element with value ${somevalue}");
 }
 
-var InputComponentForm = forwardRef((props, ref) {
+var InputComponentForm = react.forwardRef((props, ref) {
   return react.form({
     'key': 'inputForm',
     'className': 'form-inline'
@@ -37,7 +37,7 @@ var InputComponentForm = forwardRef((props, ref) {
   ]);
 });
 
-var ChildComponentForm = forwardRef((props, ref) {
+var ChildComponentForm = react.forwardRef((props, ref) {
   return react.Fragment({}, [
     react.h4({'key': 'create-child-h4'}, "ChildComponent"),
     react.form({
@@ -100,8 +100,8 @@ class _ParentComponent extends react.Component {
   }
 
   // Create refs
-  final Ref<InputElement> _inputCreateRef = createRef();
-  final Ref<_ChildComponent> _childCreateRef = createRef();
+  final Ref<InputElement> _inputCreateRef = react.createRef();
+  final Ref<_ChildComponent> _childCreateRef = react.createRef();
 
   showInputCreateRefValue(_) {
     var input = react_dom.findDOMNode(_inputCreateRef.current);

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -16,6 +16,7 @@ import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/context.dart';
 
 export 'package:react/src/context.dart';
+export 'package:react/react_client/react_interop.dart' show forwardRef, createRef;
 
 typedef Error PropValidator<TProps>(
     TProps props, String propName, String componentName, String location, String propFullName);

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -614,7 +614,8 @@ ReactDartComponentFactoryProxy _registerComponent(
   /// Create the JS [`ReactClass` component class](https://facebook.github.io/react/docs/top-level-api.html#react.createclass)
   /// with custom JS lifecycle methods.
   var reactComponentClass = createReactDartComponentClass(_dartInteropStatics, componentStatics, jsConfig)
-    ..dartComponentVersion = '1'
+    // ignore: invalid_use_of_protected_member
+    ..dartComponentVersion = ReactDartComponentVersion.component
     ..displayName = componentFactory().displayName;
 
   // Cache default props and store them on the ReactClass so they can be used
@@ -769,8 +770,8 @@ ReactDartComponentFactoryProxy2 _registerComponent2(
   var reactComponentClass =
       createReactDartComponentClass2(_ReactDartInteropStatics2.staticsForJs, componentStatics, jsConfig2)
         ..displayName = componentInstance.displayName;
-
-  reactComponentClass.dartComponentVersion = '2';
+  // ignore: invalid_use_of_protected_member
+  reactComponentClass.dartComponentVersion = ReactDartComponentVersion.component2;
 
   return new ReactDartComponentFactoryProxy2(reactComponentClass);
 }

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -27,8 +27,7 @@ import "package:react/src/react_client/synthetic_event_wrappers.dart" as events;
 import 'package:react/src/typedefs.dart';
 import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_function_name_bug;
 
-export 'package:react/react_client/react_interop.dart'
-    show ReactElement, ReactJsComponentFactory, inReactDevMode, Ref, forwardRef, createRef;
+export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode, Ref;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 
 /// The type of [Component.ref] specified as a callback.

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -712,11 +712,18 @@ class ReactJsComponentFactoryProxy extends ReactComponentFactoryProxy {
     }
 
     Map potentiallyConvertedProps;
-    if (shouldConvertDomProps) {
+
+    final mightNeedConverting = shouldConvertDomProps || props['ref'] != null;
+    if (mightNeedConverting) {
       // We can't mutate the original since we can't be certain that the value of the
       // the converted event handler will be compatible with the Map's type parameters.
-      potentiallyConvertedProps = new Map.from(props);
-      _convertEventHandlers(potentiallyConvertedProps);
+      // We also want to avoid mutating the original map where possible.
+      // So, make a copy and mutate that.
+      potentiallyConvertedProps = Map.from(props);
+      if (shouldConvertDomProps) {
+        _convertEventHandlers(potentiallyConvertedProps);
+      }
+      _convertRefValue(potentiallyConvertedProps);
     } else {
       potentiallyConvertedProps = props;
     }

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -187,8 +187,44 @@ class ReactClass {
   @Deprecated('6.0.0')
   external set dartDefaultProps(Map value);
 
+  /// A string to distinguish between different Dart component implementations / base classes.
+  ///
+  /// See [ReactDartComponentVersion] for values.
+  ///
+  /// __For internal use only.__
+  @protected
   external String get dartComponentVersion;
+  @protected
   external set dartComponentVersion(String value);
+}
+
+/// Constants for use with [ReactClass.dartComponentVersion] to distinguish
+/// different versions of Dart component implementations / base classes.
+///
+/// __For internal use only.__
+@protected
+@sealed
+abstract class ReactDartComponentVersion {
+  /// A [Component]-based component.
+  @protected
+  static const String component = '1';
+
+  /// A [Component2]-based component.
+  @protected
+  static const String component2 = '2';
+
+  /// Returns [ReactClass.dartComponentVersion] if [type] is the [ReactClass] for a Dart component
+  /// (a react-dart [ReactElement] or [ReactComponent]), and null otherwise.
+  @protected
+  static String fromType(dynamic type) {
+    // This check doesn't do much since ReactClass is an  an anonymous JS object,
+    // but it lets us safely cast to ReactClass.
+    if (type is ReactClass) {
+      return type.dartComponentVersion;
+    }
+
+    return null;
+  }
 }
 
 /// A JS interop class used as an argument to [React.createClass].

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -104,17 +104,17 @@ class JsRef {
 ///
 /// See: <https://reactjs.org/docs/forwarding-refs.html>.
 ReactJsComponentFactoryProxy forwardRef(Function(Map props, Ref ref) wrapperFunction) {
-  var hoc = _jsForwardRef(allowInterop((JsMap props, Ref ref) {
-    var dartProps = new JsBackedMap.backedBy(props);
-
-    return wrapperFunction(dartProps, ref);
+  var hoc = _jsForwardRef(allowInterop((JsMap props, JsRef ref) {
+    final dartProps = JsBackedMap.backedBy(props);
+    final dartRef = Ref.fromJs(ref);
+    return wrapperFunction(dartProps, dartRef);
   }));
 
   return new ReactJsComponentFactoryProxy(hoc, shouldConvertDomProps: false);
 }
 
 @JS('React.forwardRef')
-external ReactClass _jsForwardRef(Function(JsMap props, Ref ref) wrapperFunction);
+external ReactClass _jsForwardRef(Function(JsMap props, JsRef ref) wrapperFunction);
 
 abstract class ReactDom {
   static Element findDOMNode(object) => ReactDOM.findDOMNode(object);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -57,39 +57,43 @@ abstract class React {
 ///     }
 ///
 /// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
-Ref<CurrentType> createRef<CurrentType>() {
-  return new Ref<CurrentType>();
+Ref<T> createRef<T>() {
+  return new Ref<T>();
 }
 
 /// When this is provided as the ref prop, a reference to the rendered component
 /// will be available via [current].
 ///
-/// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
-class Ref<CurrentType> {
+/// See [createRef] for usage examples and more info.
+class Ref<T> {
   /// A JavaScript ref object returned by [React.createRef].
-  JsRef jsRef;
+  final JsRef jsRef;
 
-  Ref() {
-    jsRef = React.createRef();
-  }
+  Ref() : jsRef = React.createRef();
+
+  Ref.fromJs(this.jsRef);
 
   /// A reference to the latest instance of the rendered component.
   ///
-  /// See: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
-  CurrentType get current {
+  /// See [createRef] for usage examples and more info.
+  T get current {
     final jsCurrent = jsRef.current;
 
     if (jsCurrent is! Element) {
       final dartCurrent = (jsCurrent as ReactComponent)?.dartComponent;
 
       if (dartCurrent != null) {
-        return dartCurrent as CurrentType;
+        return dartCurrent as T;
       }
     }
     return jsCurrent;
   }
 }
 
+/// A JS ref object returned by [React.createRef].
+///
+/// Dart factories will automatically unwrap [Ref] objects to this JS representation,
+/// so using this class directly shouldn't be necessary.
 @JS()
 @anonymous
 class JsRef {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -217,7 +217,7 @@ abstract class ReactDartComponentVersion {
   /// (a react-dart [ReactElement] or [ReactComponent]), and null otherwise.
   @protected
   static String fromType(dynamic type) {
-    // This check doesn't do much since ReactClass is an  an anonymous JS object,
+    // This check doesn't do much since ReactClass is an anonymous JS object,
     // but it lets us safely cast to ReactClass.
     if (type is ReactClass) {
       return type.dartComponentVersion;

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -5,6 +5,7 @@ import 'dart:js';
 import 'dart:js_util';
 
 import 'package:meta/meta.dart';
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:test/test.dart';
 
 import 'package:react/react_client.dart';
@@ -241,13 +242,18 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
       'childId': 'test',
     }));
 
-    // Component props are accessed differently depending on if it is a dom component
-    // or a dart component.
+    // Props are accessed differently for DOM, Dart, and JS components.
     var idValue;
-    if (refObject.current is Element) {
-      idValue = refObject.current.id;
+    final current = refObject.current;
+    expect(current, isNotNull);
+    if (current is Element) {
+      idValue = current.id;
+    } else if (current is react.Component) {
+      idValue = current.props['id'];
+    } else if (rtu.isCompositeComponent(current)) {
+      idValue = JsBackedMap.fromJs((current as ReactComponent).props)['id'];
     } else {
-      idValue = refObject.current.props['id'];
+      fail('Unknown instance type: current');
     }
 
     expect(idValue, equals('test'), reason: 'child component should have access to parent props');

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -229,6 +229,10 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
 
   test('forwardRef function passes a ref through a component to one of its children', () {
     var ForwardRefTestComponent = forwardRef((props, ref) {
+      // Extra type checking since JS refs being passed through
+      // aren't caught by built-in type checking.
+      expect(ref, isA<Ref>());
+
       return factory({
         'ref': ref,
         'id': props['childId'],

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -1,13 +1,13 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: invalid_use_of_protected_member
+@TestOn('browser')
 import 'dart:js';
 
-import 'package:react/react_client/react_interop.dart';
-@TestOn('browser')
 import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_test_utils.dart' as rtu;
 
 import '../util.dart';

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -1,4 +1,8 @@
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: invalid_use_of_protected_member
+import 'dart:js';
+
+import 'package:react/react_client/react_interop.dart';
 @TestOn('browser')
 import 'package:test/test.dart';
 
@@ -43,21 +47,33 @@ main() {
       });
 
       group('utils', () {
+        test('ReactDartComponentVersion.fromType', () {
+          expect(ReactDartComponentVersion.fromType(react.div({}).type), isNull);
+          expect(ReactDartComponentVersion.fromType(JsFoo({}).type), isNull);
+          expect(ReactDartComponentVersion.fromType(Foo({}).type), ReactDartComponentVersion.component);
+          expect(ReactDartComponentVersion.fromType(Foo2({}).type), ReactDartComponentVersion.component2);
+        });
+      });
+
+      group('test utils', () {
         // todo move somewhere else
         test('isDartComponent2', () {
           expect(isDartComponent2(react.div({})), isFalse);
+          expect(isDartComponent2(JsFoo({})), isFalse);
           expect(isDartComponent2(Foo({})), isFalse);
           expect(isDartComponent2(Foo2({})), isTrue);
         });
 
         test('isDartComponent1', () {
           expect(isDartComponent1(react.div({})), isFalse);
+          expect(isDartComponent1(JsFoo({})), isFalse);
           expect(isDartComponent1(Foo({})), isTrue);
           expect(isDartComponent1(Foo2({})), isFalse);
         });
 
         test('isDartComponent', () {
           expect(isDartComponent(react.div({})), isFalse);
+          expect(isDartComponent(JsFoo({})), isFalse);
           expect(isDartComponent(Foo({})), isTrue);
           expect(isDartComponent(Foo2({})), isTrue);
         });
@@ -79,3 +95,8 @@ class _Foo2 extends react.Component2 {
   @override
   render() => react.div({});
 }
+
+final JsFoo = ReactJsComponentFactoryProxy(React.createClass(ReactClassConfig(
+  displayName: 'JsFoo',
+  render: allowInterop(() => react.div({})),
+)));

--- a/test/factory/js_factory_test.dart
+++ b/test/factory/js_factory_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_test_utils.dart';
 
 import 'common_factory_tests.dart';
 
@@ -20,6 +21,12 @@ main() {
 
     group('- dom event handler wrapping -', () {
       domEventHandlerWrappingTests(JsFoo);
+    });
+
+    group('- refs -', () {
+      refTests(JsFoo, verifyRefValue: (ref) {
+        expect(isCompositeComponentWithTypeV2(ref, JsFoo), isTrue);
+      });
     });
 
     test('has a type corresponding to the backing JS class', () {

--- a/test/util.dart
+++ b/test/util.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: invalid_use_of_protected_member
 @JS()
 library react.test.util;
 
@@ -20,17 +21,13 @@ Map getProps(dynamic elementOrComponent) {
   return new Map.fromIterable(_objectKeys(props), value: (key) => getProperty(props, key));
 }
 
-bool isDartComponent1(ReactElement element) {
-  return element.type is! String && (element.type as ReactClass).dartComponentVersion == '1';
-}
+bool isDartComponent1(ReactElement element) =>
+    ReactDartComponentVersion.fromType(element.type) == ReactDartComponentVersion.component;
 
-bool isDartComponent2(ReactElement element) {
-  return element.type is! String && (element.type as ReactClass).dartComponentVersion == '2';
-}
+bool isDartComponent2(ReactElement element) =>
+    ReactDartComponentVersion.fromType(element.type) == ReactDartComponentVersion.component2;
 
-bool isDartComponent(ReactElement element) {
-  return element.type is! String && (element.type as ReactClass).dartComponentVersion != null;
-}
+bool isDartComponent(ReactElement element) => ReactDartComponentVersion.fromType(element.type) != null;
 
 T getDartComponent<T extends react.Component>(ReactComponent dartComponent) {
   return dartComponent.dartComponent as T;


### PR DESCRIPTION
### Motivation
There were some missing areas of test coverage for some of the new APIs added in 5.x, as well as some issues discovered while improving test coverage in the corresponding React 16 branches of over_react.

### Changes
- Move export of `createRef`/`forwardRef` to `react.dart` instead of `react_client.dart` to avoid conflicting with over_react's exports of similarly-named functions. This change makes them consistent with other react-dart APIs replaced by over_react (findDomNode, Component, etc.)
- Add missing test coverage for refs for JS components, fix conversion of Dart `Ref` objects
- Fix `forwardRef` passing through a `JsRef` instead of a `Ref` to the consumer-provided function
- Add `ReactDartComponentVersion` w/ constants and helpers around `ReactClass.dartComponentVersion`
- `Ref` class boyscouting:
    - doc comment cleanup
    - update generic parameter to follow [single-letter conventions](https://dart.dev/guides/language/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters), since the word "current" in that context if anything makes the parameter more confusing


### Testing
- Unit tests pass
- Tests in over_react PR pass: https://github.com/Workiva/over_react/pull/338