### PR TITLE
CPLAT-10894 Rethrow and print registerComponent/registerComponent2 errors

### DIFF
--- a/lib/react_client.dart
+++ b/lib/react_client.dart
@@ -656,8 +656,8 @@ ReactDartComponentFactoryProxy _registerComponent(
     reactComponentClass.dartDefaultProps = defaultProps;
 
     return new ReactDartComponentFactoryProxy(reactComponentClass);
-  } catch (e) {
-    print('Error when registering Component: $e');
+  } catch (e, stack) {
+    print('Error when registering Component: $e\n$stack');
     rethrow;
   }
 }
@@ -780,6 +780,7 @@ ReactDartComponentFactoryProxy2 _registerComponent2(
   Iterable<String> skipMethods = const ['getDerivedStateFromError', 'componentDidCatch'],
   Component2BridgeFactory bridgeFactory,
 }) {
+  bool errorPrinted = false;
   try {
     bridgeFactory ??= Component2BridgeImpl.bridgeFactory;
 
@@ -796,16 +797,18 @@ ReactDartComponentFactoryProxy2 _registerComponent2(
     JsBackedMap defaultProps;
     try {
       defaultProps = JsBackedMap.from(componentInstance.defaultProps);
-    } catch (e) {
-      print('Error when registering Component2 when getting defaultProps: $e');
+    } catch (e, stack) {
+      print('Error when registering Component2 when getting defaultProps: $e\n$stack');
+      errorPrinted = true;
       rethrow;
     }
 
     JsMap jsPropTypes;
     try {
       jsPropTypes = bridgeFactory(componentInstance).jsifyPropTypes(componentInstance, componentInstance.propTypes);
-    } catch (e) {
-      print('Error when registering Component2 when getting propTypes: $e');
+    } catch (e, stack) {
+      print('Error when registering Component2 when getting propTypes: $e\n$stack');
+      errorPrinted = true;
       rethrow;
     }
 
@@ -825,8 +828,8 @@ ReactDartComponentFactoryProxy2 _registerComponent2(
     reactComponentClass.dartComponentVersion = ReactDartComponentVersion.component2;
 
     return new ReactDartComponentFactoryProxy2(reactComponentClass);
-  } catch (e) {
-    print('Error when registering Component2: $e');
+  } catch (e, stack) {
+    if (!errorPrinted) print('Error when registering Component2: $e\n$stack');
     rethrow;
   }
 }

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -176,7 +176,7 @@ main() {
 
   group('registerComponent', () {
     test('throws with printed error', () {
-      expect(() => react.registerComponent(() => ThrowsInDefaultPropsComponent()), throwsA(Error));
+      expect(() => react.registerComponent(() => ThrowsInDefaultPropsComponent()), throwsStateError);
       expect(() {
         try {
           react.registerComponent(() => ThrowsInDefaultPropsComponent());
@@ -187,7 +187,7 @@ main() {
 
   group('registerComponent2', () {
     test('throws with specific error when defaultProps throws', () {
-      expect(() => react.registerComponent2(() => ThrowsInDefaultPropsComponent2()), throwsA(Error));
+      expect(() => react.registerComponent2(() => ThrowsInDefaultPropsComponent2()), throwsStateError);
       expect(() {
         try {
           react.registerComponent2(() => ThrowsInDefaultPropsComponent2());
@@ -196,7 +196,7 @@ main() {
     });
 
     test('throws with specific error when propTypes throws', () {
-      expect(() => react.registerComponent2(() => ThrowsInPropTypesComponent2()), throwsA(Error));
+      expect(() => react.registerComponent2(() => ThrowsInPropTypesComponent2()), throwsStateError);
       expect(() {
         try {
           react.registerComponent2(() => ThrowsInPropTypesComponent2());
@@ -205,11 +205,10 @@ main() {
     });
 
     test('throws with generic error when something else throws', () {
-      expect(() => react.registerComponent2(() => DartComponent2Component(), bridgeFactory: (component) => throw Error),
-          throwsA(Error));
+      expect(() => react.registerComponent2(() => throw StateError('bad component')), throwsStateError);
       expect(() {
         try {
-          react.registerComponent2(() => DartComponent2Component(), bridgeFactory: (component) => throw Error);
+          react.registerComponent2(() => throw StateError('bad component'));
         } catch (_) {}
       }, prints(contains('Error when registering Component2:')));
     });
@@ -230,7 +229,7 @@ final Function testJsComponentFactory = (() {
 
 class ThrowsInDefaultPropsComponent extends Component {
   @override
-  Map getDefaultProps() => throw Error;
+  Map getDefaultProps() => throw StateError('bad default props');
 
   @override
   render() {
@@ -239,7 +238,7 @@ class ThrowsInDefaultPropsComponent extends Component {
 }
 
 class ThrowsInDefaultPropsComponent2 extends Component2 {
-  get defaultProps => throw Error;
+  get defaultProps => throw StateError('bad default props');
 
   @override
   render() {
@@ -248,7 +247,7 @@ class ThrowsInDefaultPropsComponent2 extends Component2 {
 }
 
 class ThrowsInPropTypesComponent2 extends Component2 {
-  get propTypes => throw Error;
+  get propTypes => throw StateError('bad prop types');
 
   @override
   render() {

--- a/test/react_client_test.dart
+++ b/test/react_client_test.dart
@@ -173,6 +173,47 @@ main() {
       expect(result, isNull);
     });
   });
+
+  group('registerComponent', () {
+    test('throws with printed error', () {
+      expect(() => react.registerComponent(() => ThrowsInDefaultPropsComponent()), throwsA(Error));
+      expect(() {
+        try {
+          react.registerComponent(() => ThrowsInDefaultPropsComponent());
+        } catch (_) {}
+      }, prints(contains('Error when registering Component:')));
+    });
+  });
+
+  group('registerComponent2', () {
+    test('throws with specific error when defaultProps throws', () {
+      expect(() => react.registerComponent2(() => ThrowsInDefaultPropsComponent2()), throwsA(Error));
+      expect(() {
+        try {
+          react.registerComponent2(() => ThrowsInDefaultPropsComponent2());
+        } catch (_) {}
+      }, prints(contains('Error when registering Component2 when getting defaultProps')));
+    });
+
+    test('throws with specific error when propTypes throws', () {
+      expect(() => react.registerComponent2(() => ThrowsInPropTypesComponent2()), throwsA(Error));
+      expect(() {
+        try {
+          react.registerComponent2(() => ThrowsInPropTypesComponent2());
+        } catch (_) {}
+      }, prints(contains('Error when registering Component2 when getting propTypes')));
+    });
+
+    test('throws with generic error when something else throws', () {
+      expect(() => react.registerComponent2(() => DartComponent2Component(), bridgeFactory: (component) => throw Error),
+          throwsA(Error));
+      expect(() {
+        try {
+          react.registerComponent2(() => DartComponent2Component(), bridgeFactory: (component) => throw Error);
+        } catch (_) {}
+      }, prints(contains('Error when registering Component2:')));
+    });
+  });
 }
 
 @JS()
@@ -186,6 +227,34 @@ final Function testJsComponentFactory = (() {
     return reactFactory(jsifyAndAllowInterop(props), listifyChildren(children));
   };
 })();
+
+class ThrowsInDefaultPropsComponent extends Component {
+  @override
+  Map getDefaultProps() => throw Error;
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+class ThrowsInDefaultPropsComponent2 extends Component2 {
+  get defaultProps => throw Error;
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+class ThrowsInPropTypesComponent2 extends Component2 {
+  get propTypes => throw Error;
+
+  @override
+  render() {
+    return null;
+  }
+}
 
 class DartComponent2Component extends Component2 {
   @override


### PR DESCRIPTION
Recommended review: [Whitespace changes only](https://github.com/cleandart/react-dart/pull/261/files?diff=split&w=1)

## Problem
Currently, registerComponent calls that throw have their errors swallowed by React if they occur in the call stack of a component render (due to the render triggering lazy evaluation of a top-level factory variable).

This can commonly happen if:
- defaultProps throws
- propTypes throws
    - can happen when consumedProps throws

## Changes: 
- In `_registerComponent` and `_registerComponent2`, add a try-catch-rethrow that also logs the error, in case it's swallowed by React
- Use print instead of window.console.error so it shows up in test output
- In `_registerComponent2` only: add more specific try-catch-rethrows around defaultProps/propTypes accesses, since that's usually what throws 
- Add regression tests that use the `prints` matcher to verify the error is printed

## QA
- [ ] CI passes, unit test coverage should be sufficient unless @greglittlefield-wf feels otherwise