### PR TITLE
Update memo signature

### DIFF
--- a/example/test/function_component_test.dart
+++ b/example/test/function_component_test.dart
@@ -68,7 +68,7 @@ class _MemoTestDemoWrapper extends react.Component2 {
   }
 }
 
-final MemoTest = react.memo((Map props) {
+final MemoTest = react.memo(react.registerFunctionComponent((Map props) {
   final context = useContext(TestNewContext);
   return react.div(
     {},
@@ -89,9 +89,9 @@ final MemoTest = react.memo((Map props) {
       ' (should never update)',
     ),
   );
-}, areEqual: (prevProps, nextProps) {
+}), areEqual: (prevProps, nextProps) {
   return prevProps['localCount'] == nextProps['localCount'];
-}, displayName: 'MemoTest');
+});
 
 var useReducerTestFunctionComponent =
     react.registerFunctionComponent(UseReducerTestComponent, displayName: 'useReducerTest');

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -327,7 +327,8 @@ ReducerHook<TState, TAction, TInit> useReducerLazy<TState, TAction, TInit>(
 /// ```
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#usecallback>.
-T useCallback<T extends Function>(T callback, List dependencies) => React.useCallback(allowInterop(callback), dependencies);
+T useCallback<T extends Function>(T callback, List dependencies) =>
+    React.useCallback(allowInterop(callback), dependencies);
 
 /// Returns the value of the nearest [Context.Provider] for the provided [context] object every time that context is
 /// updated.

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -18,7 +18,8 @@ import 'package:react/react.dart';
 import 'package:react/react_client.dart' show ComponentFactory;
 import 'package:react/react_client/bridge.dart';
 import 'package:react/react_client/js_backed_map.dart';
-import 'package:react/react_client/component_factory.dart' show ReactJsComponentFactoryProxy;
+import 'package:react/react_client/component_factory.dart'
+    show ReactDartFunctionComponentFactoryProxy, ReactJsComponentFactoryProxy;
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/private_utils.dart';
 import 'package:react/src/react_client/dart2_interop_workaround_bindings.dart';
@@ -288,11 +289,8 @@ ReactJsComponentFactoryProxy forwardRef(
 /// > Do not rely on it to “prevent” a render, as this can lead to bugs.
 ///
 /// See: <https://reactjs.org/docs/react-api.html#reactmemo>.
-ReactJsComponentFactoryProxy memo(
-  dynamic Function(Map props) wrapperFunction, {
-  bool Function(Map prevProps, Map nextProps) areEqual,
-  String displayName = 'Anonymous',
-}) {
+ReactJsComponentFactoryProxy memo(ReactDartFunctionComponentFactoryProxy factory,
+    {bool Function(Map prevProps, Map nextProps) areEqual}) {
   final _areEqual = areEqual == null
       ? null
       : allowInterop((JsMap prevProps, JsMap nextProps) {
@@ -300,16 +298,7 @@ ReactJsComponentFactoryProxy memo(
           final dartNextProps = JsBackedMap.backedBy(nextProps);
           return areEqual(dartPrevProps, dartNextProps);
         });
-
-  final wrappedComponent = allowInterop((JsMap props, [JsMap _]) {
-    final dartProps = JsBackedMap.backedBy(props);
-    return wrapperFunction(dartProps);
-  });
-
-  defineProperty(wrappedComponent, 'displayName', jsify({'value': displayName}));
-
-  final hoc = React.memo(wrappedComponent, _areEqual);
-
+  final hoc = React.memo(factory.type, _areEqual);
   return ReactJsComponentFactoryProxy(hoc);
 }
 

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -262,9 +262,9 @@ ReactJsComponentFactoryProxy forwardRef(
 /// ```dart
 /// import 'package:react/react.dart' as react;
 ///
-/// final MyComponent = react.memo((props) {
+/// final MyComponent = react.memo(react.registerFunctionComponent((props) {
 ///   /* render using props */
-/// });
+/// }));
 /// ```
 ///
 /// `memo` only affects props changes. If your function component wrapped in `memo` has a
@@ -277,9 +277,9 @@ ReactJsComponentFactoryProxy forwardRef(
 /// ```dart
 /// import 'package:react/react.dart' as react;
 ///
-/// final MyComponent = react.memo((props) {
+/// final MyComponent = react.memo(react.registerFunctionComponent((props) {
 ///   // render using props
-/// }, areEqual: (prevProps, nextProps) {
+/// }), areEqual: (prevProps, nextProps) {
 ///   // Do some custom comparison logic to return a bool based on prevProps / nextProps
 /// });
 /// ```

--- a/test/react_memo_test.dart
+++ b/test/react_memo_test.dart
@@ -16,7 +16,6 @@ main() {
 
   void renderMemoTest({
     bool testAreEqual = false,
-    String displayName,
   }) {
     expect(memoTestWrapperComponentRef, isNotNull, reason: 'test setup sanity check');
     expect(localCountDisplayRef, isNotNull, reason: 'test setup sanity check');
@@ -28,7 +27,7 @@ main() {
             return prevProps['localCount'] == nextProps['localCount'];
           };
 
-    final MemoTest = react.memo((Map props) {
+    final MemoTest = react.memo(react.registerFunctionComponent((Map props) {
       childMemoRenderCount++;
       return react.div(
         {},
@@ -41,7 +40,7 @@ main() {
           props['valueMemoShouldIgnoreViaAreEqual'],
         ),
       );
-    }, areEqual: customAreEqualFn, displayName: displayName);
+    }), areEqual: customAreEqualFn);
 
     rtu.renderIntoDocument(MemoTestWrapper({
       'ref': memoTestWrapperComponentRef,


### PR DESCRIPTION
Updates the `memo` signature to accept a `ReactDartFunctionComponentFactoryProxy` directly, since only function components can be memoized. 

Also removes the `displayName` property as it is not part of React's `memo`, and should be set by the function component config instead.