### PR TITLE
Add null handling to synthetic event duck type checking

### DIFF
--- a/lib/src/react_client/event_helpers.dart
+++ b/lib/src/react_client/event_helpers.dart
@@ -760,7 +760,8 @@ SyntheticWheelEvent createSyntheticWheelEvent({
 }
 
 extension SyntheticEventTypeHelpers on SyntheticEvent {
-  bool _checkEventType(List<String> types) => type != null && types.any((t) => type.contains(t));
+  bool _checkEventType(List<String> types) => this != null && type != null && types.any((t) => type.contains(t));
+  bool _hasProperty(String propertyName) => this != null && hasProperty(this, propertyName);
 
   /// Whether the event instance has been removed from the ReactJS event pool.
   ///
@@ -769,38 +770,38 @@ extension SyntheticEventTypeHelpers on SyntheticEvent {
   bool get isPersistent => true;
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticClipboardEvent].
-  bool get isClipboardEvent => hasProperty(this, 'clipboardData') || _checkEventType(const ['copy', 'paste', 'cut']);
+  bool get isClipboardEvent => _hasProperty('clipboardData') || _checkEventType(const ['copy', 'paste', 'cut']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticKeyboardEvent].
-  bool get isKeyboardEvent => hasProperty(this, 'key') || _checkEventType(const ['key']);
+  bool get isKeyboardEvent => _hasProperty('key') || _checkEventType(const ['key']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticCompositionEvent].
-  bool get isCompositionEvent => hasProperty(this, 'data') || _checkEventType(const ['composition']);
+  bool get isCompositionEvent => _hasProperty('data') || _checkEventType(const ['composition']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticFocusEvent].
   bool get isFocusEvent =>
-      (hasProperty(this, 'relatedTarget') && !hasProperty(this, 'button')) || _checkEventType(const ['focus', 'blur']);
+      (_hasProperty('relatedTarget') && !_hasProperty('button')) || _checkEventType(const ['focus', 'blur']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticMouseEvent].
-  bool get isMouseEvent => hasProperty(this, 'button') || _checkEventType(const ['mouse', 'click', 'drag', 'drop']);
+  bool get isMouseEvent => _hasProperty('button') || _checkEventType(const ['mouse', 'click', 'drag', 'drop']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticPointerEvent].
-  bool get isPointerEvent => hasProperty(this, 'pointerId') || _checkEventType(const ['pointer']);
+  bool get isPointerEvent => _hasProperty('pointerId') || _checkEventType(const ['pointer']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticTouchEvent].
-  bool get isTouchEvent => hasProperty(this, 'targetTouches') || _checkEventType(const ['touch']);
+  bool get isTouchEvent => _hasProperty('targetTouches') || _checkEventType(const ['touch']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticTransitionEvent].
-  bool get isTransitionEvent => hasProperty(this, 'propertyName') || _checkEventType(const ['transition']);
+  bool get isTransitionEvent => _hasProperty('propertyName') || _checkEventType(const ['transition']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticAnimationEvent].
-  bool get isAnimationEvent => hasProperty(this, 'animationName') || _checkEventType(const ['animation']);
+  bool get isAnimationEvent => _hasProperty('animationName') || _checkEventType(const ['animation']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticUIEvent].
-  bool get isUiEvent => hasProperty(this, 'detail') || _checkEventType(const ['scroll']);
+  bool get isUiEvent => _hasProperty('detail') || _checkEventType(const ['scroll']);
 
   /// Uses Duck Typing to detect if the event instance is a [SyntheticWheelEvent].
-  bool get isWheelEvent => hasProperty(this, 'deltaX') || _checkEventType(const ['wheel']);
+  bool get isWheelEvent => _hasProperty('deltaX') || _checkEventType(const ['wheel']);
 }
 
 extension DataTransferHelper on SyntheticMouseEvent {

--- a/test/react_client/event_helpers_test.dart
+++ b/test/react_client/event_helpers_test.dart
@@ -1686,6 +1686,10 @@ main() {
                 currentEventTypeBeingTested == SyntheticEventType.syntheticFormEvent ? isTrue : isFalse,
                 reason: 'The `SyntheticEvent` base class is considered a Form Event via Duck Typing.');
           });
+
+          test('when the event is null', () {
+            expect(eventTypeTester(null), isFalse);
+          });
         });
       }
 


### PR DESCRIPTION
### Problem
When [we updated the synthetic event system to use duck typing instead of Dart `is` type checking](https://github.com/cleandart/react-dart/pull/288), we created a possible null exception that presents as seen below when the event is null: 

```
Error: Cannot use 'in' operator to search for 'key' in null
```

This is a regression since before we made the switch, a check like this would have simply returned false:

```dart
final someSyntheticEvent = null;
final isSyntheticMouseEvent = someSyntheticEvent is SyntheticMouseEvent; // false
```

but now, it throws the exception when the logic is updated to:

```dart
final someSyntheticEvent = null;
final isSyntheticMouseEvent = someSyntheticEvent.isMouseEvent; // throws RTE
```

### Solution

1. Add null checks before calling `hasProperty` and `_checkEventType`.
2. Add tests