### PR TITLE
CPLAT-7571 Remove on Keyword

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -1174,11 +1174,14 @@ abstract class Component2 implements Component {
 ///       /* Include other standard component logic */
 ///
 ///     }
-mixin TypedSnapshot<TSnapshot> on Component2 {
-  @override
+///
+/// This mixin should only be used with `Component2` or `UiComponent2`. This is not
+/// enforced via the `on` keyword because of an issue with the Dart SDK.
+///
+/// See: <https://github.com/dart-lang/sdk/issues/38098>
+mixin TypedSnapshot<TSnapshot> {
   TSnapshot getSnapshotBeforeUpdate(Map prevProps, Map prevState);
 
-  @override
   void componentDidUpdate(Map prevProps, Map prevState, [covariant TSnapshot snapshot]);
 }
 


### PR DESCRIPTION
# Motivation
`TypedSnapshot uses` the on keyword to enforce that the mixin is only used with children of `Component2`. However, because `PropTypes` is implemented in `UiComponent2`, `TypedSnapshot` does not mix with `UiComponent2` well. This is related to https://github.com/dart-lang/sdk/issues/38098.

# Changes
- Remove the `on` keyword, and ultimately the dependency upon using the mixin with `Component2` based classes.

@aaronlademann-wf @greglittlefield-wf @kealjones-wk @sydneyjodon-wk 