### PR TITLE
CPLAT-8038 Implement/Expose useCallback Hook

### DIFF
--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -27,6 +27,23 @@ UseStateTestComponent(Map props) {
   ]);
 }
 
+var useCallbackTestFunctionComponent = react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
+
+UseCallbackTestComponent(Map props) {
+  final height = useState(0);
+
+  final measuredRef = useCallback((node) {
+    if(node != null) {
+      height.set(node.getBoundingClientRect().height);
+    }
+  }, []);
+
+  return react.div({}, [
+    react.h4({'ref': measuredRef}, ['Hello, world!']),
+    react.h5({'ref': measuredRef}, ['The above header is ${height.value}px tall']),
+  ]);
+}
+
 void main() {
   setClientConfiguration();
 
@@ -44,6 +61,11 @@ void main() {
           useStateTestFunctionComponent({
             'key': 'useStateTest',
             'enabled': false,
+          }, []),
+          react.br({}),
+          react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
+          useCallbackTestFunctionComponent({
+            'key': 'useCallbackTest',
           }, []),
         ]),
         querySelector('#content'));

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -25,24 +25,6 @@ var useCallbackTestFunctionComponent =
     react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
 
 UseCallbackTestComponent(Map props) {
-  final height = useState(0);
-
-  final measuredRef = useCallback((node) {
-    if (node != null) {
-      height.set(node.getBoundingClientRect().height);
-    }
-  }, []);
-
-  return react.div({}, [
-    react.h4({'ref': measuredRef}, ['Hello, world!']),
-    react.h5({}, ['The above header is ${height.value}px tall']),
-  ]);
-}
-
-var useCallbackTestFunctionComponent2 =
-    react.registerFunctionComponent(UseCallbackTestComponent2, displayName: 'useCallbackTest2');
-
-UseCallbackTestComponent2(Map props) {
   final count = useState(0);
   final delta = useState(1);
 
@@ -77,10 +59,6 @@ void main() {
           react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
           useCallbackTestFunctionComponent({
             'key': 'useCallbackTest',
-          }, []),
-          react.br({}),
-          useCallbackTestFunctionComponent2({
-            'key': 'useCallbackTest2',
           }, []),
         ]),
         querySelector('#content'));

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -21,20 +21,44 @@ UseStateTestComponent(Map props) {
   ]);
 }
 
-var useCallbackTestFunctionComponent = react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
+var useCallbackTestFunctionComponent =
+    react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
 
 UseCallbackTestComponent(Map props) {
   final height = useState(0);
 
   final measuredRef = useCallback((node) {
-    if(node != null) {
+    if (node != null) {
       height.set(node.getBoundingClientRect().height);
     }
   }, []);
 
   return react.div({}, [
     react.h4({'ref': measuredRef}, ['Hello, world!']),
-    react.h5({'ref': measuredRef}, ['The above header is ${height.value}px tall']),
+    react.h5({}, ['The above header is ${height.value}px tall']),
+  ]);
+}
+
+var useCallbackTestFunctionComponent2 =
+    react.registerFunctionComponent(UseCallbackTestComponent2, displayName: 'useCallbackTest2');
+
+UseCallbackTestComponent2(Map props) {
+  final count = useState(0);
+  final delta = useState(1);
+
+  var increment = useCallback((_) {
+    count.setWithUpdater((prev) => prev + delta.value);
+  }, [delta.value]);
+
+  var incrementDelta = useCallback((_) {
+    delta.setWithUpdater((prev) => prev + 1);
+  }, []);
+
+  return react.div({}, [
+    react.div({}, ['Delta is ${delta.value}']),
+    react.div({}, ['Count is ${count.value}']),
+    react.button({'onClick': increment}, ['Increment count']),
+    react.button({'onClick': incrementDelta}, ['Increment delta']),
   ]);
 }
 
@@ -53,6 +77,10 @@ void main() {
           react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
           useCallbackTestFunctionComponent({
             'key': 'useCallbackTest',
+          }, []),
+          react.br({}),
+          useCallbackTestFunctionComponent2({
+            'key': 'useCallbackTest2',
           }, []),
         ]),
         querySelector('#content'));

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -102,9 +102,6 @@ StateHook<T> useState<T>(T initialValue) => StateHook(initialValue);
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#lazy-initial-state>.
 StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 
-
-
 Function useCallback(Function callback, List dependencies) {
   return React.useCallback(allowInterop(callback), dependencies);
 }
-

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -107,3 +107,10 @@ StateHook<T> useState<T>(T initialValue) => StateHook(initialValue);
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#lazy-initial-state>.
 StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
+
+
+
+Function useCallback(Function callback, List dependencies) {
+  return React.useCallback(allowInterop(callback), dependencies);
+}
+

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -102,4 +102,36 @@ StateHook<T> useState<T>(T initialValue) => StateHook(initialValue);
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#lazy-initial-state>.
 StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 
+/// Returns a memoized version of [callback] that only changes if one of the [dependencies] has changed.
+///
+/// Note there are two rules for using Hooks (<https://reactjs.org/docs/hooks-rules.html>):
+///
+/// * Only call Hooks at the top level.
+/// * Only call Hooks from inside a [DartFunctionComponent].
+///
+/// __Example__:
+///
+/// ```
+/// UseCallbackTestComponent(Map props) {
+///   final count = useState(0);
+///   final delta = useState(1);
+///
+///   var increment = useCallback((_) {
+///     count.setWithUpdater((prev) => prev + delta.value);
+///   }, [delta.value]);
+///
+///   var incrementDelta = useCallback((_) {
+///     delta.setWithUpdater((prev) => prev + 1);
+///   }, []);
+///
+///   return react.div({}, [
+///     react.div({}, ['Delta is ${delta.value}']),
+///     react.div({}, ['Count is ${count.value}']),
+///     react.button({'onClick': increment}, ['Increment count']),
+///     react.button({'onClick': incrementDelta}, ['Increment delta']),
+///   ]);
+/// }
+/// ```
+///
+/// Learn more:<https://reactjs.org/docs/hooks-reference.html#usecallback>.
 Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -102,6 +102,4 @@ StateHook<T> useState<T>(T initialValue) => StateHook(initialValue);
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#lazy-initial-state>.
 StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 
