### PR TITLE
Release react 5.0.0 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
-## 5.0.0 (alpha)
-
-- [5.0.0-alpha.1](https://github.com/cleandart/react-dart/compare/5.0.0-alpha.0...5.0.0-alpha.1)
-
-  - [#216] Update to ReactJS version 16.10.1
-
-- [5.0.0-alpha.0](https://github.com/cleandart/react-dart/compare/4.9.1...5.0.0-alpha.0)
+## [5.0.0](https://github.com/cleandart/react-dart/compare/4.9.1...5.0.0)
 
   __ReactJS 16.x Support__
 
   - The underlying `.js` files provided by this package are now ReactJS version 16.
   - Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `5.1.0`](https://github.com/cleandart/react-dart/milestone/1).
 
-> [Full list of 5.0.0 Pull Requests](https://github.com/cleandart/react-dart/milestone/2?closed=1) 
+> [Full list of 5.0.0 Changes](https://github.com/cleandart/react-dart/milestone/2?closed=1) 
+
+> __[Full List of Breaking Changes](https://github.com/cleandart/react-dart/pull/224)__
 
 ## [4.9.1](https://github.com/cleandart/react-dart/compare/4.9.0...4.9.1)
 - [#205] Fix `context` setter typing to match getter and not fail `implicit_casts: false`

--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -103,7 +103,7 @@ var geocodesResultList = react.registerComponent(() => new _GeocodesResultList()
 ///
 /// > The functions can be [Component] parameters _(handy for callbacks)_
 ///
-/// > The DOM [Element]s can be accessed using [ref]s.
+/// > The DOM [Element]s can be accessed using `ref`s.
 class _GeocodesForm extends react.Component {
   var searchInputInstance;
 

--- a/example/test/get_dom_node_test.dart
+++ b/example/test/get_dom_node_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 
 import "package:react/react.dart" as react;

--- a/example/test/ref_test.dart
+++ b/example/test/ref_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use_from_same_package
 import "dart:html";
 
 import "package:react/react.dart" as react;

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 /// A Dart library for building UI using ReactJS.
 library react;
 

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 @JS()
 library react_client;
 
@@ -25,7 +27,7 @@ import 'package:react/src/ddc_emulated_function_name_bug.dart' as ddc_emulated_f
 export 'package:react/react_client/react_interop.dart' show ReactElement, ReactJsComponentFactory, inReactDevMode;
 export 'package:react/react.dart' show ReactComponentFactoryProxy, ComponentFactory;
 
-/// The type of [Component.ref] specified as a callback.
+/// The type of `Component.ref` specified as a callback.
 ///
 /// See: <https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute>
 typedef _CallbackRef<T>(T componentOrDomNode);
@@ -414,41 +416,6 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
 /// Create react-dart registered component for the HTML [Element].
 _reactDom(String name) {
   return new ReactDomComponentFactoryProxy(name);
-}
-
-/// Returns whether an [InputElement] is a [CheckboxInputElement] based the value of the `type` key in [props].
-_isCheckbox(props) {
-  return props['type'] == 'checkbox';
-}
-
-/// Get value from the provided [domElem].
-///
-/// If the [domElem] is a [CheckboxInputElement], return [bool], else return [String] value.
-_getValueFromDom(domElem) {
-  var props = domElem.attributes;
-
-  if (_isCheckbox(props)) {
-    return domElem.checked;
-  } else {
-    return domElem.value;
-  }
-}
-
-/// Set value to props based on type of input.
-///
-/// _Note: Processing checkbox `checked` value is handled as a special case._
-_setValueToProps(Map props, val) {
-  if (_isCheckbox(props)) {
-    if (val) {
-      props['checked'] = true;
-    } else {
-      if (props.containsKey('checked')) {
-        props.remove('checked');
-      }
-    }
-  } else {
-    props['value'] = val;
-  }
 }
 
 /// A mapping from converted/wrapped JS handler functions (the result of [_convertEventHandlers])

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -1,6 +1,9 @@
 /// JS interop classes for main React JS APIs and react-dart internals.
 ///
 /// For use in `react_client.dart` and by advanced react-dart users.
+
+// ignore_for_file: deprecated_member_use_from_same_package
+
 @JS()
 library react_client.react_interop;
 
@@ -53,7 +56,7 @@ abstract class ReactDomServer {
 //   Types and data structures
 // ----------------------------------------------------------------------------
 
-/// A React class specification returned by [React.createClass].
+/// A React class specification returned by `React.createClass`.
 ///
 /// To be used as the value of [ReactElement.type], which is set upon initialization
 /// by a component factory or by [React.createElement].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 5.0.0-alpha.1
+version: 5.0.0
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -3,7 +3,6 @@ import 'dart:html';
 import 'dart:js';
 import 'dart:js_util';
 
-import 'dart:js_util';
 import 'package:test/test.dart';
 
 import 'package:react/react_client.dart';
@@ -195,6 +194,7 @@ void refTests(ReactComponentFactoryProxy factory, {void verifyRefValue(dynamic r
   test('string refs are created with the correct value', () {
     ReactComponent renderedInstance = _renderWithOwner(() => factory({'ref': 'test'}));
 
+    // ignore: deprecated_member_use_from_same_package
     verifyRefValue(renderedInstance.dartComponent.ref('test'));
   });
 }

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -3,7 +3,6 @@ import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_test_utils.dart' as rtu;
 
 import 'common_factory_tests.dart';
 

--- a/test/js_interop_helpers_test/shared_tests.dart
+++ b/test/js_interop_helpers_test/shared_tests.dart
@@ -2,10 +2,9 @@
 library js_function_test;
 
 import 'dart:html';
-import 'dart:js_util';
+import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';
-import 'dart:js_util' as js_util;
 import 'package:react/react_client/react_interop.dart';
 import 'package:test/test.dart';
 

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -405,9 +405,11 @@ void main() {
         void handleFirstStateUpdate() {
           firstStateUpdateCalls++;
           expect(component.state, newState1);
+          // ignore: deprecated_member_use_from_same_package
           component.replaceState(newState2, handleSecondStateUpdate);
         }
 
+        // ignore: deprecated_member_use_from_same_package
         component.replaceState(newState1, handleFirstStateUpdate);
 
         expect(firstStateUpdateCalls, 1);

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/react_interop.dart' show React, ReactClass, ReactComponent;
+import 'package:react/react_client/react_interop.dart' show React, ReactComponent;
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/src/react_client/event_prop_key_to_event_factory.dart';


### PR DESCRIPTION
This stable, __major__ release of react includes:

### ReactJS 16.x Support

- The underlying `.js` files provided by this package are now ReactJS version `16.10.1`.
- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `5.1.0`](https://github.com/cleandart/react-dart/milestone/1).

> [Full list of 5.0.0 Changes](https://github.com/cleandart/react-dart/milestone/2?closed=1) 

🚨 __NOTE: This will be the last release of react that supports the Dart 1 SDK.__   🚨

---

### Breaking Changes

__ReactJS 16 breaking changes__

> Source: https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes

Breakage | Migration path
-- | --
Errors in the render and lifecycle methods now unmount the component tree by default. | To prevent this, add error boundaries to the appropriate places in the UI.This can be done easily via the OverReact `ErrorBoundary` utility component.
Unitless `props.style` string values are no longer auto-converted to `px`.This has been a warning since React 15.0.0. | Change values from Strings to nums, or add a unit explicitly to string
`react_dom.render` calls within React lifecycle methods are no longer guaranteed to be synchronous, and may return `null` | Either: Use Portals to render content in a different DOM treeUpdate code to handle async mounting
`setState` callbacks (second argument) now fire immediately after componentDidMount / componentDidUpdate instead of after all components have rendered. | Transfer callback logic into `componentDidUpdate`.
It is not safe to re-render into a container that was modified by something other than React. This worked previously in some cases but was never supported. We now emit a warning in this case. | Instead you should clean up your component trees using `unmountComponentAtNode`.
Bool values used in non-bool props are no longer stringified, and are ignored. In most cases, passing bool values to these props is a programmer error, and should be replaced with the correct attribute values. | `.toString()` the value in any places where "false" or "true" are needed.
Previously, changing the `ref` to a component would always detach the ref before that component’s render is called. Now, we change the `ref` later, when applying the changes to the DOM. | Should not affect most usages.
When replacing `<A />` with `<B />`, `B.componentWillMount` now always happens before `A.componentWillUnmount`. Previously, `A.componentWillUnmount` could fire first in some cases. | Should not affect most usages. If it does, switching from `componentWillMount` to `componentDidMount` should resolve the issue, and will be functionally equivalent in most cases.

__Dart API breaking changes__

Breakage | Migration path
-- | --
The `react_server.dart` entrypoint has been removed | None
The `react_test.dart` entrypoint has been removed | None
`Component.bind` is removed | Set up event handler manually.
`react_test_utils.SimulateNative` is removed | Use `react_test_utils.Simulate` instead.
`jsify` is removed from `js_interop_helpers.dart` | Use `dart:js`, and replace `jsify` with `JsObject.jsify`.
`getProperty` / `setProperty` are removed from `js_interop_helpers.dart` | Use the same functions from `dart:js` instead.
`ReactComponentFactory` is removed | Use `ReactComponentFactoryProxy` instead.
`emptyJsMap` is removed | Use `newObject()` from `dart:js_util` instead.
`EmptyObject` is removed | Use the class instance created by calling `newObject()` from `dart:js_util` instead.
`ReactComponent.isMounted` is removed | Set up your own flags using component lifecycle methods.

