### PR TITLE
Material-UI Migration Preparations

### DIFF
--- a/example/geocodes/geocodes.dart
+++ b/example/geocodes/geocodes.dart
@@ -5,6 +5,7 @@ import 'dart:html';
 
 import 'package:react/react.dart' as react;
 import 'package:react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 
 /**
  * Hello,
@@ -330,5 +331,5 @@ var geocodesApp = react.registerComponent(() => new _GeocodesApp());
 ///
 /// Select the root of the app and the place in the DOM where it should be mounted.
 void main() {
-  react_dom.render(geocodesApp({}), querySelector('#content'));
+  react_dom.render((ThemeProvider()..theme = wkTheme)(geocodesApp({})), querySelector('#content'));
 }

--- a/example/geocodes/geocodes.html
+++ b/example/geocodes/geocodes.html
@@ -34,6 +34,7 @@
     <!-- Load React, your application code and Dart -->
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="geocodes.dart.js"></script>
     
   </body>

--- a/example/js_components/index.html
+++ b/example/js_components/index.html
@@ -18,6 +18,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="https://unpkg.com/@material-ui/core/umd/material-ui.development.js" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/example/js_components/js_components.dart
+++ b/example/js_components/js_components.dart
@@ -8,11 +8,12 @@ import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
+import 'package:react_material_ui/styles/theme_provider.dart';
 
 main() {
   var content = IndexComponent({});
 
-  react_dom.render(content, querySelector('#content'));
+  react_dom.render((ThemeProvider()..theme = wkTheme)(content), querySelector('#content'));
 }
 
 var IndexComponent = react.registerComponent2(() => new _IndexComponent());

--- a/example/test/call_and_nosuchmethod_test.html
+++ b/example/test/call_and_nosuchmethod_test.html
@@ -14,6 +14,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="call_and_nosuchmethod_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/example/test/context_test.html
+++ b/example/test/context_test.html
@@ -12,6 +12,7 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="context_test.dart.js"></script>
   </body>
 </html>

--- a/example/test/error_boundary_test.html
+++ b/example/test/error_boundary_test.html
@@ -12,6 +12,7 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="error_boundary_test.dart.js"></script>
   </body>
 </html>

--- a/example/test/false_and_null_test.html
+++ b/example/test/false_and_null_test.html
@@ -12,6 +12,7 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script type="application/dart" src="false_and_null_test.dart"></script>
     <script src="packages/browser/dart.js"></script>
   </body>

--- a/example/test/function_component_test.html
+++ b/example/test/function_component_test.html
@@ -12,6 +12,7 @@
     <div id="content" class="container"></div>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="function_component_test.dart.js"></script>
   </body>
 </html>

--- a/example/test/get_dom_node_test.html
+++ b/example/test/get_dom_node_test.html
@@ -14,6 +14,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="get_dom_node_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/example/test/order_test.html
+++ b/example/test/order_test.html
@@ -14,6 +14,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="order_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/example/test/react_test.html
+++ b/example/test/react_test.html
@@ -21,6 +21,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="react_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
 

--- a/example/test/ref_test.html
+++ b/example/test/ref_test.html
@@ -14,6 +14,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="ref_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/example/test/speed_test.html
+++ b/example/test/speed_test.html
@@ -14,6 +14,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="speed_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/example/test/unmount_test.html
+++ b/example/test/unmount_test.html
@@ -21,6 +21,7 @@
 
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script defer src="unmount_test.dart.js"></script>
     <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,11 @@ environment:
 dependencies:
   js: ^0.6.0
   meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  react_material_ui:
+    hosted:
+      name: react_material_ui
+      url: https://pub.workiva.org
+    version: ^1.1.1
 dev_dependencies:
   args: ^1.5.1
   build_runner: ^1.6.5

--- a/test/factory/dart_factory_test.html
+++ b/test/factory/dart_factory_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="dart_factory_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/factory/dart_function_factory_test.html
+++ b/test/factory/dart_function_factory_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="dart_function_factory_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/factory/dom_factory_test.html
+++ b/test/factory/dom_factory_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="dom_factory_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/factory/js_factory_test.html
+++ b/test/factory/js_factory_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <script src="js_factory_test.js"></script>
 

--- a/test/forward_ref_test.html
+++ b/test/forward_ref_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <link rel="x-dart-test" href="forward_ref_test.dart">
     <script src="packages/test/dart.js"></script>
 </head>

--- a/test/hooks_test.html
+++ b/test/hooks_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <link rel="x-dart-test" href="hooks_test.dart">
     <script src="packages/test/dart.js"></script>
 </head>

--- a/test/js_builds/js_dev_test.html
+++ b/test/js_builds/js_dev_test.html
@@ -7,6 +7,7 @@
     <script src="console_spy_include_this_js_first.js"></script>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="js_dev_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/js_builds/js_dev_with_addons_test.html
+++ b/test/js_builds/js_dev_with_addons_test.html
@@ -7,6 +7,7 @@
     <script src="console_spy_include_this_js_first.js"></script>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="js_dev_with_addons_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/js_builds/js_prod_combined_test.html
+++ b/test/js_builds/js_prod_combined_test.html
@@ -6,6 +6,7 @@
 
     <script src="console_spy_include_this_js_first.js"></script>
     <script src="packages/react/react_with_react_dom_prod.js"></script>
+    <script src="packages/react_material_ui/react-material-ui.umd.js"></script>
 
     <script>
       // This DDC workaround usually gets pulled in via the React dev bundles,

--- a/test/js_builds/js_prod_test.html
+++ b/test/js_builds/js_prod_test.html
@@ -7,6 +7,7 @@
     <script src="console_spy_include_this_js_first.js"></script>
     <script src="packages/react/react_prod.js"></script>
     <script src="packages/react/react_dom_prod.js"></script>
+    <script src="packages/react_material_ui/react-material-ui.umd.js"></script>
 
     <script>
       // This DDC workaround usually gets pulled in via the React dev bundles,

--- a/test/lifecycle_test.html
+++ b/test/lifecycle_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="ReactSetStateTestComponent.js"></script>
     <script src="ReactSetStateTestComponent2.js"></script>
     <link rel="x-dart-test" href="lifecycle_test.dart">

--- a/test/react_client/bridge_test.html
+++ b/test/react_client/bridge_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="../ReactCompositeTestComponent.js"></script>
     <link rel="x-dart-test" href="bridge_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/react_client/chain_refs_test.html
+++ b/test/react_client/chain_refs_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <script>
         function JsType() {}

--- a/test/react_client/event_helpers_test.html
+++ b/test/react_client/event_helpers_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <script>
         function JsType() {}

--- a/test/react_client/js_backed_map_test.html
+++ b/test/react_client/js_backed_map_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <script>
         function JsType() {}

--- a/test/react_client/react_interop_test.html
+++ b/test/react_client/react_interop_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="react_interop_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/react_client_test.html
+++ b/test/react_client_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script src="ReactCompositeTestComponent.js"></script>
     <script>
         function JsType() {}

--- a/test/react_context_test.html
+++ b/test/react_context_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <script>
         function JsType() {}
     </script>

--- a/test/react_fragment_test.html
+++ b/test/react_fragment_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <link rel="x-dart-test" href="react_fragment_test.dart">
     <script src="packages/test/dart.js"></script>
 </head>

--- a/test/react_memo_test.html
+++ b/test/react_memo_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <link rel="x-dart-test" href="react_memo_test.dart">
     <script src="packages/test/dart.js"></script>
 </head>

--- a/test/react_strictmode_test.html
+++ b/test/react_strictmode_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
     <link rel="x-dart-test" href="react_strictmode_test.dart">
     <script src="packages/test/dart.js"></script>
 </head>

--- a/test/react_test_utils_test.html
+++ b/test/react_test_utils_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="react_test_utils_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/util_test.html
+++ b/test/util_test.html
@@ -5,6 +5,7 @@
     <title></title>
     <script src="packages/react/react_with_addons.js"></script>
     <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react_material_ui/react-material-ui-development.umd.js"></script>
 
     <link rel="x-dart-test" href="util_test.dart">
     <script src="packages/test/dart.js"></script>


### PR DESCRIPTION
## Motivation
[MUI component migrations](https://wiki.atl.workiva.net/display/CP/Material+Design) will begin soon, and there are a few housekeeping items that are necessary for a smooth rollout across the Workiva ecosystem.

A member of Client Platform will reach out when this PR is ready for team review.

If you have any questions about this PR, reach out to us in the [#support-mui-migration](https://workiva.slack.com/app_redirect?channel=support-mui-migration) Slack channel!

## Changes
This PR includes automated changes to ensure that the consumption of upstream dependencies that have migrated at least one Web Skin Dart component to MUI doesn't result in unexpected failures in this package or unexpected styling regressions in any of the standalone apps within this repo.

This is accomplished by:

1. Adding the JS MUI `<script>` tag to all HTML files used in this repo where React components are being rendered on the page
1. Adding `react_material_ui` as a dependency so that the `<script>` tags added do not cause 404 errors
1. Adding `react_material_ui` to the `dependency_validator` ignore list(s)
1. Wrapping top-level React trees (e.g. `react_dom.render` calls) in a `ThemeProvider` that sets the theme to our Workiva theme. This guards against components consumed from upstream dependencies being styled inconsistently.

The initial commit is automatically applied by a codemod and follow up commits may be made to:
- Fix tests

### Release Notes
Prepare for MUI component migrations

## QA Instructions
- [ ] CI Passes
- [ ] The app does not throw runtime exceptions when navigating to places where the top-level `react_dom.render` calls are relevant
  _(only necessary if functional tests run in CI does not navigate to all the views where the `react_dom.render` calls are used.)_

[_Created by Sourcegraph batch change `Workiva/mui_migration_rmui_prep2`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/mui_migration_rmui_prep2)