### PR TITLE
Ensure `memo`'s `ReactJsComponentFactoryProxy` always uses List children

### DIFF
--- a/lib/react.dart
+++ b/lib/react.dart
@@ -1353,7 +1353,10 @@ abstract class ReactComponentFactoryProxy implements Function {
     // Use `identical` since it compiles down to `===` in dart2js instead of calling equality helper functions,
     // and we don't want to allow any object overriding `operator==` to claim it's equal to `_notSpecified`.
     if (identical(c1, _notSpecified)) {
-      childArguments = [];
+      // Use a const list so that empty children prop values are always identical
+      // in the JS props, resulting in JS libraries (e.g., react-redux) and Dart code alike
+      // not marking props as having changed as a result of rerendering the ReactElement with a new list.
+      childArguments = const [];
     } else if (identical(c2, _notSpecified)) {
       childArguments = [c1];
     } else if (identical(c3, _notSpecified)) {

--- a/lib/react_client/react_interop.dart
+++ b/lib/react_client/react_interop.dart
@@ -303,7 +303,9 @@ ReactJsComponentFactoryProxy memo(ReactDartFunctionComponentFactoryProxy factory
           return areEqual(dartPrevProps, dartNextProps);
         });
   final hoc = React.memo(factory.type, _areEqual);
-  return ReactJsComponentFactoryProxy(hoc);
+  setProperty(hoc, 'dartComponentVersion', ReactDartComponentVersion.component2);
+
+  return ReactJsComponentFactoryProxy(hoc, alwaysReturnChildrenAsList: true);
 }
 
 abstract class ReactDom {

--- a/test/factory/dart_function_factory_test.dart
+++ b/test/factory/dart_function_factory_test.dart
@@ -53,6 +53,16 @@ main() {
       );
     });
   });
+
+  group('memo', () {
+    group('- common factory behavior -', () {
+      commonFactoryTests(
+        MemoTest,
+        isFunctionComponent: true,
+        dartComponentVersion: ReactDartComponentVersion.component2,
+      );
+    });
+  });
 }
 
 String _getJsFunctionName(Function object) => getProperty(object, 'name') ?? getProperty(object, '\$static_name');
@@ -70,3 +80,8 @@ final ForwardRefTest = react.forwardRef((props, ref) {
   props['onDartRender']?.call(props);
   return react.div({...props, 'ref': ref});
 });
+
+final MemoTest = react.memo(react.registerFunctionComponent((props) {
+  props['onDartRender']?.call(props);
+  return react.div({...props});
+}));


### PR DESCRIPTION
## Motivation
While adding onto the `memo` API in OverReact, it was discovered that consuming `props.children` in the `memo` HOC threw a type error because the children weren't guaranteed to be a List as expected.

## Changes
- Utilize the `alwaysReturnChildrenAsList` flag on `ReactJsComponentFactoryProxy` to ensure children are always wrapped in a List
- Add tests