### PR TITLE
Deprecate Helper Method

### DIFF
--- a/lib/src/react_client/event_helpers.dart
+++ b/lib/src/react_client/event_helpers.dart
@@ -598,6 +598,7 @@ extension SyntheticEventTypeHelpers on SyntheticEvent {
   bool get isFocusEvent => this is SyntheticFocusEvent;
 
   /// Returns whether this is a [SyntheticFormEvent].
+  @Deprecated('Check the event \'type\' property instead. This will be removed in v6.0.0.')
   bool get isFormEvent => this is SyntheticFormEvent;
 
   /// Returns whether this is a [SyntheticMouseEvent].


### PR DESCRIPTION
A helper method was added in stable that we realized wasn't necessary in the 6.0.0 line. This PR just deprecates that method!