### PR TITLE
Run function/forwardRef components in component zone, run children tests

### DIFF
--- a/lib/react_client/component_factory.dart
+++ b/lib/react_client/component_factory.dart
@@ -387,7 +387,7 @@ class ReactDartFunctionComponentFactoryProxy extends ReactComponentFactoryProxy 
     // to force `null` as the return value if user returns a Dart `null`.
     // See: https://github.com/dart-lang/sdk/issues/27485
     jsFunctionComponent(JsMap jsProps, [JsMap _legacyContext]) =>
-        dartFunctionComponent(JsBackedMap.backedBy(jsProps)) ?? jsNull;
+        componentZone.run(() => dartFunctionComponent(JsBackedMap.backedBy(jsProps)) ?? jsNull);
     JsFunctionComponent interopFunction = allowInterop(jsFunctionComponent);
     if (displayName != null) {
       // This is a work-around to display the correct name in the React DevTools.

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -26,7 +26,8 @@ import '../util.dart';
 ///
 /// [dartComponentVersion] should be specified for all components with Dart render code in order to
 /// properly test `props.children`, forwardRef compatibility, etc.
-void commonFactoryTests(ReactComponentFactoryProxy factory, {bool isFunctionComponent = false, String dartComponentVersion}) {
+void commonFactoryTests(ReactComponentFactoryProxy factory,
+    {bool isFunctionComponent = false, String dartComponentVersion}) {
   _childKeyWarningTests(
     factory,
     renderWithUniqueOwnerName: _renderWithUniqueOwnerName,
@@ -43,7 +44,8 @@ void commonFactoryTests(ReactComponentFactoryProxy factory, {bool isFunctionComp
     expect(ReactDartComponentVersion.fromType(factory.type), dartComponentVersion);
   });
 
-  void sharedChildrenTests(dynamic getChildren(ReactElement instance), {@required bool shouldAlwaysBeList, Map props = const {}}) {
+  void sharedChildrenTests(dynamic getChildren(ReactElement instance),
+      {@required bool shouldAlwaysBeList, Map props = const {}}) {
     // There are different code paths for 0, 1, 2, 3, 4, 5, 6, and 6+ arguments.
     // Test all of them.
     group('a number of variadic children:', () {
@@ -64,15 +66,17 @@ void commonFactoryTests(ReactComponentFactoryProxy factory, {bool isFunctionComp
 
         test('$childrenCount', () {
           final expectedChildren = new List.generate(childrenCount, (i) => i + 1);
-          final arguments = <dynamic>[{...props}]..add(expectedChildren);
+          final arguments = <dynamic>[
+            {...props}
+          ]..add(expectedChildren);
           final instance = Function.apply(factory, arguments);
           expect(getChildren(instance), expectedChildren);
         });
       }
 
       test('$maxSupportedVariadicChildCount (and passes static analysis)', () {
-        final instance = factory({...props}, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40);
+        final instance = factory({...props}, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+            22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40);
         // Generate these instead of hard coding them to ensure the arguments passed into this test match maxSupportedVariadicChildCount
         final expectedChildren = new List.generate(maxSupportedVariadicChildCount, (i) => i + 1);
         expect(getChildren(instance), equals(expectedChildren));
@@ -80,7 +84,9 @@ void commonFactoryTests(ReactComponentFactoryProxy factory, {bool isFunctionComp
     });
 
     test('a List', () {
-      var instance = factory({...props}, [
+      var instance = factory({
+        ...props
+      }, [
         'one',
         'two',
       ]);
@@ -139,7 +145,8 @@ void commonFactoryTests(ReactComponentFactoryProxy factory, {bool isFunctionComp
       final oldComponentZone = componentZone;
       addTearDown(() => componentZone = oldComponentZone);
       componentZone = Zone.current.fork();
-      expect(componentZone, isNot(Zone.current), reason: 'test setup: component zone should be different than the zone used to render it');
+      expect(componentZone, isNot(Zone.current),
+          reason: 'test setup: component zone should be different than the zone used to render it');
 
       Zone renderZone;
       rtu.renderIntoDocument(factory({
@@ -386,7 +393,6 @@ void refTests<T>(ReactComponentFactoryProxy factory, {void verifyRefValue(dynami
   });
 
   group('forwardRef wraps event handlers properly,', () {
-
     const dartInside = EventTestCase.dart('onMouseDown', 'inside forwardRef');
     const dart = EventTestCase.dart('onMouseUp', 'set on forwardRef hoc');
     const dartCloned = EventTestCase.dart('onMouseLeave', 'cloned onto forwardRef hoc');

--- a/test/factory/common_factory_tests.dart
+++ b/test/factory/common_factory_tests.dart
@@ -50,12 +50,12 @@ void commonFactoryTests(ReactComponentFactoryProxy factory,
     // Test all of them.
     group('a number of variadic children:', () {
       test('0', () {
-        final instance = factory({...props});
+        final instance = factory(props);
         expect(getChildren(instance), shouldAlwaysBeList ? [] : isNull);
       });
 
       test('1', () {
-        final instance = factory({...props}, 1);
+        final instance = factory(props, 1);
         expect(getChildren(instance), shouldAlwaysBeList ? [1] : 1);
       });
 
@@ -66,17 +66,15 @@ void commonFactoryTests(ReactComponentFactoryProxy factory,
 
         test('$childrenCount', () {
           final expectedChildren = new List.generate(childrenCount, (i) => i + 1);
-          final arguments = <dynamic>[
-            {...props}
-          ]..add(expectedChildren);
+          final arguments = <dynamic>[props, ...expectedChildren];
           final instance = Function.apply(factory, arguments);
           expect(getChildren(instance), expectedChildren);
         });
       }
 
       test('$maxSupportedVariadicChildCount (and passes static analysis)', () {
-        final instance = factory({...props}, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-            22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40);
+        final instance = factory(props, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+            23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40);
         // Generate these instead of hard coding them to ensure the arguments passed into this test match maxSupportedVariadicChildCount
         final expectedChildren = new List.generate(maxSupportedVariadicChildCount, (i) => i + 1);
         expect(getChildren(instance), equals(expectedChildren));
@@ -84,9 +82,7 @@ void commonFactoryTests(ReactComponentFactoryProxy factory,
     });
 
     test('a List', () {
-      var instance = factory({
-        ...props
-      }, [
+      var instance = factory(props, [
         'one',
         'two',
       ]);
@@ -94,17 +90,17 @@ void commonFactoryTests(ReactComponentFactoryProxy factory,
     });
 
     test('an empty List', () {
-      var instance = factory({...props}, []);
+      var instance = factory(props, []);
       expect(getChildren(instance), equals([]));
     });
 
     test('an Iterable', () {
-      var instance = factory({...props}, new Iterable.generate(3, (int i) => '$i'));
+      var instance = factory(props, new Iterable.generate(3, (int i) => '$i'));
       expect(getChildren(instance), equals(['0', '1', '2']));
     });
 
     test('an empty Iterable', () {
-      var instance = factory({...props}, new Iterable.empty());
+      var instance = factory(props, new Iterable.empty());
       expect(getChildren(instance), equals([]));
     });
   }
@@ -136,7 +132,13 @@ void commonFactoryTests(ReactComponentFactoryProxy factory,
         return children;
       }
 
-      sharedChildrenTests(getDartChildren, shouldAlwaysBeList: true, props: {'onDartRender': onDartRender});
+      sharedChildrenTests(
+        getDartChildren,
+        shouldAlwaysBeList: true,
+        props: Map.unmodifiable({
+          'onDartRender': onDartRender,
+        }),
+      );
     });
   }
 

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: invalid_use_of_protected_member
+import 'package:react/react_client/react_interop.dart';
 @TestOn('browser')
 import 'package:test/test.dart';
 
@@ -17,7 +18,7 @@ main() {
     group('- common factory behavior -', () {
       group('Component -', () {
         group('- common factory behavior -', () {
-          commonFactoryTests(Foo);
+          commonFactoryTests(Foo, dartComponentVersion: ReactDartComponentVersion.component);
         });
 
         group('- refs -', () {
@@ -29,7 +30,7 @@ main() {
 
       group('Component2 -', () {
         group('- common factory behavior -', () {
-          commonFactoryTests(Foo2);
+          commonFactoryTests(Foo2, dartComponentVersion: ReactDartComponentVersion.component2);
         });
 
         group('- refs -', () {

--- a/test/factory/dart_factory_test.dart
+++ b/test/factory/dart_factory_test.dart
@@ -1,7 +1,9 @@
+@TestOn('browser')
+library react.dart_factory_test;
+
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: invalid_use_of_protected_member
 import 'package:react/react_client/react_interop.dart';
-@TestOn('browser')
 import 'package:test/test.dart';
 
 import 'package:react/react.dart' as react;

--- a/test/factory/dart_function_factory_test.dart
+++ b/test/factory/dart_function_factory_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 // ignore_for_file: invalid_use_of_protected_member
 @TestOn('browser')
+library react.dart_function_factory_test;
 
 import 'package:js/js_util.dart';
 import 'package:react/react.dart' as react;

--- a/test/factory/dart_function_factory_test.dart
+++ b/test/factory/dart_function_factory_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:js/js_util.dart';
 import 'package:react/react.dart' as react;
+import 'package:react/react_client/react_interop.dart';
 import 'package:test/test.dart';
 
 import 'common_factory_tests.dart';
@@ -16,7 +17,11 @@ main() {
 
     group('Function Component -', () {
       group('- common factory behavior -', () {
-        commonFactoryTests(FunctionFoo, isFunctionComponent: true);
+        commonFactoryTests(
+          FunctionFoo,
+          isFunctionComponent: true,
+          dartComponentVersion: ReactDartComponentVersion.component2,
+        );
       });
 
       group('displayName', () {
@@ -38,6 +43,16 @@ main() {
       });
     });
   });
+
+  group('forwardRef', () {
+    group('- common factory behavior -', () {
+      commonFactoryTests(
+        ForwardRefTest,
+        isFunctionComponent: true,
+        dartComponentVersion: ReactDartComponentVersion.component2,
+      );
+    });
+  });
 }
 
 String _getJsFunctionName(Function object) => getProperty(object, 'name') ?? getProperty(object, '\$static_name');
@@ -50,3 +65,8 @@ _FunctionFoo(Map props) {
   props['onDartRender']?.call(props);
   return react.div({});
 }
+
+final ForwardRefTest = react.forwardRef((props, ref) {
+  props['onDartRender']?.call(props);
+  return react.div({...props, 'ref': ref});
+});

--- a/test/factory/dom_factory_test.dart
+++ b/test/factory/dom_factory_test.dart
@@ -1,4 +1,6 @@
 @TestOn('browser')
+library react.dom_factory_test;
+
 import 'dart:html';
 
 import 'package:test/test.dart';

--- a/test/factory/js_factory_test.dart
+++ b/test/factory/js_factory_test.dart
@@ -1,6 +1,6 @@
 @JS()
 @TestOn('browser')
-library js_factory_test;
+library react.js_factory_test;
 
 import 'dart:html';
 


### PR DESCRIPTION
## Motivation
- Render logic for function and `forwardRef` components weren't being run in the component zone, which was inconsistent with class-based components.
- Existing children tests that verify children are always `List`s in Dart weren't being run for function and `forwardRef` components

## Solution
- Add component zone logic and tests to `commonFactoryTests`
- Run `commonFactoryTests` for `forwardRef` components
- Update children tests to run for function and `forwardRef` components

### Testing
- Tests pass
- Revert changes in https://github.com/cleandart/react-dart/pull/269 and verify that children tests fail