### PR TITLE
CPLAT-8042 Implement/Expose useLayoutEffect Hook

### DIFF
--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -184,9 +184,9 @@ UseRefTestComponent(Map props) {
   ]);
 }
 
-var random = new Random();
+final random = new Random();
 
-var randomUseLayoutEffectTestComponent =
+final randomUseLayoutEffectTestComponent =
     react.registerFunctionComponent(RandomUseLayoutEffectTestComponent, displayName: 'randomUseLayoutEffectTest');
 
 RandomUseLayoutEffectTestComponent(Map props) {
@@ -206,7 +206,7 @@ RandomUseLayoutEffectTestComponent(Map props) {
   ]);
 }
 
-var randomUseEffectTestComponent =
+final randomUseEffectTestComponent =
     react.registerFunctionComponent(RandomUseEffectTestComponent, displayName: 'randomUseEffectTest');
 
 RandomUseEffectTestComponent(Map props) {

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -199,10 +199,10 @@ RandomUseLayoutEffectTestComponent(Map props) {
   });
 
   return react.Fragment({}, [
-    react.h5({'key': 'randULE1'}, ['Example using useLayoutEffect:']),
-    react.div({'key': 'randULE2'}, ['value: ${value.value}']),
-    react.button({'key': 'randULE3','onClick': (_) => value.set(0)}, ['Change Value']),
-    react.br({'key': 'randULE4'}),
+    react.h5({'key': 'randomUseLayout1'}, ['Example using useLayoutEffect:']),
+    react.div({'key': 'randomUseLayout2'}, ['value: ${value.value}']),
+    react.button({'key': 'randomUseLayout3', 'onClick': (_) => value.set(0)}, ['Change Value']),
+    react.br({'key': 'randomUseLayout4'}),
   ]);
 }
 
@@ -219,9 +219,9 @@ RandomUseEffectTestComponent(Map props) {
   });
 
   return react.Fragment({}, [
-    react.h5({'key': 'randUE1'}, ['Example using useEffect (notice flicker):']),
-    react.div({'key': 'randUE2',}, ['value: ${value.value}']),
-    react.button({'key': 'randUE3','onClick': (_) => value.set(0)}, ['Change Value']),
+    react.h5({'key': 'random1'}, ['Example using useEffect (notice flicker):']),
+    react.div({'key': 'random2'}, ['value: ${value.value}']),
+    react.button({'key': 'random3', 'onClick': (_) => value.set(0)}, ['Change Value']),
   ]);
 }
 

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -184,7 +184,7 @@ UseRefTestComponent(Map props) {
   ]);
 }
 
-final random = new Random();
+final random = Random();
 
 final randomUseLayoutEffectTestComponent =
     react.registerFunctionComponent(RandomUseLayoutEffectTestComponent, displayName: 'randomUseLayoutEffectTest');

--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -1,4 +1,5 @@
 import 'dart:html';
+import 'dart:math';
 
 import 'package:react/hooks.dart';
 import 'package:react/react.dart' as react;
@@ -183,6 +184,47 @@ UseRefTestComponent(Map props) {
   ]);
 }
 
