### PR TITLE
CPLAT-8036 Add useContext Hook

### DIFF
--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -62,7 +62,7 @@ int calculateChangedBits(currentValue, nextValue) {
 
 var TestNewContext = react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
 
-var newContextProviderComponent = react.registerComponent(() => new _NewContextProviderComponent());
+var newContextProviderComponent = react.registerComponent(() => _NewContextProviderComponent());
 
 class _NewContextProviderComponent extends react.Component2 {
   get initialState => {'renderCount': 0, 'complexMap': false};

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -12,9 +12,10 @@ UseStateTestComponent(Map props) {
 
   return react.div({}, [
     count.value,
-    react.button({'onClick': (_) => count.set(0)}, ['Reset']),
+    react.button({'onClick': (_) => count.set(0), 'key': 'ust1'}, ['Reset']),
     react.button({
       'onClick': (_) => count.setWithUpdater((prev) => prev + 1),
+      'key': 'ust2'
     }, [
       '+'
     ]),
@@ -37,11 +38,66 @@ UseCallbackTestComponent(Map props) {
   }, []);
 
   return react.div({}, [
-    react.div({}, ['Delta is ${delta.value}']),
-    react.div({}, ['Count is ${count.value}']),
-    react.button({'onClick': increment}, ['Increment count']),
-    react.button({'onClick': incrementDelta}, ['Increment delta']),
+    react.div({'key': 'ucbt1'}, ['Delta is ${delta.value}']),
+    react.div({'key': 'ucbt2'}, ['Count is ${count.value}']),
+    react.button({'onClick': increment,'key': 'ucbt3'}, ['Increment count']),
+    react.button({'onClick': incrementDelta, 'key': 'ucbt4'}, ['Increment delta']),
   ]);
+}
+
+var useContextTestFunctionComponent =
+    react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
+
+UseContextTestComponent(Map props) {
+  final context = useContext(TestNewContext);
+  return react.div({'key': 'uct1'}, [
+    react.div({'key': 'uct2'}, ['useContext counter value is ${context['renderCount']}']),
+  ]);
+}
+
+int calculateChangedBits(currentValue, nextValue) {
+  int result = 1 << 1;
+  if (nextValue['renderCount'] % 2 == 0) {
+    result |= 1 << 2;
+  }
+  return result;
+}
+
+var TestNewContext = react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
+
+var newContextProviderComponent = react.registerComponent(() => new _NewContextProviderComponent());
+
+class _NewContextProviderComponent extends react.Component2 {
+  get initialState => {'renderCount': 0, 'complexMap': false};
+
+  render() {
+    final provideMap = {'renderCount': this.state['renderCount']};
+
+    return react.div({
+      'key': 'ulasda',
+      'style': {
+        'marginTop': 20,
+      }
+    }, [
+      react.button({
+        'type': 'button',
+        'key': 'button',
+        'className': 'btn btn-primary',
+        'onClick': _onButtonClick,
+      }, 'Redraw'),
+      react.br({'key': 'break1'}),
+      'TestContext.Provider props.value: ${provideMap}',
+      react.br({'key': 'break2'}),
+      react.br({'key': 'break3'}),
+      TestNewContext.Provider(
+        {'key': 'tcp', 'value': provideMap},
+        props['children'],
+      ),
+    ]);
+  }
+  _onButtonClick(event) {
+    this.setState({'renderCount': this.state['renderCount'] + 1, 'complexMap': false});
+  }
 }
 
 void main() {
@@ -49,19 +105,24 @@ void main() {
 
   render() {
     react_dom.render(
-        react.Fragment({}, [
-          react.h1({'key': 'functionComponentTestLabel'}, ['Function Component Tests']),
-          react.h2({'key': 'useStateTestLabel'}, ['useState Hook Test']),
-          useStateTestFunctionComponent({
-            'key': 'useStateTest',
-          }, []),
-          react.br({}),
-          react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
-          useCallbackTestFunctionComponent({
-            'key': 'useCallbackTest',
+      react.Fragment({'key': 'fctf'}, [
+        react.h1({'key': 'functionComponentTestLabel'}, ['Function Component Tests']),
+        react.h2({'key': 'useStateTestLabel'}, ['useState Hook Test']),
+        useStateTestFunctionComponent({
+          'key': 'useStateTest',
+        }, []),
+        react.br({'key': 'br'}),
+        react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
+        useCallbackTestFunctionComponent({
+          'key': 'useCallbackTest',
+        }, []),
+        newContextProviderComponent({'key': 'provider'}, [
+          useContextTestFunctionComponent({
+            'key': 'useContextTest',
           }, []),
         ]),
-        querySelector('#content'));
+      ]),
+    querySelector('#content'));
   }
 
   render();

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -5,9 +5,7 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
 
-var useStateTestFunctionComponent = react.registerFunctionComponent(
-    UseStateTestComponent,
-    displayName: 'useStateTest');
+var useStateTestFunctionComponent = react.registerFunctionComponent(UseStateTestComponent, displayName: 'useStateTest');
 
 UseStateTestComponent(Map props) {
   final count = useState(0);
@@ -15,18 +13,12 @@ UseStateTestComponent(Map props) {
   return react.div({}, [
     count.value,
     react.button({'onClick': (_) => count.set(0), 'key': 'ust1'}, ['Reset']),
-    react.button({
-      'onClick': (_) => count.setWithUpdater((prev) => prev + 1),
-      'key': 'ust2'
-    }, [
-      '+'
-    ]),
+    react.button({'onClick': (_) => count.setWithUpdater((prev) => prev + 1), 'key': 'ust2'}, ['+']),
   ]);
 }
 
-var useCallbackTestFunctionComponent = react.registerFunctionComponent(
-    UseCallbackTestComponent,
-    displayName: 'useCallbackTest');
+var useCallbackTestFunctionComponent =
+    react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
 
 UseCallbackTestComponent(Map props) {
   final count = useState(0);
@@ -44,22 +36,19 @@ UseCallbackTestComponent(Map props) {
     react.div({'key': 'ucbt1'}, ['Delta is ${delta.value}']),
     react.div({'key': 'ucbt2'}, ['Count is ${count.value}']),
     react.button({'onClick': increment, 'key': 'ucbt3'}, ['Increment count']),
-    react.button(
-        {'onClick': incrementDelta, 'key': 'ucbt4'}, ['Increment delta']),
+    react.button({'onClick': incrementDelta, 'key': 'ucbt4'}, ['Increment delta']),
   ]);
 }
 
-var useContextTestFunctionComponent = react.registerFunctionComponent(
-    UseContextTestComponent,
-    displayName: 'useContextTest');
+var useContextTestFunctionComponent =
+    react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
 
 UseContextTestComponent(Map props) {
   final context = useContext(TestNewContext);
   return react.div({
     'key': 'uct1'
   }, [
-    react.div({'key': 'uct2'},
-        ['useContext counter value is ${context['renderCount']}']),
+    react.div({'key': 'uct2'}, ['useContext counter value is ${context['renderCount']}']),
   ]);
 }
 
@@ -71,11 +60,9 @@ int calculateChangedBits(currentValue, nextValue) {
   return result;
 }
 
-var TestNewContext =
-    react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
+var TestNewContext = react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
 
-var newContextProviderComponent =
-    react.registerComponent(() => new _NewContextProviderComponent());
+var newContextProviderComponent = react.registerComponent(() => new _NewContextProviderComponent());
 
 class _NewContextProviderComponent extends react.Component2 {
   get initialState => {'renderCount': 0, 'complexMap': false};
@@ -107,8 +94,7 @@ class _NewContextProviderComponent extends react.Component2 {
   }
 
   _onButtonClick(event) {
-    this.setState(
-        {'renderCount': this.state['renderCount'] + 1, 'complexMap': false});
+    this.setState({'renderCount': this.state['renderCount'] + 1, 'complexMap': false});
   }
 }
 
@@ -120,8 +106,7 @@ void main() {
         react.Fragment({
           'key': 'fctf'
         }, [
-          react.h1({'key': 'functionComponentTestLabel'},
-              ['Function Component Tests']),
+          react.h1({'key': 'functionComponentTestLabel'}, ['Function Component Tests']),
           react.h2({'key': 'useStateTestLabel'}, ['useState Hook Test']),
           useStateTestFunctionComponent({
             'key': 'useStateTest',

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -5,7 +5,9 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart';
 
-var useStateTestFunctionComponent = react.registerFunctionComponent(UseStateTestComponent, displayName: 'useStateTest');
+var useStateTestFunctionComponent = react.registerFunctionComponent(
+    UseStateTestComponent,
+    displayName: 'useStateTest');
 
 UseStateTestComponent(Map props) {
   final count = useState(0);
@@ -22,8 +24,9 @@ UseStateTestComponent(Map props) {
   ]);
 }
 
-var useCallbackTestFunctionComponent =
-    react.registerFunctionComponent(UseCallbackTestComponent, displayName: 'useCallbackTest');
+var useCallbackTestFunctionComponent = react.registerFunctionComponent(
+    UseCallbackTestComponent,
+    displayName: 'useCallbackTest');
 
 UseCallbackTestComponent(Map props) {
   final count = useState(0);
@@ -40,18 +43,23 @@ UseCallbackTestComponent(Map props) {
   return react.div({}, [
     react.div({'key': 'ucbt1'}, ['Delta is ${delta.value}']),
     react.div({'key': 'ucbt2'}, ['Count is ${count.value}']),
-    react.button({'onClick': increment,'key': 'ucbt3'}, ['Increment count']),
-    react.button({'onClick': incrementDelta, 'key': 'ucbt4'}, ['Increment delta']),
+    react.button({'onClick': increment, 'key': 'ucbt3'}, ['Increment count']),
+    react.button(
+        {'onClick': incrementDelta, 'key': 'ucbt4'}, ['Increment delta']),
   ]);
 }
 
-var useContextTestFunctionComponent =
-    react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
+var useContextTestFunctionComponent = react.registerFunctionComponent(
+    UseContextTestComponent,
+    displayName: 'useContextTest');
 
 UseContextTestComponent(Map props) {
   final context = useContext(TestNewContext);
-  return react.div({'key': 'uct1'}, [
-    react.div({'key': 'uct2'}, ['useContext counter value is ${context['renderCount']}']),
+  return react.div({
+    'key': 'uct1'
+  }, [
+    react.div({'key': 'uct2'},
+        ['useContext counter value is ${context['renderCount']}']),
   ]);
 }
 
@@ -63,9 +71,11 @@ int calculateChangedBits(currentValue, nextValue) {
   return result;
 }
 
-var TestNewContext = react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
+var TestNewContext =
+    react.createContext<Map>({'renderCount': 0}, calculateChangedBits);
 
-var newContextProviderComponent = react.registerComponent(() => new _NewContextProviderComponent());
+var newContextProviderComponent =
+    react.registerComponent(() => new _NewContextProviderComponent());
 
 class _NewContextProviderComponent extends react.Component2 {
   get initialState => {'renderCount': 0, 'complexMap': false};
@@ -95,8 +105,10 @@ class _NewContextProviderComponent extends react.Component2 {
       ),
     ]);
   }
+
   _onButtonClick(event) {
-    this.setState({'renderCount': this.state['renderCount'] + 1, 'complexMap': false});
+    this.setState(
+        {'renderCount': this.state['renderCount'] + 1, 'complexMap': false});
   }
 }
 
@@ -105,24 +117,29 @@ void main() {
 
   render() {
     react_dom.render(
-      react.Fragment({'key': 'fctf'}, [
-        react.h1({'key': 'functionComponentTestLabel'}, ['Function Component Tests']),
-        react.h2({'key': 'useStateTestLabel'}, ['useState Hook Test']),
-        useStateTestFunctionComponent({
-          'key': 'useStateTest',
-        }, []),
-        react.br({'key': 'br'}),
-        react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
-        useCallbackTestFunctionComponent({
-          'key': 'useCallbackTest',
-        }, []),
-        newContextProviderComponent({'key': 'provider'}, [
-          useContextTestFunctionComponent({
-            'key': 'useContextTest',
+        react.Fragment({
+          'key': 'fctf'
+        }, [
+          react.h1({'key': 'functionComponentTestLabel'},
+              ['Function Component Tests']),
+          react.h2({'key': 'useStateTestLabel'}, ['useState Hook Test']),
+          useStateTestFunctionComponent({
+            'key': 'useStateTest',
           }, []),
+          react.br({'key': 'br'}),
+          react.h2({'key': 'useCallbackTestLabel'}, ['useCallback Hook Test']),
+          useCallbackTestFunctionComponent({
+            'key': 'useCallbackTest',
+          }, []),
+          newContextProviderComponent({
+            'key': 'provider'
+          }, [
+            useContextTestFunctionComponent({
+              'key': 'useContextTest',
+            }, []),
+          ]),
         ]),
-      ]),
-    querySelector('#content'));
+        querySelector('#content'));
   }
 
   render();

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -136,7 +136,7 @@ StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
 Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);
 
-/// Returns the value of the nearest [Context.Provider] for the provided [Context] object every time that context is
+/// Returns the value of the nearest [Context.Provider] for the provided [context] object every time that context is
 /// updated.
 ///
 /// The usage is similar to that of a [Context.Consumer] in that the return type of [useContext] is dependent upon
@@ -162,4 +162,4 @@ Function useCallback(Function callback, List dependencies) => React.useCallback(
 /// ```
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecontext>.
-dynamic useContext(Context context) => ContextHelpers.unjsifyNewContext(React.useContext(context.jsThis));
+T useContext<T>(Context<T> context) => ContextHelpers.unjsifyNewContext(React.useContext(context.jsThis));

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -136,7 +136,8 @@ StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
 Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);
 
-/// Returns the value of the nearest [Context.Provider] for the provided [Context] object.
+/// Returns the value of the nearest [Context.Provider] for the provided [Context] object every time that context is
+/// updated.
 ///
 /// The usage is similar to that of a [Context.Consumer] in that the return type of [useContext] is dependent upon
 /// the typing of the value passed into [createContext] and [Context.Provider].

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -135,3 +135,30 @@ StateHook<T> useStateLazy<T>(T init()) => StateHook.lazy(init);
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
 Function useCallback(Function callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);
+
+/// Returns the value of the nearest [Context.Provider] for the provided [Context] object.
+///
+/// The usage is similar to that of a [Context.Consumer] in that the return type of [useContext] is dependent upon
+/// the typing of the value passed into [createContext] and [Context.Provider].
+///
+/// > __Note:__ there are two [rules for using Hooks](https://reactjs.org/docs/hooks-rules.html):
+/// >
+/// > * Only call Hooks at the top level.
+/// > * Only call Hooks from inside a [DartFunctionComponent].
+///
+/// __Example__:
+///
+/// ```
+/// Context newContext = createContext(0, calcuateChangedBits);
+///
+/// UseCallbackTestComponent(Map props) {
+///   final context = useContext(newContext);
+///
+///   return react.div({}, [
+///     react.div({}, ['The context value is $context']), // initially renders: 'The context value is 0'
+///   ]);
+/// }
+/// ```
+///
+/// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecontext>.
+dynamic useContext(Context context) => ContextHelpers.unjsifyNewContext(React.useContext(context.jsThis));

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -150,13 +150,13 @@ Function useCallback(Function callback, List dependencies) => React.useCallback(
 /// __Example__:
 ///
 /// ```
-/// Context newContext = createContext(0, calcuateChangedBits);
+/// Context countContext = createContext(0);
 ///
 /// UseCallbackTestComponent(Map props) {
-///   final context = useContext(newContext);
+///   final count = useContext(countContext);
 ///
 ///   return react.div({}, [
-///     react.div({}, ['The context value is $context']), // initially renders: 'The context value is 0'
+///     react.div({}, ['The count from context is $count']), // initially renders: 'The count from context is 0'
 ///   ]);
 /// }
 /// ```

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -48,6 +48,7 @@ abstract class React {
 
   external static List<dynamic> useState(dynamic value);
   external static Function useCallback(Function callback, List dependencies);
+  external static ReactContext useContext(ReactContext context);
 }
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -47,7 +47,7 @@ import 'package:react/react_client.dart';
 ///     }
 ///
 /// Learn more at: https://reactjs.org/docs/context.html
-class Context {
+class Context<T> {
   Context(this.Provider, this.Consumer, this._jsThis);
   final ReactContext _jsThis;
 
@@ -101,7 +101,7 @@ class Context {
 ///     }
 ///
 /// Learn more: https://reactjs.org/docs/context.html#reactcreatecontext
-Context createContext<TValue>([
+Context<TValue> createContext<TValue>([
   TValue defaultValue,
   int Function(TValue currentValue, TValue nextValue) calculateChangedBits,
 ]) {

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -187,15 +187,12 @@ main() {
 
         test('callback stays the same if state not in dependency list', () {
           react_test_utils.Simulate.click(incrementNoDepButtonRef);
-          expect(countRef.text, '3',
-              reason:
-                  'still increments by 1 because delta not in dependency list');
+          expect(countRef.text, '3', reason: 'still increments by 1 because delta not in dependency list');
         });
 
         test('callback stays the same if state not in dependency list', () {
           react_test_utils.Simulate.click(incrementWithDepButtonRef);
-          expect(countRef.text, '5',
-              reason: 'increments by 2 because delta updated');
+          expect(countRef.text, '5', reason: 'increments by 2 because delta updated');
         });
       });
     });
@@ -214,16 +211,13 @@ main() {
           return react.div({
             'key': 'uct1'
           }, [
-            react.div(
-                {'key': 'uct2'}, ['useContext counter value is ${context}']),
+            react.div({'key': 'uct2'}, ['useContext counter value is ${context}']),
           ]);
         }
 
-        TestCalculateChangedBitsContext =
-            react.createContext(1, calculateChangedBits);
-        useContextTestFunctionComponent = react.registerFunctionComponent(
-            UseContextTestComponent,
-            displayName: 'useContextTest');
+        TestCalculateChangedBitsContext = react.createContext(1, calculateChangedBits);
+        useContextTestFunctionComponent =
+            react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
 
         react_dom.render(
             ContextProviderWrapper({
@@ -271,8 +265,7 @@ int calculateChangedBits(currentValue, nextValue) {
   return result;
 }
 
-ReactDartComponentFactoryProxy2 ContextProviderWrapper =
-    react.registerComponent(() => new _ContextProviderWrapper());
+ReactDartComponentFactoryProxy2 ContextProviderWrapper = react.registerComponent(() => new _ContextProviderWrapper());
 
 class _ContextProviderWrapper extends react.Component2 {
   get initialState {
@@ -285,10 +278,8 @@ class _ContextProviderWrapper extends react.Component2 {
 
   render() {
     return react.div({}, [
-      props['contextToUse'].Provider({
-        'value':
-            props['mode'] == 'increment' ? state['counter'] : props['value']
-      }, props['children'])
+      props['contextToUse']
+          .Provider({'value': props['mode'] == 'increment' ? state['counter'] : props['value']}, props['children'])
     ]);
   }
 }

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -199,13 +199,15 @@ main() {
     });
 
     group('useContext -', () {
-      var mountNode = DivElement();
+      DivElement mountNode;
       _ContextProviderWrapper providerRef;
       int currentCount = 0;
       Context<int> testContext;
       Function useContextTestFunctionComponent;
 
       setUp(() {
+        mountNode = DivElement();
+
         UseContextTestComponent(Map props) {
           final context = useContext(testContext);
           currentCount = context;
@@ -215,10 +217,6 @@ main() {
             react.div({'key': 'uct2'}, ['useContext counter value is ${context}']),
           ]);
         }
-
-        tearDown(() {
-          mountNode = null;
-        });
 
         testContext = react.createContext(1);
         useContextTestFunctionComponent =
@@ -238,6 +236,7 @@ main() {
       });
 
       tearDown(() {
+        mountNode = null;
         currentCount = 0;
         testContext = null;
         useContextTestFunctionComponent = null;

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -236,6 +236,7 @@ main() {
       });
 
       tearDown(() {
+        react_dom.unmountComponentAtNode(mountNode);
         mountNode = null;
         currentCount = 0;
         testContext = null;

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -202,7 +202,7 @@ main() {
       var mountNode = DivElement();
       _ContextProviderWrapper providerRef;
       int currentCount = 0;
-      Context testContext;
+      Context<int> testContext;
       Function useContextTestFunctionComponent;
 
       setUp(() {

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -187,12 +187,15 @@ main() {
 
         test('callback stays the same if state not in dependency list', () {
           react_test_utils.Simulate.click(incrementNoDepButtonRef);
-          expect(countRef.text, '3', reason: 'still increments by 1 because delta not in dependency list');
+          expect(countRef.text, '3',
+              reason:
+                  'still increments by 1 because delta not in dependency list');
         });
 
         test('callback stays the same if state not in dependency list', () {
           react_test_utils.Simulate.click(incrementWithDepButtonRef);
-          expect(countRef.text, '5', reason: 'increments by 2 because delta updated');
+          expect(countRef.text, '5',
+              reason: 'increments by 2 because delta updated');
         });
       });
     });
@@ -208,14 +211,19 @@ main() {
         UseContextTestComponent(Map props) {
           final context = useContext(TestCalculateChangedBitsContext);
           currentCount = context;
-          return react.div({'key': 'uct1'}, [
-            react.div({'key': 'uct2'}, ['useContext counter value is ${context}']),
+          return react.div({
+            'key': 'uct1'
+          }, [
+            react.div(
+                {'key': 'uct2'}, ['useContext counter value is ${context}']),
           ]);
         }
 
-        TestCalculateChangedBitsContext = react.createContext(1, calculateChangedBits);
-        useContextTestFunctionComponent =
-            react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
+        TestCalculateChangedBitsContext =
+            react.createContext(1, calculateChangedBits);
+        useContextTestFunctionComponent = react.registerFunctionComponent(
+            UseContextTestComponent,
+            displayName: 'useContextTest');
 
         react_dom.render(
             ContextProviderWrapper({
@@ -225,7 +233,7 @@ main() {
                 providerRef = ref;
               }
             }, [
-              useContextTestFunctionComponent({'key': 't1'},[]),
+              useContextTestFunctionComponent({'key': 't1'}, []),
             ]),
             mountNode);
       });
@@ -263,7 +271,8 @@ int calculateChangedBits(currentValue, nextValue) {
   return result;
 }
 
-ReactDartComponentFactoryProxy2 ContextProviderWrapper = react.registerComponent(() => new _ContextProviderWrapper());
+ReactDartComponentFactoryProxy2 ContextProviderWrapper =
+    react.registerComponent(() => new _ContextProviderWrapper());
 
 class _ContextProviderWrapper extends react.Component2 {
   get initialState {
@@ -276,8 +285,10 @@ class _ContextProviderWrapper extends react.Component2 {
 
   render() {
     return react.div({}, [
-      props['contextToUse']
-          .Provider({'value': props['mode'] == 'increment' ? state['counter'] : props['value']}, props['children'])
+      props['contextToUse'].Provider({
+        'value':
+            props['mode'] == 'increment' ? state['counter'] : props['value']
+      }, props['children'])
     ]);
   }
 }

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -8,6 +8,7 @@ import 'dart:html';
 import "package:js/js.dart";
 import 'package:react/hooks.dart';
 import 'package:react/react.dart' as react;
+import 'package:react/react.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
@@ -201,12 +202,12 @@ main() {
       var mountNode = DivElement();
       _ContextProviderWrapper providerRef;
       int currentCount = 0;
-      var TestCalculateChangedBitsContext;
-      var useContextTestFunctionComponent;
+      Context testContext;
+      Function useContextTestFunctionComponent;
 
       setUp(() {
         UseContextTestComponent(Map props) {
-          final context = useContext(TestCalculateChangedBitsContext);
+          final context = useContext(testContext);
           currentCount = context;
           return react.div({
             'key': 'uct1'
@@ -215,13 +216,13 @@ main() {
           ]);
         }
 
-        TestCalculateChangedBitsContext = react.createContext(1, calculateChangedBits);
+        testContext = react.createContext(1, calculateChangedBits);
         useContextTestFunctionComponent =
             react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
 
         react_dom.render(
             ContextProviderWrapper({
-              'contextToUse': TestCalculateChangedBitsContext,
+              'contextToUse': testContext,
               'mode': 'increment',
               'ref': (ref) {
                 providerRef = ref;
@@ -234,7 +235,7 @@ main() {
 
       tearDown(() {
         currentCount = 0;
-        TestCalculateChangedBitsContext = null;
+        testContext = null;
         useContextTestFunctionComponent = null;
         providerRef = null;
       });

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -216,7 +216,11 @@ main() {
           ]);
         }
 
-        testContext = react.createContext(1, calculateChangedBits);
+        tearDown(() {
+          mountNode = null;
+        });
+
+        testContext = react.createContext(1);
         useContextTestFunctionComponent =
             react.registerFunctionComponent(UseContextTestComponent, displayName: 'useContextTest');
 
@@ -256,14 +260,6 @@ main() {
       });
     });
   });
-}
-
-int calculateChangedBits(currentValue, nextValue) {
-  int result = 1 << 1;
-  if (nextValue % 2 == 0) {
-    result |= 1 << 2;
-  }
-  return result;
 }
 
 ReactDartComponentFactoryProxy2 ContextProviderWrapper = react.registerComponent(() => new _ContextProviderWrapper());


### PR DESCRIPTION
### Motivation
Expose the `useContext` hook so that functional components can tap into it.

### Changes
- Add `useContext` function
- Add an example
- Add tests

### Testing
- Verify the example works as expected

Please Review @greglittlefield-wf @kealjones-wk @aaronlademann-wf @sydneyjodon-wk 