### PR TITLE
Proxy event.persist() when wrapping synthetic JS events

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -1451,6 +1451,29 @@ class SyntheticEvent {
   /// See: <https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation>
   final dynamic stopPropagation;
 
+  /// For use by react-dart internals only.
+  @protected
+  void Function() $$jsPersistDoNotSetThisOrYouWillBeFired;
+  bool _isPersistent = false;
+
+  /// Whether the event instance has been removed from the ReactJS event pool.
+  ///
+  /// > See: [persist]
+  bool get isPersistent => _isPersistent;
+
+  /// Call this method on the current event instance if you want to access the event properties in an asynchronous way.
+  ///
+  /// This will remove the synthetic event from the event pool and allow references
+  /// to the event to be retained by user code.
+  ///
+  /// See: <https://reactjs.org/docs/events.html#event-pooling>
+  void persist() {
+    if ($$jsPersistDoNotSetThisOrYouWillBeFired != null) {
+      _isPersistent = true;
+      $$jsPersistDoNotSetThisOrYouWillBeFired();
+    }
+  }
+
   /// Indicates which phase of the [Event] flow is currently being evaluated.
   ///
   /// Possible values:

--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -938,8 +938,10 @@ _convertEventHandlers(Map args) {
 
 /// Wrapper for [SyntheticEvent].
 SyntheticEvent syntheticEventFactory(events.SyntheticEvent e) {
-  return new SyntheticEvent(e.bubbles, e.cancelable, e.currentTarget, e.defaultPrevented, () => e.preventDefault(),
-      () => e.stopPropagation(), e.eventPhase, e.isTrusted, e.nativeEvent, e.target, e.timeStamp, e.type);
+  return SyntheticEvent(e.bubbles, e.cancelable, e.currentTarget, e.defaultPrevented, () => e.preventDefault(),
+      () => e.stopPropagation(), e.eventPhase, e.isTrusted, e.nativeEvent, e.target, e.timeStamp, e.type)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticClipboardEvent].
@@ -957,7 +959,9 @@ SyntheticClipboardEvent syntheticClipboardEventFactory(events.SyntheticClipboard
       e.target,
       e.timeStamp,
       e.type,
-      e.clipboardData);
+      e.clipboardData)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticKeyboardEvent].
@@ -985,7 +989,9 @@ SyntheticKeyboardEvent syntheticKeyboardEventFactory(events.SyntheticKeyboardEve
       e.keyCode,
       e.metaKey,
       e.repeat,
-      e.shiftKey);
+      e.shiftKey)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticCompositionEvent].
@@ -1003,7 +1009,9 @@ SyntheticCompositionEvent syntheticCompositionEventFactory(events.SyntheticCompo
       e.target,
       e.timeStamp,
       e.type,
-      e.data);
+      e.data)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticFocusEvent].
@@ -1021,13 +1029,17 @@ SyntheticFocusEvent syntheticFocusEventFactory(events.SyntheticFocusEvent e) {
       e.target,
       e.timeStamp,
       e.type,
-      e.relatedTarget);
+      e.relatedTarget)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticFormEvent].
 SyntheticFormEvent syntheticFormEventFactory(events.SyntheticFormEvent e) {
   return new SyntheticFormEvent(e.bubbles, e.cancelable, e.currentTarget, e.defaultPrevented, () => e.preventDefault(),
-      () => e.stopPropagation(), e.eventPhase, e.isTrusted, e.nativeEvent, e.target, e.timeStamp, e.type);
+      () => e.stopPropagation(), e.eventPhase, e.isTrusted, e.nativeEvent, e.target, e.timeStamp, e.type)
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticDataTransfer].
@@ -1126,7 +1138,9 @@ SyntheticPointerEvent syntheticPointerEventFactory(events.SyntheticPointerEvent 
     e.twist,
     e.pointerType,
     e.isPrimary,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticMouseEvent].
@@ -1159,7 +1173,9 @@ SyntheticMouseEvent syntheticMouseEventFactory(events.SyntheticMouseEvent e) {
     e.screenX,
     e.screenY,
     e.shiftKey,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticTouchEvent].