+var random = new Random();
+
+var randomUseLayoutEffectTestComponent =
+    react.registerFunctionComponent(RandomUseLayoutEffectTestComponent, displayName: 'randomUseLayoutEffectTest');
+
+RandomUseLayoutEffectTestComponent(Map props) {
+  StateHook<double> value = useState(0);
+
+  useLayoutEffect(() {
+    if (value.value == 0) {
+      value.set(10 + random.nextDouble() * 200);
+    }
+  });
+
+  return react.Fragment({}, [
+    react.h5({'key': 'randULE1'}, ['Example using useLayoutEffect:']),
+    react.div({'key': 'randULE2'}, ['value: ${value.value}']),
+    react.button({'key': 'randULE3','onClick': (_) => value.set(0)}, ['Change Value']),
+    react.br({'key': 'randULE4'}),
+  ]);
+}
+
+var randomUseEffectTestComponent =
+    react.registerFunctionComponent(RandomUseEffectTestComponent, displayName: 'randomUseEffectTest');
+
+RandomUseEffectTestComponent(Map props) {
+  StateHook<double> value = useState(0);
+
+  useEffect(() {
+    if (value.value == 0) {
+      value.set(10 + random.nextDouble() * 200);
+    }
+  });
+
+  return react.Fragment({}, [
+    react.h5({'key': 'randUE1'}, ['Example using useEffect (notice flicker):']),
+    react.div({'key': 'randUE2',}, ['value: ${value.value}']),
+    react.button({'key': 'randUE3','onClick': (_) => value.set(0)}, ['Change Value']),
+  ]);
+}
+
 void main() {
   setClientConfiguration();
 
@@ -217,6 +259,14 @@ void main() {
           react.h2({'key': 'useRefTestLabel'}, ['useRef Hook Test']),
           useRefTestFunctionComponent({
             'key': 'useRefTest',
+          }, []),
+          react.h2({'key': 'useLayoutEffectTestLabel'}, ['useLayoutEffect Hook Test']),
+          randomUseLayoutEffectTestComponent({
+            'key': 'useLayoutEffectTest',
+          }, []),
+          react.br({'key': 'br4'}),
+          randomUseEffectTestComponent({
+            'key': 'useLayoutEffectTest2',
           }, []),
         ]),
         querySelector('#content'));

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -393,7 +393,7 @@ T useContext<T>(Context<T> context) => ContextHelpers.unjsifyNewContext(React.us
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useref>.
 Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
 
-/// Runs [sideEffect] synchronously after all DOM mutations, but before the screen is updated.
+/// Runs [sideEffect] synchronously after a [DartFunctionComponent] renders, but before the screen is updated.
 ///
 /// Compare to [useEffect] which runs [sideEffect] after the screen updates.
 /// Prefer the standard [useEffect] when possible to avoid blocking visual updates.

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -396,3 +396,21 @@ T useContext<T>(Context<T> context) => ContextHelpers.unjsifyNewContext(React.us
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useref>.
 Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
+
+void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies]) {
+  var wrappedSideEffect = allowInterop(() {
+    var result = sideEffect();
+    if (result is Function) {
+      return allowInterop(result);
+    }
+
+    /// When no cleanup function is returned, [sideEffect] returns undefined.
+    return jsUndefined;
+  });
+
+  if (dependencies != null) {
+    return React.useLayoutEffect(wrappedSideEffect, dependencies);
+  } else {
+    return React.useLayoutEffect(wrappedSideEffect);
+  }
+}

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -407,8 +407,8 @@ Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
 ///
 /// ```
 /// UseLayoutEffectTestComponent(Map props) {
-///   var width = useState(0);
-///   var height = useState(0);
+///   final width = useState(0);
+///   final height = useState(0);
 ///
 ///   Ref textareaRef = useRef();
 ///