-Function useCallback(Function callback, List dependencies) {
-  return React.useCallback(allowInterop(callback), dependencies);
-}
+Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -133,5 +133,5 @@ StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 /// }
 /// ```
 ///
-/// Learn more:<https://reactjs.org/docs/hooks-reference.html#usecallback>.
+/// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
 Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -10,10 +10,10 @@ import 'package:react/react_client/react_interop.dart';
 /// The current value of the state is available via [value] and
 /// functions to update it are available via [set] and [setWithUpdater].
 ///
-/// Note there are two rules for using Hooks (<https://reactjs.org/docs/hooks-rules.html>):
-///
-/// * Only call Hooks at the top level.
-/// * Only call Hooks from inside a [DartFunctionComponent].
+/// > __Note:__ there are two [rules for using Hooks](https://reactjs.org/docs/hooks-rules.html):
+/// >
+/// > * Only call Hooks at the top level.
+/// > * Only call Hooks from inside a [DartFunctionComponent].
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-state.html>.
 class StateHook<T> {
@@ -104,10 +104,10 @@ StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 
 /// Returns a memoized version of [callback] that only changes if one of the [dependencies] has changed.
 ///
-/// Note there are two rules for using Hooks (<https://reactjs.org/docs/hooks-rules.html>):
-///
-/// * Only call Hooks at the top level.
-/// * Only call Hooks from inside a [DartFunctionComponent].
+/// > __Note:__ there are two [rules for using Hooks](https://reactjs.org/docs/hooks-rules.html):
+/// >
+/// > * Only call Hooks at the top level.
+/// > * Only call Hooks from inside a [DartFunctionComponent].
 ///
 /// __Example__:
 ///

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -47,6 +47,7 @@ abstract class React {
   external static ReactClass forwardRef(Function(JsMap props, JsRef ref) wrapperFunction);
 
   external static List<dynamic> useState(dynamic value);
+  external static Function useCallback(Function callback, List dependencies);
 }
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -92,5 +92,109 @@ main() {
         expect(countRef.text, '1');
       });
     });
+
+    group('useCallback -', () {
+      ReactDartFunctionComponentFactoryProxy UseCallbackTest;
+      DivElement deltaRef;
+      DivElement countRef;
+      ButtonElement incrementWithDepButtonRef;
+      ButtonElement incrementNoDepButtonRef;
+      ButtonElement incrementDeltaButtonRef;
+
+      setUpAll(() {
+        var mountNode = new DivElement();
+
+        UseCallbackTest = react.registerFunctionComponent((Map props) {
+          final count = useState(0);
+          final delta = useState(1);
+
+          var incrementNoDep = useCallback((_) {
+            count.setWithUpdater((prev) => prev + delta.value);
+          }, []);
+
+          var incrementWithDep = useCallback((_) {
+            count.setWithUpdater((prev) => prev + delta.value);
+          }, [delta.value]);
+
+          var incrementDelta = useCallback((_) {
+            delta.setWithUpdater((prev) => prev + 1);
+          }, []);
+
+          return react.div({}, [
+            react.div({
+              'ref': (ref) {
+                deltaRef = ref;
+              },
+            }, [
+              delta.value
+            ]),
+            react.div({
+              'ref': (ref) {
+                countRef = ref;
+              },
+            }, [
+              count.value
+            ]),
+            react.button({
+              'onClick': incrementNoDep,
+              'ref': (ref) {
+                incrementNoDepButtonRef = ref;
+              },
+            }, [
+              'Increment count no dep'
+            ]),
+            react.button({
+              'onClick': incrementWithDep,
+              'ref': (ref) {
+                incrementWithDepButtonRef = ref;
+              },
+            }, [
+              'Increment count'
+            ]),
+            react.button({
+              'onClick': incrementDelta,
+              'ref': (ref) {
+                incrementDeltaButtonRef = ref;
+              },
+            }, [
+              'Increment delta'
+            ]),
+          ]);
+        });
+
+        react_dom.render(UseCallbackTest({}), mountNode);
+      });
+
+      tearDownAll(() {
+        UseCallbackTest = null;
+      });
+
+      test('callback is called correctly', () {
+        expect(countRef.text, '0');
+        expect(deltaRef.text, '1');
+
+        react_test_utils.Simulate.click(incrementNoDepButtonRef);
+        expect(countRef.text, '1');
+
+        react_test_utils.Simulate.click(incrementWithDepButtonRef);
+        expect(countRef.text, '2');
+      });
+
+      group('after depending state changes,', () {
+        setUpAll(() {
+          react_test_utils.Simulate.click(incrementDeltaButtonRef);
+        });
+
+        test('callback stays the same if state not in dependency list', () {
+          react_test_utils.Simulate.click(incrementNoDepButtonRef);
+          expect(countRef.text, '3', reason: 'still increments by 1 because delta not in dependency list');
+        });
+
+        test('callback stays the same if state not in dependency list', () {
+          react_test_utils.Simulate.click(incrementWithDepButtonRef);
+          expect(countRef.text, '5', reason: 'increments by 2 because delta updated');
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
## Motivation
Support useCallback hook in react-dart

## Changes
- Added `useCallback` function
- Wrote tests.

Please review: @kealjones-wk @aaronlademann-wf @greglittlefield-wf @joebingham-wk 