### PR TITLE
Update factory fields in component factories to be getters

### DIFF
--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -327,7 +327,8 @@ ReducerHook<TState, TAction, TInit> useReducerLazy<TState, TAction, TInit>(
 /// ```
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
-T useCallback<T extends Function>(T callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);
+T useCallback<T extends Function>(T callback, List dependencies) =>
+    React.useCallback(allowInterop(callback), dependencies);
 
 /// Returns the value of the nearest [Context.Provider] for the provided [context] object every time that context is
 /// updated.

--- a/lib/react_client/component_factory.dart
+++ b/lib/react_client/component_factory.dart
@@ -198,6 +198,7 @@ class ReactDartComponentFactoryProxy2<TComponent extends Component2> extends Rea
   final ReactClass reactClass;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
+  @Deprecated('6.0.0')
   ReactJsComponentFactory get reactComponentFactory => React.createFactory(reactClass);
 
   final Map defaultProps;
@@ -225,6 +226,7 @@ class ReactJsContextComponentFactoryProxy extends ReactJsComponentFactoryProxy {
   final bool isProvider;
   final bool shouldConvertDomProps;
 
+  @Deprecated('6.0.0')
   Function get factory => React.createFactory(type);
 
   ReactJsContextComponentFactoryProxy(
@@ -271,6 +273,7 @@ class ReactJsComponentFactoryProxy extends ReactComponentFactoryProxy {
   final ReactClass type;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
+  @Deprecated('6.0.0')
   Function get factory => React.createFactory(type);
 
   /// Whether to automatically prepare props relating to bound values and event handlers
@@ -319,6 +322,7 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   final String name;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
+  @Deprecated('6.0.0')
   Function get factory => React.createFactory(name);
 
   ReactDomComponentFactoryProxy(this.name) {

--- a/lib/react_client/component_factory.dart
+++ b/lib/react_client/component_factory.dart
@@ -109,7 +109,7 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
   final ReactClass reactClass;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
-  final ReactJsComponentFactory reactComponentFactory;
+  ReactJsComponentFactory get reactComponentFactory => React.createFactory(reactClass);
 
   /// The cached Dart default props retrieved from [reactClass] that are passed
   /// into [generateExtendedJsProps] upon [ReactElement] creation.
@@ -117,7 +117,6 @@ class ReactDartComponentFactoryProxy<TComponent extends Component> extends React
 
   ReactDartComponentFactoryProxy(ReactClass reactClass)
       : this.reactClass = reactClass,
-        this.reactComponentFactory = React.createFactory(reactClass),
         this.defaultProps = reactClass.dartDefaultProps;
 
   ReactClass get type => reactClass;
@@ -199,13 +198,12 @@ class ReactDartComponentFactoryProxy2<TComponent extends Component2> extends Rea
   final ReactClass reactClass;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
-  final ReactJsComponentFactory reactComponentFactory;
+  ReactJsComponentFactory get reactComponentFactory => React.createFactory(reactClass);
 
   final Map defaultProps;
 
   ReactDartComponentFactoryProxy2(ReactClass reactClass)
       : this.reactClass = reactClass,
-        this.reactComponentFactory = React.createFactory(reactClass),
         this.defaultProps = new JsBackedMap.fromJs(reactClass.defaultProps);
 
   ReactClass get type => reactClass;
@@ -225,8 +223,9 @@ class ReactJsContextComponentFactoryProxy extends ReactJsComponentFactoryProxy {
   final ReactClass type;
   final bool isConsumer;
   final bool isProvider;
-  final Function factory;
   final bool shouldConvertDomProps;
+
+  Function get factory => React.createFactory(type);
 
   ReactJsContextComponentFactoryProxy(
     ReactClass jsClass, {
@@ -234,7 +233,6 @@ class ReactJsContextComponentFactoryProxy extends ReactJsComponentFactoryProxy {
     this.isConsumer: false,
     this.isProvider: false,
   })  : this.type = jsClass,
-        this.factory = React.createFactory(jsClass),
         super(jsClass, shouldConvertDomProps: shouldConvertDomProps);
 
   @override
@@ -273,7 +271,7 @@ class ReactJsComponentFactoryProxy extends ReactComponentFactoryProxy {
   final ReactClass type;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
-  final Function factory;
+  Function get factory => React.createFactory(type);
 
   /// Whether to automatically prepare props relating to bound values and event handlers
   /// via [ReactDomComponentFactoryProxy.convertProps] for consumption by React JS DOM components.
@@ -295,7 +293,6 @@ class ReactJsComponentFactoryProxy extends ReactComponentFactoryProxy {
     this.alwaysReturnChildrenAsList: false,
     List<String> additionalRefPropKeys = const [],
   })  : this.type = jsClass,
-        this.factory = React.createFactory(jsClass),
         this._additionalRefPropKeys = additionalRefPropKeys {
     if (jsClass == null) {
       throw new ArgumentError('`jsClass` must not be null. '
@@ -322,9 +319,9 @@ class ReactDomComponentFactoryProxy extends ReactComponentFactoryProxy {
   final String name;
 
   /// The JS component factory used by this factory to build [ReactElement]s.
-  final Function factory;
+  Function get factory => React.createFactory(name);
 
-  ReactDomComponentFactoryProxy(this.name) : this.factory = React.createFactory(name) {
+  ReactDomComponentFactoryProxy(this.name) {
     // TODO: Should we remove this once we validate that the bug is gone in Dart 2 DDC?
     if (ddc_emulated_function_name_bug.isBugPresent) {
       ddc_emulated_function_name_bug.patchName(this);

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -41,6 +41,7 @@ abstract class React {
   ]);
   @Deprecated('6.0.0')
   external static ReactClass createClass(ReactClassConfig reactClassConfig);
+  @Deprecated('6.0.0')
   external static ReactJsComponentFactory createFactory(type);
   external static ReactElement createElement(dynamic type, props, [dynamic children]);
   external static JsRef createRef();


### PR DESCRIPTION
Factory fields have been updated to be getters so they will be lazy evaluated to avoid this warning showing in the console:
```
Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
```