@@ -427,8 +427,8 @@ Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#uselayouteffect>.
 void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies]) {
-  var wrappedSideEffect = allowInterop(() {
-    var result = sideEffect();
+  final wrappedSideEffect = allowInterop(() {
+    final result = sideEffect();
     if (result is Function) {
       return allowInterop(result);
     }

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -393,9 +393,9 @@ T useContext<T>(Context<T> context) => ContextHelpers.unjsifyNewContext(React.us
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useref>.
 Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
 
-/// Runs [sideEffect] synchronously after a render, but before the screen is updated.
+/// Runs [sideEffect] synchronously after all DOM mutations, but before the screen is updated.
 ///
-/// Compare to [useEffect] which runs [sideEffect] asynchronously after the render is painted to the screen.
+/// Compare to [useEffect] which runs [sideEffect] after the screen updates.
 /// Prefer the standard [useEffect] when possible to avoid blocking visual updates.
 ///
 /// > __Note:__ there are two [rules for using Hooks](https://reactjs.org/docs/hooks-rules.html):

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -151,11 +151,7 @@ void useEffect(dynamic Function() sideEffect, [List<Object> dependencies]) {
     return jsUndefined;
   });
 
-  if (dependencies != null) {
-    return React.useEffect(wrappedSideEffect, dependencies);
-  } else {
-    return React.useEffect(wrappedSideEffect);
-  }
+  return React.useEffect(wrappedSideEffect, dependencies);
 }
 
 /// The return value of [useReducer].
@@ -397,6 +393,39 @@ T useContext<T>(Context<T> context) => ContextHelpers.unjsifyNewContext(React.us
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useref>.
 Ref<T> useRef<T>([T initialValue]) => Ref.useRefInit(initialValue);
 
+/// Runs [sideEffect] synchronously after a render, but before the screen is updated.
+///
+/// Compare to [useEffect] which runs [sideEffect] asynchronously after the render is painted to the screen.
+/// Prefer the standard [useEffect] when possible to avoid blocking visual updates.
+///
+/// > __Note:__ there are two [rules for using Hooks](https://reactjs.org/docs/hooks-rules.html):
+/// >
+/// > * Only call Hooks at the top level.
+/// > * Only call Hooks from inside a [DartFunctionComponent].
+///
+/// __Example__:
+///
+/// ```
+/// UseLayoutEffectTestComponent(Map props) {
+///   var width = useState(0);
+///   var height = useState(0);
+///
+///   Ref textareaRef = useRef();
+///
+///   useLayoutEffect(() {
+///     width.set(textareaRef.current.clientWidth);
+///     height.set(textareaRef.current.clientHeight);
+///   });
+///
+///   return react.Fragment({}, [
+///     react.div({}, ['textarea width: ${width.value}']),
+///     react.div({}, ['textarea height: ${height.value}']),
+///     react.textarea({'onClick': (_) => width.set(0), 'ref': textareaRef,}),
+///   ]);
+/// }
+/// ```
+///
+/// Learn more: <https://reactjs.org/docs/hooks-reference.html#uselayouteffect>.
 void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies]) {
   var wrappedSideEffect = allowInterop(() {
     var result = sideEffect();
@@ -408,9 +437,5 @@ void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies])
     return jsUndefined;
   });
 
-  if (dependencies != null) {
-    return React.useLayoutEffect(wrappedSideEffect, dependencies);
-  } else {
-    return React.useLayoutEffect(wrappedSideEffect);
-  }
+  return React.useLayoutEffect(wrappedSideEffect, dependencies);
 }

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -53,6 +53,7 @@ abstract class React {
   external static Function useCallback(Function callback, List dependencies);
   external static ReactContext useContext(ReactContext context);
   external static JsRef useRef([dynamic initialValue]);
+  external static void useLayoutEffect(dynamic Function() sideEffect, [List dependencies]);
 }
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -53,7 +53,7 @@ abstract class React {
   external static Function useCallback(Function callback, List dependencies);
   external static ReactContext useContext(ReactContext context);
   external static JsRef useRef([dynamic initialValue]);
-  external static void useLayoutEffect(dynamic Function() sideEffect, [List dependencies]);
+  external static void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies]);
 }
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -665,8 +665,7 @@ void testEffectHook(Function effectHook) {
     });
 
     test('side effect (with empty dependency list) is not called again', () {
-      expect(useEffectWithEmptyDepsCallCount, 1,
-          reason: 'side effect is only called once for empty dependency list');
+      expect(useEffectWithEmptyDepsCallCount, 1, reason: 'side effect is only called once for empty dependency list');
       expect(useEffectCleanupWithEmptyDepsCallCount, 0, reason: 'component has not been unmounted');
     });
   });

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -555,7 +555,7 @@ void testEffectHook(Function effectHook) {
   int useEffectCleanupWithEmptyDepsCallCount;
 
   setUpAll(() {
-    mountNode = new DivElement();
+    mountNode = DivElement();
     useEffectCallCount = 0;
     useEffectCleanupCallCount = 0;
     useEffectWithDepsCallCount = 0;

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -91,159 +91,7 @@ main() {
     });
 
     group('useEffect -', () {
-      ReactDartFunctionComponentFactoryProxy UseEffectTest;
-      ButtonElement countButtonRef;
-      DivElement countRef;
-      DivElement mountNode;
-      int useEffectCallCount;
-      int useEffectCleanupCallCount;
-      int useEffectWithDepsCallCount;
-      int useEffectCleanupWithDepsCallCount;
-      int useEffectWithDepsCallCount2;
-      int useEffectCleanupWithDepsCallCount2;
-      int useEffectWithEmptyDepsCallCount;
-      int useEffectCleanupWithEmptyDepsCallCount;
-
-      setUpAll(() {
-        mountNode = new DivElement();
-        useEffectCallCount = 0;
-        useEffectCleanupCallCount = 0;
-        useEffectWithDepsCallCount = 0;
-        useEffectCleanupWithDepsCallCount = 0;
-        useEffectWithDepsCallCount2 = 0;
-        useEffectCleanupWithDepsCallCount2 = 0;
-        useEffectWithEmptyDepsCallCount = 0;
-        useEffectCleanupWithEmptyDepsCallCount = 0;
-
-        UseEffectTest = react.registerFunctionComponent((Map props) {
-          final count = useState(0);
-          final countDown = useState(0);
-
-          useEffect(() {
-            useEffectCallCount++;
-            return () {
-              useEffectCleanupCallCount++;
-            };
-          });
-
-          useEffect(() {
-            useEffectWithDepsCallCount++;
-            return () {
-              useEffectCleanupWithDepsCallCount++;
-            };
-          }, [count.value]);
-
-          useEffect(() {
-            useEffectWithDepsCallCount2++;
-            return () {
-              useEffectCleanupWithDepsCallCount2++;
-            };
-          }, [countDown.value]);
-
-          useEffect(() {
-            useEffectWithEmptyDepsCallCount++;
-            return () {
-              useEffectCleanupWithEmptyDepsCallCount++;
-            };
-          }, []);
-
-          return react.div({}, [
-            react.div({
-              'ref': (ref) {
-                countRef = ref;
-              },
-            }, [
-              count.value
-            ]),
-            react.button({
-              'onClick': (_) {
-                count.set(count.value + 1);
-              },
-              'ref': (ref) {
-                countButtonRef = ref;
-              },
-            }, [
-              '+'
-            ]),
-          ]);
-        });
-
-        react_dom.render(UseEffectTest({}), mountNode);
-      });
-
-      test('side effect (no dependency list) is called after the first render', () {
-        expect(countRef.text, '0');
-
-        expect(useEffectCallCount, 1);
-        expect(useEffectCleanupCallCount, 0, reason: 'component has not been unmounted or re-rendered');
-      });
-
-      test('side effect (with dependency list) is called after the first render', () {
-        expect(useEffectWithDepsCallCount, 1);
-        expect(useEffectCleanupWithDepsCallCount, 0, reason: 'component has not been unmounted or re-rendered');
-
-        expect(useEffectWithDepsCallCount2, 1);
-        expect(useEffectCleanupWithDepsCallCount2, 0, reason: 'component has not been unmounted or re-rendered');
-      });
-
-      test('side effect (with empty dependency list) is called after the first render', () {
-        expect(useEffectWithEmptyDepsCallCount, 1);
-        expect(useEffectCleanupWithEmptyDepsCallCount, 0, reason: 'component has not been unmounted or re-rendered');
-      });
-
-      group('after state change,', () {
-        setUpAll(() {
-          react_test_utils.Simulate.click(countButtonRef);
-        });
-
-        test('side effect (no dependency list) is called again', () {
-          expect(countRef.text, '1');
-
-          expect(useEffectCallCount, 2);
-          expect(useEffectCleanupCallCount, 1, reason: 'cleanup called before re-render');
-        });
-
-        test('side effect (with dependency list) is called again if one of its dependencies changed', () {
-          expect(useEffectWithDepsCallCount, 2, reason: 'count.value changed');
-          expect(useEffectCleanupWithDepsCallCount, 1, reason: 'cleanup called before re-render');
-        });
-
-        test('side effect (with dependency list) is not called again if none of its dependencies changed', () {
-          expect(useEffectWithDepsCallCount2, 1, reason: 'countDown.value did not change');
-          expect(useEffectCleanupWithDepsCallCount2, 0,
-              reason: 'cleanup not called because countDown.value did not change');
-        });
-
-        test('side effect (with empty dependency list) is not called again', () {
-          expect(useEffectWithEmptyDepsCallCount, 1,
-              reason: 'side effect is only called once for empty dependency list');
-          expect(useEffectCleanupWithEmptyDepsCallCount, 0, reason: 'component has not been unmounted');
-        });
-      });
-
-      group('after component is unmounted,', () {
-        setUpAll(() {
-          react_dom.unmountComponentAtNode(mountNode);
-        });
-
-        test('cleanup (no dependency list) is called', () {
-          expect(useEffectCallCount, 2, reason: 'side effect not called on unmount');
-          expect(useEffectCleanupCallCount, 2);
-        });
-
-        test('cleanup (with dependency list) is called', () {
-          expect(useEffectWithDepsCallCount, 2, reason: 'side effect not called on unmount');
-          expect(useEffectCleanupWithDepsCallCount, 2);
-
-          expect(useEffectWithDepsCallCount2, 1, reason: 'side effect not called on unmount');
-          expect(useEffectCleanupWithDepsCallCount2, 1);
-        });
-
-        test('cleanup (with empty dependency list) is called', () {
-          expect(useEffectWithEmptyDepsCallCount, 1, reason: 'side effect not called on unmount');
-          expect(useEffectCleanupWithEmptyDepsCallCount, 1);
-        });
-      });
+      testEffectHook(useEffect);
     });
 
     group('useReducer -', () {
@@ -666,6 +514,10 @@ main() {
         });
       });
     });
