### PR TITLE
Release react 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.6.0](https://github.com/cleandart/react-dart/compare/5.5.1...5.6.0)
+
+- [#275] Add `forwardRef2` / `memo2` to fix _"jsification"_ of Dart props
+    - Deprecates `forwardRef` / `memo`
+- [#274] (Security update) Bump serialize-javascript JS dependency to version `3.1.0`
+
 ## [5.5.1](https://github.com/cleandart/react-dart/compare/5.5.0...5.5.1)
 
 - [#258] Exclude `propTypes` from Dart2js output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## [5.5.1](https://github.com/cleandart/react-dart/compare/5.5.0...5.5.1)
 
-- Exclude `propTypes` from Dart2js output.
-- Deprecate `registerComponent`.
-    - _Accidentally overlooked when `Component` was deprecated_
+- [#258] Exclude `propTypes` from Dart2js output.
+    - Deprecate `registerComponent`.
+        - _Accidentally overlooked when `Component` was deprecated_
+- [#276] Allow null ref value in `useImperativeHandle` hook
 
 ## [5.5.0](https://github.com/cleandart/react-dart/compare/5.4.0...5.5.0)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react
-version: 5.5.1
+version: 5.6.0
 authors:
   - Samuel Hapák <samuel.hapak@gmail.com>
   - Greg Littlefield <greg.littlefield@workiva.com>


### PR DESCRIPTION
The latest version of react includes:

- #275 Add `forwardRef2` / `memo2` to fix _"jsification"_ of Dart props
    - Deprecates `forwardRef` / `memo`
- #274 _(Security update)_ Bump serialize-javascript JS dependency to version `3.1.0`