### PR TITLE
useImperativeHandle should not throw if ref is null

### DIFF
--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -529,8 +529,10 @@ void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies])
 /// ```
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useimperativehandle>.
-void useImperativeHandle(Ref ref, dynamic Function() createHandle, [List<dynamic> dependencies]) =>
-    React.useImperativeHandle(ref.jsRef, allowInterop(createHandle), dependencies);
+void useImperativeHandle(Ref ref, dynamic Function() createHandle, [List<dynamic> dependencies]) {
+  if (ref == null) return;
+  React.useImperativeHandle(ref.jsRef, allowInterop(createHandle), dependencies);
+}
 
 /// Displays [value] as a label for a custom hook in React DevTools.
 ///

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -692,6 +692,25 @@ main() {
           ]);
         });
 
+        var NullRefComponent = react.registerFunctionComponent((props) {
+          var count = useState(0);
+          Ref someRefThatIsNotSet = props['someRefThatIsNotSet'];
+
+          useImperativeHandle(someRefThatIsNotSet, () => count.value, [count.value]);
+
+          return react.Fragment({}, [
+            react.div({'ref': someRefThatIsNotSet}, count.value),
+            react.button({
+              'ref': (ref) => reRenderButtonRef2 = ref,
+              'onClick': (_) => count.setWithUpdater((prev) => prev + 1),
+            }, []),
+          ]);
+        });
+
+        expect(() => react_dom.render(NullRefComponent({}, []), mountNode), returnsNormally,
+            reason: 'Hook should not throw if the ref is null');
+        react_dom.unmountComponentAtNode(mountNode);
+
         UseImperativeHandleTest = react.registerFunctionComponent((Map props) {
           noDepsRef = useRef();
           emptyDepsRef = useRef();


### PR DESCRIPTION
I came across this RTE recently that occurs during mount as a result of us accessing `jsRef` on the `Ref` when passing through to the  `React.useImperativeHandle` JS interop layer.

Instead of throwing, these changes make it so that the creation of the imperative handle is simply a no-op unless the `Ref` provided is not null.