### PR TITLE
Make JsBackedMap.values MSIE 11 compatible

### DIFF
--- a/lib/react_client/js_backed_map.dart
+++ b/lib/react_client/js_backed_map.dart
@@ -38,7 +38,8 @@ class JsBackedMap extends MapBase<dynamic, dynamic> {
 
   // Private helpers with narrower typing than we want to expose, for use in other methods
   List<dynamic> get _keys => _Object.keys(jsObject);
-  List<dynamic> get _values => _Object.values(jsObject);
+  // Use keys to access the value instead oof `Object.values` since MSIE 11 doesn't support it
+  List<dynamic> get _values => _keys.map((key) => this[key]).toList();
 
   /// Adds all key/value pairs of the JS object [jsOther] to this map.
   ///


### PR DESCRIPTION
`Object.values` is not supported in MSIE 11. We still have consumers that need to support the browser, so our `JsBackedMap.values` implementation needs to support it.

Currently, if you access the `values` getter ([as we do within `forwardRef`](https://github.com/cleandart/react-dart/blob/5.5.0-wip/lib/react_client/react_interop.dart#L238)), MSIE 11 will choke. This fixes that.

@greglittlefield-wf 