### PR TITLE
CPLAT-8122 Shorten propTypes boilerplate

### DIFF
--- a/example/test/react_test_components.dart
+++ b/example/test/react_test_components.dart
@@ -7,9 +7,10 @@ import "package:react/react_dom.dart" as react_dom;
 class _HelloComponent extends react.Component2 {
   @override
   get propTypes => {
-        'name': (Map props, propName, componentName, location, propFullName) {
-          if (props[propName].length > 20) {
-            return ArgumentError('(${props[propName]}) is too long. $propName has a max length of 20 characters.');
+        'name': (Map props, info) {
+          String propValue = props[info.propName];
+          if (propValue.length > 20) {
+            return ArgumentError('($propValue) is too long. $propValue has a max length of 20 characters.');
           }
           return null;
         },

--- a/lib/react.dart
+++ b/lib/react.dart
@@ -9,16 +9,15 @@ library react;
 
 import 'package:meta/meta.dart';
 import 'package:react/react_client/bridge.dart';
+import 'package:react/src/prop_validator.dart';
 import 'package:react/src/typedefs.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/context.dart';
 
 export 'package:react/src/context.dart';
+export 'package:react/src/prop_validator.dart';
 export 'package:react/react_client/react_interop.dart' show forwardRef, createRef;
-
-typedef Error PropValidator<TProps>(
-    TProps props, String propName, String componentName, String location, String propFullName);
 
 typedef T ComponentFactory<T extends Component>();
 typedef ReactComponentFactoryProxy ComponentRegistrar(ComponentFactory componentFactory,
@@ -779,39 +778,45 @@ abstract class Component2 implements Component {
   /// See: <https://reactjs.org/docs/react-component.html#static-getderivedstatefromerror>
   Map getDerivedStateFromError(dynamic error) => null;
 
-  /// Allows usage of PropValidator functions to check the validity of a prop passed to it.
+  /// Allows usage of PropValidator functions to check the validity of a prop within the props passed to it.
+  ///
+  /// The second argument (`info`) contains metadata about the prop specified by the key.
+  /// `propName`, `componentName`, `location` and `propFullName` are available.
+  ///
   /// When an invalid value is provided for a prop, a warning will be shown in the JavaScript console.
+  ///
   /// For performance reasons, propTypes is only checked in development mode.
   ///
   /// Simple Example:
   ///
-  ///       @override
-  ///       get propTypes => {
-  ///         'name': (Map props, propName, componentName, location, propFullName) {
-  ///           if (props[propName].length > 20) {
-  ///             return ArgumentError('(${props[propName]}) is too long. $propName has a max length of 20 characters.');
-  ///           }
-  ///           return null;
-  ///         },
-  ///       };
+  /// ```
+  /// @override
+  /// get propTypes => {
+  ///   'name': (Map props, info) {
+  ///     if (props['name'].length > 20) {
+  ///       return ArgumentError('(${props['name']}) is too long. 'name' has a max length of 20 characters.');
+  ///     }
+  ///   },
+  /// };
+  /// ```
   ///
   /// Example of 2 props being dependent:
-  ///       @override
-  ///       get propTypes => {
-  ///         'someProp': (Map props, propName, componentName, location, propFullName) {
-  ///           if (props[propName] == true && props['anotherProp'] == null) {
-  ///             return ArgumentError('If (${props[propName]}) is true. You must have a value for "anotherProp".');
-  ///           }
-  ///           return null;
-  ///         },
-  ///         'anotherProp': (Map props, propName, componentName, location, propFullName) {
-  ///           if (props[propName] != null && props['someProp'] != true) {
-  ///             return ArgumentError('You must set "someProp" to true to use $propName.');
-  ///           }
-  ///           return null;
-  ///         },
-  ///       };
   ///
+  /// ```
+  /// @override
+  /// get propTypes => {
+  ///   'someProp': (Map props, info) {
+  ///     if (props[info.propName] == true && props['anotherProp'] == null) {
+  ///       return ArgumentError('If (${props[info.propName]}) is true. You must have a value for "anotherProp".');
+  ///     }
+  ///   },
+  ///   'anotherProp': (Map props, info) {
+  ///     if (props[info.propName] != null && props['someProp'] != true) {
+  ///       return ArgumentError('You must set "someProp" to true to use $[info.propName].');
+  ///     }
+  ///   },
+  /// };
+  /// ```
   ///
   /// See: <https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes>
   Map<String, PropValidator<Null>> get propTypes => {};

--- a/lib/react_client/bridge.dart
+++ b/lib/react_client/bridge.dart
@@ -128,7 +128,11 @@ class Component2BridgeImpl extends Component2Bridge {
         var error = validator(
             convertedProps,
             PropValidatorInfo(
-                propName: propName, componentName: componentName, location: location, propFullName: propFullName));
+              propName: propName,
+              componentName: componentName,
+              location: location,
+              propFullName: propFullName,
+            ));
         return error == null ? null : JsError(error.toString());
       }
 

--- a/lib/react_client/bridge.dart
+++ b/lib/react_client/bridge.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import 'package:react/react.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart';
+import 'package:react/src/prop_validator.dart';
 import 'package:react/src/typedefs.dart';
 
 /// A function that returns a bridge instance for use with a given [component].
@@ -47,7 +48,8 @@ abstract class Component2Bridge {
   void setState(Component2 component, Map newState, SetStateCallback callback);
   void setStateWithUpdater(Component2 component, StateUpdaterCallback stateUpdater, SetStateCallback callback);
   void forceUpdate(Component2 component, SetStateCallback callback);
-  JsMap jsifyPropTypes(Component2 component, Map propTypes);
+  JsMap jsifyPropTypes(
+      covariant Component2 component, covariant Map<String, /*PropValidator<UiProps>*/ Function> propTypes);
 }
 
 // TODO 3.1.0-wip custom adapter for over_react to avoid typedPropsFactory usages?
@@ -107,7 +109,8 @@ class Component2BridgeImpl extends Component2Bridge {
   }
 
   @override
-  JsMap jsifyPropTypes(Component2 component, Map propTypes) {
+  JsMap jsifyPropTypes(
+      covariant Component2 component, covariant Map<String, /*PropValidator<Map>*/ Function> propTypes) {
     return JsBackedMap.from(propTypes.map((propKey, validator) {
       // Wraps the propValidator methods that users provide in order to allow them to be consumable from javascript.
       dynamic handlePropValidator(
@@ -116,13 +119,16 @@ class Component2BridgeImpl extends Component2Bridge {
         String componentName,
         String location,
         String propFullName,
-        // This is a required argument of PropTypes but is usally hidden from the JS consumer.
+        // This is a required argument of PropTypes but is usually hidden from the JS consumer.
         String secret,
       ) {
         // Create a Dart consumable version of the JsMap.
         var convertedProps = JsBackedMap.fromJs(props);
         // Call the users validator with the newly wrapped props.
-        var error = validator(convertedProps, propName, componentName, location, propFullName);
+        var error = validator(
+            convertedProps,
+            PropValidatorInfo(
+                propName: propName, componentName: componentName, location: location, propFullName: propFullName));
         return error == null ? null : JsError(error.toString());
       }
 

--- a/lib/src/prop_validator.dart
+++ b/lib/src/prop_validator.dart
@@ -1,0 +1,21 @@
+/// Typedef for `Component2.propTypes` - used to check the validity of one or more of the [props].
+///
+/// [info] is a [PropValidatorInfo] class that contains metadata about the prop referenced as
+/// the key within the `Component2.propTypes` map.
+/// `propName`, `componentName`, `location` and `propFullName` are available.
+typedef PropValidator<T> = Error Function(T props, PropValidatorInfo info);
+
+/// Metadata about a prop being validated by a [PropValidator].
+class PropValidatorInfo {
+  final String propName;
+  final String componentName;
+  final String location;
+  final String propFullName;
+
+  const PropValidatorInfo({
+    this.propName,
+    this.componentName,
+    this.location,
+    this.propFullName,
+  });
+}

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -151,10 +151,11 @@ ReactDartComponentFactoryProxy2 PropTypesTest = react.registerComponent(() => ne
 
 class PropTypesTestComponent extends react.Component2 {
   get propTypes => {
-        'intProp': (Map props, propName, componentName, location, propFullName) {
-          if (props[propName] is! int) {
+        'intProp': (Map props, info) {
+          dynamic propValue = props[info.propName];
+          if (propValue is! int) {
             return ArgumentError(
-                '$propName should be int. {"props": "$props", "propName": "$propName", "componentName": "$componentName", "location": "$location", "propFullName": "$propFullName"}');
+                '${info.propName} should be int. {"props": "$props", "propName": "${info.propName}", "componentName": "${info.componentName}", "location": "${info.location}", "propFullName": "${info.propFullName}"}');
           }
           return null;
         }

--- a/test/lifecycle_test/component2.dart
+++ b/test/lifecycle_test/component2.dart
@@ -152,7 +152,7 @@ ReactDartComponentFactoryProxy2 PropTypesTest = react.registerComponent(() => ne
 class PropTypesTestComponent extends react.Component2 {
   get propTypes => {
         'intProp': (Map props, info) {
-          dynamic propValue = props[info.propName];
+          var propValue = props[info.propName];
           if (propValue is! int) {
             return ArgumentError(
                 '${info.propName} should be int. {"props": "$props", "propName": "${info.propName}", "componentName": "${info.componentName}", "location": "${info.location}", "propFullName": "${info.propFullName}"}');


### PR DESCRIPTION
## Motivation
The `Component2.propTypes` boilerplate was unnecessarily verbose.

## Changes
1. Add a class that contains the metadata that was previously provided as separate arguments, and change the `PropValidator` typedef signature to only require two arguments - with the second argument being an instance of the metadata class.

    __Before:__

    ```dart
    @override
    get propTypes => {
      'name': (Map props, propName, componentName, location, propFullName) {
        if (props[propName].length > 20) {
          return ArgumentError('...');
        }
        return null;
      },
    };
    ```

    __After:__

    ```dart
    @override
    get propTypes => {
      'name': (Map props, info) {
        if (props[info.propName].length > 20) {
          return ArgumentError('...');
        }
        return null;
      },
    };
    ```

1. Update JS interop to pass through the field values from the `ReactValidatorInfo` fields as individual arguments to the JS `React.propTypes` function.
1. Update some dynamic call sites where they could be tightened to at least `Function`.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @kealjones-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Passing CI
        - [ ] Passing CI on [the analogous over_react PR](https://github.com/Workiva/over_react/pull/414)