+
+    group('useLayoutEffect -', () {
+      testEffectHook(useLayoutEffect);
+    });
   });
 }
 
@@ -686,4 +538,160 @@ class _ContextProviderWrapper extends react.Component2 {
           .Provider({'value': props['mode'] == 'increment' ? state['counter'] : props['value']}, props['children'])
     ]);
   }
+}
+
+void testEffectHook(Function effectHook) {
+  ReactDartFunctionComponentFactoryProxy UseEffectTest;
+  ButtonElement countButtonRef;
+  DivElement countRef;
+  DivElement mountNode;
+  int useEffectCallCount;
+  int useEffectCleanupCallCount;
+  int useEffectWithDepsCallCount;
+  int useEffectCleanupWithDepsCallCount;
+  int useEffectWithDepsCallCount2;
+  int useEffectCleanupWithDepsCallCount2;
+  int useEffectWithEmptyDepsCallCount;
+  int useEffectCleanupWithEmptyDepsCallCount;
+
+  setUpAll(() {
+    mountNode = new DivElement();
+    useEffectCallCount = 0;
+    useEffectCleanupCallCount = 0;
+    useEffectWithDepsCallCount = 0;
+    useEffectCleanupWithDepsCallCount = 0;
+    useEffectWithDepsCallCount2 = 0;
+    useEffectCleanupWithDepsCallCount2 = 0;
+    useEffectWithEmptyDepsCallCount = 0;
+    useEffectCleanupWithEmptyDepsCallCount = 0;
+
+    UseEffectTest = react.registerFunctionComponent((Map props) {
+      final count = useState(0);
+      final countDown = useState(0);
+
+      effectHook(() {
+        useEffectCallCount++;
+        return () {
+          useEffectCleanupCallCount++;
+        };
+      });
+
+      effectHook(() {
+        useEffectWithDepsCallCount++;
+        return () {
+          useEffectCleanupWithDepsCallCount++;
+        };
+      }, [count.value]);
+
+      effectHook(() {
+        useEffectWithDepsCallCount2++;
+        return () {
+          useEffectCleanupWithDepsCallCount2++;
+        };
+      }, [countDown.value]);
+
+      effectHook(() {
+        useEffectWithEmptyDepsCallCount++;
+        return () {
+          useEffectCleanupWithEmptyDepsCallCount++;
+        };
+      }, []);
+
+      return react.div({}, [
+        react.div({
+          'ref': (ref) {
+            countRef = ref;
+          },
+        }, [
+          count.value
+        ]),
+        react.button({
+          'onClick': (_) {
+            count.set(count.value + 1);
+          },
+          'ref': (ref) {
+            countButtonRef = ref;
+          },
+        }, [
+          '+'
+        ]),
+      ]);
+    });
+
+    react_dom.render(UseEffectTest({}), mountNode);
+  });
+
+  test('side effect (no dependency list) is called after the first render', () {
+    expect(countRef.text, '0');
+
+    expect(useEffectCallCount, 1);
+    expect(useEffectCleanupCallCount, 0, reason: 'component has not been unmounted or re-rendered');
+  });
+
+  test('side effect (with dependency list) is called after the first render', () {
+    expect(useEffectWithDepsCallCount, 1);
+    expect(useEffectCleanupWithDepsCallCount, 0, reason: 'component has not been unmounted or re-rendered');
+
+    expect(useEffectWithDepsCallCount2, 1);
+    expect(useEffectCleanupWithDepsCallCount2, 0, reason: 'component has not been unmounted or re-rendered');
+  });
+
+  test('side effect (with empty dependency list) is called after the first render', () {
+    expect(useEffectWithEmptyDepsCallCount, 1);
+    expect(useEffectCleanupWithEmptyDepsCallCount, 0, reason: 'component has not been unmounted or re-rendered');
+  });
+
+  group('after state change,', () {
+    setUpAll(() {
+      react_test_utils.Simulate.click(countButtonRef);
+    });
+
+    test('side effect (no dependency list) is called again', () {
+      expect(countRef.text, '1');
+
+      expect(useEffectCallCount, 2);
+      expect(useEffectCleanupCallCount, 1, reason: 'cleanup called before re-render');
+    });
+
+    test('side effect (with dependency list) is called again if one of its dependencies changed', () {
+      expect(useEffectWithDepsCallCount, 2, reason: 'count.value changed');
+      expect(useEffectCleanupWithDepsCallCount, 1, reason: 'cleanup called before re-render');
+    });
+
+    test('side effect (with dependency list) is not called again if none of its dependencies changed', () {
+      expect(useEffectWithDepsCallCount2, 1, reason: 'countDown.value did not change');
+      expect(useEffectCleanupWithDepsCallCount2, 0,
+          reason: 'cleanup not called because countDown.value did not change');
+    });
+
+    test('side effect (with empty dependency list) is not called again', () {
+      expect(useEffectWithEmptyDepsCallCount, 1,
+          reason: 'side effect is only called once for empty dependency list');
+      expect(useEffectCleanupWithEmptyDepsCallCount, 0, reason: 'component has not been unmounted');
+    });
+  });
+
+  group('after component is unmounted,', () {
+    setUpAll(() {
+      react_dom.unmountComponentAtNode(mountNode);
+    });
+
+    test('cleanup (no dependency list) is called', () {
+      expect(useEffectCallCount, 2, reason: 'side effect not called on unmount');
+      expect(useEffectCleanupCallCount, 2);
+    });
+
+    test('cleanup (with dependency list) is called', () {
+      expect(useEffectWithDepsCallCount, 2, reason: 'side effect not called on unmount');
+      expect(useEffectCleanupWithDepsCallCount, 2);
+
+      expect(useEffectWithDepsCallCount2, 1, reason: 'side effect not called on unmount');
+      expect(useEffectCleanupWithDepsCallCount2, 1);
+    });
+
+    test('cleanup (with empty dependency list) is called', () {
+      expect(useEffectWithEmptyDepsCallCount, 1, reason: 'side effect not called on unmount');
+      expect(useEffectCleanupWithEmptyDepsCallCount, 1);
+    });
+  });
 }


### PR DESCRIPTION
## Motivation
Support useLayoutEffect hook in `react-dart`.

## Changes
- Added `useLayoutEffect` function.
- Wrote tests.

Please review: @greglittlefield-wf @aaronlademann-wf @joebingham-wk 