### PR TITLE
CPLAT-8698 Expose the componentZone

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -62,13 +62,12 @@ dynamic listifyChildren(dynamic children) {
 /// __Example:__
 ///
 ///     test('zone test', () {
-///       currentComponentZone = Zone.current;
+///       componentZone = Zone.current;
 ///
 ///       // ... test your component
 ///     }
-///
 @visibleForTesting
-Zone currentComponentZone = Zone.root;
+Zone componentZone = Zone.root;
 
 /// Use [ReactDartComponentFactoryProxy2] instead.
 ///
@@ -490,9 +489,6 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
 })();
 
 abstract class _ReactDartInteropStatics2 {
-  /// The zone in which all component lifecycle methods are run.
-  static final componentZone = currentComponentZone;
-
   static void _updatePropsAndStateWithJs(Component2 component, JsMap props, JsMap state) {
     component
       ..props = new JsBackedMap.backedBy(props)

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -13,6 +13,7 @@ import 'dart:js';
 import 'dart:js_util';
 
 import "package:js/js.dart";
+import 'package:meta/meta.dart';
 
 import "package:react/react.dart";
 import 'package:react/react_client/js_interop_helpers.dart';
@@ -52,6 +53,22 @@ dynamic listifyChildren(dynamic children) {
     return children;
   }
 }
+
+/// The zone in which React will call component lifecycle methods.
+///
+/// This can be used to sync a test's zone and React's component zone, ensuring that component prop callbacks and
+/// lifecycle method output all occurs within the same zone as the test.
+///
+/// __Example:__
+///
+///     test('zone test', () {
+///       currentComponentZone = Zone.current;
+///
+///       // ... test your component
+///     }
+///
+@visibleForTesting
+Zone currentComponentZone = Zone.root;
 
 /// Use [ReactDartComponentFactoryProxy2] instead.
 ///
@@ -473,9 +490,8 @@ final ReactDartInteropStatics _dartInteropStatics = (() {
 })();
 
 abstract class _ReactDartInteropStatics2 {
-  // TODO 3.1.0-wip expose for testing?
   /// The zone in which all component lifecycle methods are run.
-  static final componentZone = Zone.root;
+  static final componentZone = currentComponentZone;
 
   static void _updatePropsAndStateWithJs(Component2 component, JsMap props, JsMap state) {
     component

--- a/test/lifecycle_test.dart
+++ b/test/lifecycle_test.dart
@@ -14,7 +14,6 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
-import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 import 'package:test/test.dart';


### PR DESCRIPTION
### Motivation
To make testing easier, we want to expose the componentZone field to allow the active zone to be configured to match that of a test.

### Changes
- Add `currentComponentZone` and set `_ReactDartInteropStatics2`'s `componentZone` equal to it. 

Please review @greglittlefield-wf @aaronlademann-wf @kealjones-wk @sydneyjodon-wk 