### PR TITLE
Format on Dart 2.10.4, only check formatting on stable runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: dart
 
 dart:
+  # We need 2.9.2 this to verify the Chrome MemoryInfo workaround: https://github.com/cleandart/react-dart/pull/280
+  # TODO remove the workaround as well as this config once SDK lower bound is >=2.9.3
   - 2.9.2
   - stable
   - dev
@@ -14,7 +16,7 @@ cache:
 before_script:
   - dartanalyzer .
   - |
-    if [ "$TRAVIS_DART_VERSION" != "dev" ]; then
+    if [ "$TRAVIS_DART_VERSION" == "stable" ]; then
       dartfmt --line-length=120 --dry-run --set-exit-if-changed .
     fi
   - pub run dependency_validator -i build_runner,build_test,build_web_compilers

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  # We need 2.9.2 this to verify the Chrome MemoryInfo workaround: https://github.com/cleandart/react-dart/pull/280
+  # We need 2.9.2 to verify the Chrome MemoryInfo workaround: https://github.com/cleandart/react-dart/pull/280
   # TODO remove the workaround as well as this config once SDK lower bound is >=2.9.3
   - 2.9.2
   - stable

--- a/test/lifecycle_test/util.dart
+++ b/test/lifecycle_test/util.dart
@@ -40,7 +40,11 @@ mixin LifecycleTestHelper on Component {
       'context': context,
     });
 
-    var lifecycleCallback = props == null ? staticProps == null ? null : staticProps[memberName] : props[memberName];
+    var lifecycleCallback = props == null
+        ? staticProps == null
+            ? null
+            : staticProps[memberName]
+        : props[memberName];
     if (lifecycleCallback != null) {
       return Function.apply(
           lifecycleCallback,


### PR DESCRIPTION
## Motivation
CI was failing on every commit because the code was formatted under Dart 2.9, and CI was only skipping formatting on `dev` runs and not the Dart 2.10 `stable` run.

Previously, stable runs were broken due to build issues, but now that that's fixed, we can format on stable.

## Solution
- Format on Dart 2.10.4 (stable)
- Only check formatting on stable runs

## QA steps
- Verify all Travis builds are green