@@ -1184,7 +1200,9 @@ SyntheticTouchEvent syntheticTouchEventFactory(events.SyntheticTouchEvent e) {
     e.shiftKey,
     e.targetTouches,
     e.touches,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticTransitionEvent].
@@ -1205,7 +1223,9 @@ SyntheticTransitionEvent syntheticTransitionEventFactory(events.SyntheticTransit
     e.propertyName,
     e.elapsedTime,
     e.pseudoElement,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticAnimationEvent].
@@ -1226,7 +1246,9 @@ SyntheticAnimationEvent syntheticAnimationEventFactory(events.SyntheticAnimation
     e.animationName,
     e.elapsedTime,
     e.pseudoElement,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticUIEvent].
@@ -1246,7 +1268,9 @@ SyntheticUIEvent syntheticUIEventFactory(events.SyntheticUIEvent e) {
     e.type,
     e.detail,
     e.view,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 /// Wrapper for [SyntheticWheelEvent].
@@ -1268,7 +1292,9 @@ SyntheticWheelEvent syntheticWheelEventFactory(events.SyntheticWheelEvent e) {
     e.deltaMode,
     e.deltaY,
     e.deltaZ,
-  );
+  )
+    // ignore: invalid_use_of_protected_member
+    ..$$jsPersistDoNotSetThisOrYouWillBeFired = () => e.persist();
 }
 
 dynamic _findDomNode(component) {

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -142,6 +142,41 @@ void domEventHandlerWrappingTests(ReactComponentFactoryProxy factory) {
     expect(actualEvent, isA<react.SyntheticEvent>());
   });
 
+  group('wraps the handler with a function that proxies ReactJS event "persistence" as expected', () {
+    test('when event.persist() is called', () {
+      react.SyntheticMouseEvent actualEvent;
+
+      var renderedInstance = rtu.renderIntoDocument(factory({
+        'onClick': (react.SyntheticMouseEvent event) {
+          event.persist();
+          actualEvent = event;
+        }
+      }));
+
+      rtu.Simulate.click(react_dom.findDOMNode(renderedInstance));
+
+      // ignore: invalid_use_of_protected_member
+      expect(actualEvent.$$jsPersistDoNotSetThisOrYouWillBeFired, isA<Function>());
+      expect(actualEvent.isPersistent, isTrue);
+    });
+
+    test('when event.persist() is not called', () {
+      react.SyntheticMouseEvent actualEvent;
+
+      var renderedInstance = rtu.renderIntoDocument(factory({
+        'onClick': (react.SyntheticMouseEvent event) {
+          actualEvent = event;
+        }
+      }));
+
+      rtu.Simulate.click(react_dom.findDOMNode(renderedInstance));
+
+      // ignore: invalid_use_of_protected_member
+      expect(actualEvent.$$jsPersistDoNotSetThisOrYouWillBeFired, isA<Function>());
+      expect(actualEvent.isPersistent, isFalse);
+    });
+  });
+
   test('doesn\'t wrap the handler if it is null', () {
     var renderedInstance = rtu.renderIntoDocument(factory({'onClick': null}));
 


### PR DESCRIPTION
While playing around with using `forwardRef` in [the over_react redux todo demo app](https://github.com/Workiva/over_react/pull/439), I discovered that if a JS component makes use of [`event.persist()`](https://reactjs.org/docs/events.html#event-pooling), a runtime exception occurs if that JS component is wrapped with `forwardRef` as a result of the Dart event wrapper not having a method called `persist`.

This PR remedies that issue in a non-breaking way by adding a public - but very ominous field `$$jsPersistDoNotSetThisOrYouWillBeFired` - which gets set to a function by that analogous synthetic event factory in `react_client.dart`. This field will call the JS `event.persist()` function when called on the Dart side.  The use of this field was necessary since the pre-existing pattern was to add have an argument in the constructor that would do the same _(e.g. `SyntheticEvent._preventDefault` gets set via the `_preventDefault` argument in the constructor)_.  Following this pre-existing pattern would require us to make breaking changes to numerous public constructor signatures.

FYA: @sydneyjodon-wk @joebingham-wk @greglittlefield-wf @kealjones-wk 