### PR TITLE
Restore Dart 1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ jobs:
         - dartanalyzer .
         - pub run test -p chrome
         - pub run build_runner test -- -p chrome
+    - stage: Dart 1
+      dart: 1.24.3
+      before_install:
+        - sed -i '/Remove if solving times out in Dart 1/d'  pubspec.yaml
+      script:
+        - dartanalyzer .
+        - pub run test -p chrome

--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:html';
 
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
@@ -263,7 +263,7 @@ class _GeocodesApp extends react.Component {
         // If yes, query was `OK` and `shown_addresses` are replaced
         state['history'][id]['status'] = 'OK';
 
-        var data = json.decode(raw);
+        var data = convert.json.decode(raw);
 
         // Calling `setState` will update the state and then repaint the component.
         //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,14 @@ authors:
 description: Bindings of the ReactJS library for building interactive interfaces.
 homepage: https://github.com/cleandart/react-dart
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=1.24.3 <3.0.0'
 dependencies:
-  js: ^0.6.1+1
+  js: ^0.6.0
   meta: ^1.1.6
 dev_dependencies:
-  build_runner: ^1.6.5
-  build_test: ^0.10.8
-  build_web_compilers: ^2.1.4
+  build_runner: ">=0.6.0 <2.0.0"         # Remove if solving times out in Dart 1
+  build_test: ">=0.9.0 <1.0.0"           # Remove if solving times out in Dart 1
+  build_web_compilers: ">=0.2.0 <3.0.0"  # Remove if solving times out in Dart 1
+  dart2_constant: ^1.0.0
   dependency_validator: ^1.2.0
-  test: ^1.6.5
+  test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
The decision has been made to not remove Dart 1 support until the `5.1.0` release that will follow the `5.0.0` release.

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 