### PR TITLE
Release react 5.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-## [5.0.0-alpha.0](https://github.com/cleandart/react-dart/compare/4.9.1...5.0.0-alpha.0)
+## 5.0.0 (alpha)
 
-__ReactJS 16.x Support__
+- [5.0.0-alpha.1](https://github.com/cleandart/react-dart/compare/5.0.0-alpha.0...5.0.0-alpha.1)
 
-- The underlying `.js` files provided by this package are now ReactJS version 16.
-- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `5.1.0`](https://github.com/cleandart/react-dart/milestone/1).
+  - [#216] Update to ReactJS version 16.10.1
+
+- [5.0.0-alpha.0](https://github.com/cleandart/react-dart/compare/4.9.1...5.0.0-alpha.0)
+
+  __ReactJS 16.x Support__
+
+  - The underlying `.js` files provided by this package are now ReactJS version 16.
+  - Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `5.1.0`](https://github.com/cleandart/react-dart/milestone/1).
 
 > [Full list of 5.0.0 Pull Requests](https://github.com/cleandart/react-dart/milestone/2?closed=1) 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Dart wrapper for [React JS](https://reactjs.org/)
 
-[![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dartlang.org/packages/react)
+[![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dev/packages/react)
 ![ReactJS v16.10.1](https://img.shields.io/badge/React_JS-v16.10.1-green.svg)
 [![Build Status](https://travis-ci.com/cleandart/react-dart.svg?branch=master)](https://travis-ci.com/cleandart/react-dart)
-[![React Dart API Docs](https://img.shields.io/badge/api_docs-react-blue.svg)](https://pub.dartlang.org/documentation/react/latest/)
+[![React Dart API Docs](https://img.shields.io/badge/api_docs-react-blue.svg)](https://pub.dev/documentation/react/latest/)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dart wrapper for [React JS](https://reactjs.org/)
 
 [![Pub](https://img.shields.io/pub/v/react.svg)](https://pub.dartlang.org/packages/react)
-![ReactJS v16.8.6](https://img.shields.io/badge/React_JS-v16.8.6-green.svg)
+![ReactJS v16.10.1](https://img.shields.io/badge/React_JS-v16.10.1-green.svg)
 [![Build Status](https://travis-ci.com/cleandart/react-dart.svg?branch=master)](https://travis-ci.com/cleandart/react-dart)
 [![React Dart API Docs](https://img.shields.io/badge/api_docs-react-blue.svg)](https://pub.dartlang.org/documentation/react/latest/)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 5.0.0-alpha.0
+version: 5.0.0-alpha.1
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>


### PR DESCRIPTION
This __alpha__ release bumps the ReactJS version to 16.10.1 (#216)